### PR TITLE
Fix validate document error with font option underline

### DIFF
--- a/lib/axlsx/stylesheet/font.rb
+++ b/lib/axlsx/stylesheet/font.rb
@@ -76,7 +76,10 @@ module Axlsx
     attr_reader :i
 
     # Indicates if the font should be rendered underlined
-    # @return [Boolean]
+    # It must be one of :none, :single, :double, :singleAccounting, :doubleAccounting, true, false
+    # @return [String]
+    # @note
+    #  true or false is for backwards compatibility and is reassigned to :single or :none respectively
     attr_reader :u
 
     # Indicates if the font should be rendered with a strikthrough
@@ -118,7 +121,12 @@ module Axlsx
     # @see i
     def i=(v) Axlsx::validate_boolean v; @i = v end
     # @see u
-    def u=(v) Axlsx::validate_boolean v; @u = v end
+    def u=(v)
+      v = :single if (v == true || v == 1 || v == :true || v == 'true')
+      v = :none if (v == false || v == 0 || v == :false || v == 'false')
+      Axlsx::validate_cell_u v
+      @u = v
+    end
     # @see strike
     def strike=(v) Axlsx::validate_boolean v; @strike = v end
     # @see outline

--- a/test/stylesheet/tc_font.rb
+++ b/test/stylesheet/tc_font.rb
@@ -62,11 +62,23 @@ class TestFont < Test::Unit::TestCase
     assert_equal(@item.i, true)
   end
 
-    # def u=(v) Axlsx::validate_boolean v; @u = v end
+    # def u=(v) Axlsx::validate_cell_u v; @u = v end
   def test_u
     assert_raise(ArgumentError) { @item.u = -7 }
+    assert_nothing_raised { @item.u = :single }
+    assert_equal(@item.u, :single)
+    doc = Nokogiri::XML(@item.to_xml_string)
+    assert(doc.xpath('//u[@val="single"]'))
+  end
+
+  def test_u_backward_compatibility
+    # backward compatibility for true
     assert_nothing_raised { @item.u = true }
-    assert_equal(@item.u, true)
+    assert_equal(@item.u, :single)
+
+    # backward compatibility for false
+    assert_nothing_raised { @item.u = false }
+    assert_equal(@item.u, :none)
   end
 
     # def strike=(v) Axlsx::validate_boolean v; @strike = v end

--- a/test/stylesheet/tc_styles.rb
+++ b/test/stylesheet/tc_styles.rb
@@ -124,7 +124,7 @@ class TestStyles < Test::Unit::TestCase
       :sz => 20,
       :b => 1,
       :i => 1,
-      :u => 1,
+      :u => :single,
       :strike => 1,
       :outline => 1,
       :shadow => 1,
@@ -231,5 +231,31 @@ class TestStyles < Test::Unit::TestCase
     assert_equal(0, style, "returns the first dxfId")
     style = @styles.add_style :bg_color=>"FF000000", :fg_color=>"FFFFFFFF", :sz=>13, :alignment=>{:horizontal=>:left}, :border=>{:style => :thin, :color => "FFFF0000"}, :hidden=>true, :locked=>true, :type => :dxf
     assert_equal(1, style, "returns the second dxfId")
+  end
+
+  def test_valid_document_with_font_options
+    font_options = {
+      :fg_color => "FF050505",
+      :sz => 20,
+      :b => 1,
+      :i => 1,
+      :u => :single,
+      :strike => 1,
+      :outline => 1,
+      :shadow => 1,
+      :charset => 9,
+      :family => 1,
+      :font_name => "woot font"
+    }
+    @styles.add_style font_options
+
+    schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
+    doc = Nokogiri::XML(@styles.to_xml_string)
+    errors = []
+    schema.validate(doc).each do |error|
+      errors.push error
+      puts error.message
+    end
+    assert(errors.size == 0)
   end
 end


### PR DESCRIPTION
This PR tries to fix Issue https://github.com/caxlsx/caxlsx/issues/14

Solution: 
- The correct supported values for underline are `:none, :single, :double, :singleAccounting, :doubleAccounting`
- Allow and Set the correct value from the above list.
- Also try to maintain backward compatibility.