### PR TITLE
Add option to protect against csv injection attacks

### DIFF
--- a/examples/example.rb
+++ b/examples/example.rb
@@ -21,6 +21,7 @@ examples << :images
 examples << :format_dates
 examples << :mbcs
 examples << :formula
+examples << :escape_formulas
 examples << :auto_filter
 examples << :sheet_protection
 examples << :data_types
@@ -361,6 +362,21 @@ if examples.include? :formula
     sheet.add_row ['col 1', 'col 2', 'col 3', 'col 4']
     sheet.add_row [1, 2, 3, "=SUM(A2:C2)"]
   end
+end
+##```
+
+##Escaping formulas for cells
+#```ruby
+if examples.include? :escape_formulas
+  wb.add_worksheet(:name => "Escaping Formulas") do |sheet|
+    sheet.add_row [1, 2, 3, "=SUM(A2:C2)"], escape_formulas: true
+    sheet.add_row [
+      "=IF(2+2=4,4,5)",
+      "=IF(13+13=4,4,5)",
+      "=IF(99+99=4,4,5)"
+    ], escape_formulas: [true, false, true]
+  end
+  p.serialize("escaped_formulas.xlsx")
 end
 ##```
 
@@ -882,4 +898,3 @@ if examples.include? :tab_color
   p.serialize 'tab_color.xlsx'
 end
 ##```
-

--- a/lib/axlsx/workbook/worksheet/row.rb
+++ b/lib/axlsx/workbook/worksheet/row.rb
@@ -147,10 +147,11 @@ module Axlsx
     # @option options [Array, Integer] style
     def array_to_cells(values, options={})
       DataTypeValidator.validate :array_to_cells, Array, values
-      types, style, formula_values = options.delete(:types), options.delete(:style), options.delete(:formula_values)
+      types, style, formula_values, escape_formulas = options.delete(:types), options.delete(:style), options.delete(:formula_values), options.delete(:escape_formulas)
       values.each_with_index do |value, index|
         options[:style] = style.is_a?(Array) ? style[index] : style if style
         options[:type] = types.is_a?(Array) ? types[index] : types if types
+        options[:escape_formulas] = escape_formulas.is_a?(Array) ? escape_formulas[index] : escape_formulas if escape_formulas
         options[:formula_value] = formula_values[index] if formula_values.is_a?(Array)
 
         self[index] = Cell.new(self, value, options)

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -390,6 +390,12 @@ module Axlsx
     # @example - use << alias
     #     ws << [3, 4, 5], :types => [nil, :float]
     #
+    # @example - specify whether a row should escape formulas or not
+    #     ws.add_row ['=IF(2+2=4,4,5)', 2, 3], :escape_formulas=>true
+    #
+    # @example - specify whether a certain cells in a row should escape formulas or not
+    #     ws.add_row ['=IF(2+2=4,4,5)', '=IF(13+13=4,4,5)'], :escape_formulas=>[true, false]
+    #
     # @see Worksheet#column_widths
     # @return [Row]
     # @option options [Array] values
@@ -397,6 +403,10 @@ module Axlsx
     # @option options [Array, Integer] style
     # @option options [Array] widths each member of the widths array will affect how auto_fit behavies.
     # @option options [Float] height the row's height (in points)
+    # @option options [Array, Boolean] escape_formulas - Whether to treat a value starting with an equal
+    #    sign as formula (default) or as simple string.
+    #    Allowing user generated data to be interpreted as formulas can be dangerous
+    #   (see https://www.owasp.org/index.php/CSV_Injection for details).
     def add_row(values=[], options={})
       row = Row.new(self, values, options)
       update_column_info row, options.delete(:widths)

--- a/test/workbook/worksheet/tc_row.rb
+++ b/test/workbook/worksheet/tc_row.rb
@@ -60,6 +60,23 @@ class TestRow < Test::Unit::TestCase
 
   end
 
+  def test_array_to_cells_with_escape_formulas
+    row = ['=HYPERLINK("http://www.example.com", "CSV Payload")', '=Bar']
+    @ws.add_row row, escape_formulas: true
+
+    assert_equal @ws.rows.last.cells[0].escape_formulas, true
+    assert_equal @ws.rows.last.cells[1].escape_formulas, true
+  end
+
+  def test_array_to_cells_with_escape_formulas_as_an_array
+    row = ['=HYPERLINK("http://www.example.com", "CSV Payload")', '+Foo', '-Bar']
+    @ws.add_row row, escape_formulas: [true, false, true]
+
+    assert_equal @ws.rows.last.cells.first.escape_formulas, true
+    assert_equal @ws.rows.last.cells[1].escape_formulas, false
+    assert_equal @ws.rows.last.cells[2].escape_formulas, true
+  end
+
   def test_custom_height
     @row.height = 20
     assert(@row.custom_height)


### PR DESCRIPTION
Added the option to pass in escape_formulas: true into the #add_row method.

In John Legrand's words, from this issue #624
"""
It would be nice to be able to pass an option to block formula injection. We use this Gem to let clients export tables to excel sheets. This is an unsafe practice because a formula could be injected. There should be an ability to block these injections to OWASP standards. (prepending "'" to anything that starts with something possibly malicious. https://www.owasp.org/index.php/CSV_Injection
"""