### PR TITLE
Check size in bytes as opposed to string size

### DIFF
--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -656,7 +656,7 @@ module Axlsx
 
     def validate_sheet_name(name)
       DataTypeValidator.validate :worksheet_name, String, name
-      raise ArgumentError, (ERR_SHEET_NAME_TOO_LONG % name) if name.size > 31
+      raise ArgumentError, (ERR_SHEET_NAME_TOO_LONG % name) if name.bytesize > 31
       raise ArgumentError, (ERR_SHEET_NAME_CHARACTER_FORBIDDEN % name) if '[]*/\?:'.chars.any? { |char| name.include? char }
       name = Axlsx::coder.encode(name)
       sheet_names = @workbook.worksheets.reject { |s| s == self }.map { |s| s.name }

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -29,6 +29,10 @@ class TestWorksheet < Test::Unit::TestCase
     assert_raises(ArgumentError) { @ws.name = 'foo?bar' }
   end
 
+  def test_name_on_name_too_long
+    assert_raises(ArgumentError) { @ws.name = '123456789012345678901234567890¡' }
+  end
+
   def test_page_margins
     assert(@ws.page_margins.is_a? Axlsx::PageMargins)
   end


### PR DESCRIPTION
- `size` returns length in characters, but doesn't factor in multibyte Unicode characters.
By switching to `bytesize`, we check the relevant measure of how many bytes the worksheet name is.
- Fixes https://github.com/randym/axlsx/issues/588
- Copy of PR against original axlsx
(https://github.com/randym/axlsx/pull/589)