### PR TITLE
Remove a typo from comment

### DIFF
--- a/lib/axlsx/util/validators.rb
+++ b/lib/axlsx/util/validators.rb
@@ -92,7 +92,7 @@ module Axlsx
 
   # Requires that the value is a Integer or Float and is greater or equal to 0
   # @param [Any] v The value validated
-  # @raise [ArgumentError] raised if the value is not a Fixnun, Integer, Float value greater or equal to 0
+  # @raise [ArgumentError] raised if the value is not a Integer, Float value greater or equal to 0
   # @return [Boolean] true if the data is valid
   def self.validate_unsigned_numeric(v)
     DataTypeValidator.validate(:unsigned_numeric, Numeric, v, UINT_VALIDATOR)


### PR DESCRIPTION
Fixnum is removed by 12d6433, but this typo was remained.