### PR TITLE
CI: Use bionic, use its pre-installed Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
     - rvm: rbx-3
     - rvm: jruby-19mode
     - rvm: jruby-9.1.17.0
+      jdk: openjdk9
     - rvm: jruby-9.2.9.0
       jdk: openjdk11
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,14 @@ matrix:
     - rvm: rbx-3
     - rvm: jruby-19mode
     - rvm: jruby-9.1.17.0
-    - rvm: jruby-9.2.8.0    
+    - rvm: jruby-9.2.9.0    
     - rvm: ruby-head
     - rvm: jruby-head
   allow_failures:
     - rvm: rbx-3
     - rvm: ruby-head
     - rvm: jruby-9.1.17.0
-    - rvm: jruby-9.2.8.0
+    - rvm: jruby-9.2.9.0
     - rvm: jruby-head
 jdk:
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 sudo: required
-dist: trusty
+dist: bionic
 group: beta
 cache: bundler
 bundler_args: --without profile
@@ -12,25 +12,30 @@ notifications:
       - digital.ipseity@gmail.com
     on_success: always
 
+# Use the pre-installed Ruby versions listed at
+# https://docs.travis-ci.com/user/reference/bionic/#ruby-support
 matrix:
   include:
     - rvm: 2.1
     - rvm: 2.2.10
-    - rvm: 2.3.5
-    - rvm: 2.4.7
-    - rvm: 2.5.6
-    - rvm: 2.6.4
+    - rvm: 2.3.8
+    - rvm: 2.4.5
+    - rvm: 2.5.3
+    - rvm: 2.6.3
     - rvm: rbx-3
     - rvm: jruby-19mode
     - rvm: jruby-9.1.17.0
+    - rvm: jruby-9.2.8.0    
     - rvm: ruby-head
     - rvm: jruby-head
   allow_failures:
     - rvm: rbx-3
     - rvm: ruby-head
     - rvm: jruby-9.1.17.0
+    - rvm: jruby-9.2.8.0
     - rvm: jruby-head
-
+jdk:
+  - openjdk8
 env:
   global:
     - JRUBY_OPTS="-Xcli.debug=true --debug"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ matrix:
     - rvm: rbx-3
     - rvm: jruby-19mode
     - rvm: jruby-9.1.17.0
-    - rvm: jruby-9.2.9.0    
+    - rvm: jruby-9.2.9.0
+      jdk: openjdk11
     - rvm: ruby-head
     - rvm: jruby-head
   allow_failures:


### PR DESCRIPTION
This PR begins using Ruby versions that are preinstalled on Travis images for Ubuntu. Also, starts using `bionic`.

  - see https://docs.travis-ci.com/user/reference/bionic/#ruby-support for the Ruby versions

This was inspired by https://github.com/randym/axlsx/pull/618


**Update**: JRuby 9.2.9.0 on openjdk-11 _works_. The other targets have issues.