### PR TITLE
Escape characters in charts

### DIFF
--- a/lib/axlsx/drawing/series_title.rb
+++ b/lib/axlsx/drawing/series_title.rb
@@ -7,13 +7,15 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
+      clean_value = Axlsx::trust_input ? @text.to_s : ::CGI.escapeHTML(Axlsx::sanitize(@text.to_s))
+
       str << '<c:tx>'
       str << '<c:strRef>'
       str << ('<c:f>' << Axlsx::cell_range([@cell]) << '</c:f>')
       str << '<c:strCache>'
       str << '<c:ptCount val="1"/>'
       str << '<c:pt idx="0">'
-      str << ('<c:v>' << @text << '</c:v>')
+      str << ('<c:v>' << clean_value << '</c:v>')
       str << '</c:pt>'
       str << '</c:strCache>'
       str << '</c:strRef>'

--- a/lib/axlsx/drawing/title.rb
+++ b/lib/axlsx/drawing/title.rb
@@ -62,6 +62,7 @@ module Axlsx
     def to_xml_string(str = '')
       str << '<c:title>'
       unless @text.empty?
+        clean_value = Axlsx::trust_input ? @text.to_s : ::CGI.escapeHTML(Axlsx::sanitize(@text.to_s))
         str << '<c:tx>'
         if @cell.is_a?(Cell)
           str << '<c:strRef>'
@@ -69,7 +70,7 @@ module Axlsx
           str << '<c:strCache>'
           str << '<c:ptCount val="1"/>'
           str << '<c:pt idx="0">'
-          str << ('<c:v>' << @text << '</c:v>')
+          str << ('<c:v>' << clean_value << '</c:v>')
           str << '</c:pt>'
           str << '</c:strCache>'
           str << '</c:strRef>'
@@ -80,7 +81,7 @@ module Axlsx
             str << '<a:p>'
               str << '<a:r>'
                 str << ('<a:rPr sz="' << @text_size.to_s << '"/>')
-                str << ('<a:t>' << @text.to_s << '</a:t>')
+                str << ('<a:t>' << clean_value << '</a:t>')
               str << '</a:r>'
             str << '</a:p>'
           str << '</c:rich>'

--- a/test/drawing/tc_series_title.rb
+++ b/test/drawing/tc_series_title.rb
@@ -36,8 +36,8 @@ class TestSeriesTitle < Test::Unit::TestCase
     @title.text = "&><'\""
 
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = doc.errors.map { |error| puts error.message; error }
-    assert(errors.empty?, "escape special characters")
+    errors = doc.errors
+    assert(errors.empty?, "invalid xml: #{errors.map(&:to_s).join(', ')}")
   end
 
   def test_to_xml_string_for_special_characters_in_cell
@@ -48,7 +48,7 @@ class TestSeriesTitle < Test::Unit::TestCase
     @title.cell = cell
 
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = doc.errors.map { |error| puts error.message; error }
-    assert(errors.empty?, "escape special characters")
+    errors = doc.errors
+    assert(errors.empty?, "invalid xml: #{errors.map(&:to_s).join(', ')}")
   end
 end

--- a/test/drawing/tc_series_title.rb
+++ b/test/drawing/tc_series_title.rb
@@ -30,4 +30,25 @@ class TestSeriesTitle < Test::Unit::TestCase
     assert(@title.text == "one")
   end
 
+  def test_to_xml_string_for_special_characters
+    @chart.add_series(title: @title, data: [3, 7], labels: ['A', 'B'])
+
+    @title.text = "&><'\""
+
+    doc = Nokogiri::XML(@chart.to_xml_string)
+    errors = doc.errors.map { |error| puts error.message; error }
+    assert(errors.empty?, "escape special characters")
+  end
+
+  def test_to_xml_string_for_special_characters_in_cell
+    @chart.add_series(title: @title, data: [3, 7], labels: ['A', 'B'])
+
+    cell = @row.cells.first
+    cell.value = "&><'\""
+    @title.cell = cell
+
+    doc = Nokogiri::XML(@chart.to_xml_string)
+    errors = doc.errors.map { |error| puts error.message; error }
+    assert(errors.empty?, "escape special characters")
+  end
 end

--- a/test/drawing/tc_title.rb
+++ b/test/drawing/tc_title.rb
@@ -54,8 +54,8 @@ class TestTitle < Test::Unit::TestCase
   def test_to_xml_string_for_special_characters
     @chart.title.text = "&><'\""
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = doc.errors.map { |error| puts error.message; error }
-    assert(errors.empty?, "escape special characters")
+    errors = doc.errors
+    assert(errors.empty?, "invalid xml: #{errors.map(&:to_s).join(', ')}")
   end
 
   def test_to_xml_string_for_special_characters_in_cell
@@ -64,7 +64,7 @@ class TestTitle < Test::Unit::TestCase
 
     @chart.title.cell = cell
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = doc.errors.map { |error| puts error.message; error }
-    assert(errors.empty?, "escape special characters")
+    errors = doc.errors
+    assert(errors.empty?, "invalid xml: #{errors.map(&:to_s).join(', ')}")
   end
 end

--- a/test/drawing/tc_title.rb
+++ b/test/drawing/tc_title.rb
@@ -51,4 +51,20 @@ class TestTitle < Test::Unit::TestCase
     assert_equal(1, doc.xpath('//c:v[text()="one"]').size)
   end
 
+  def test_to_xml_string_for_special_characters
+    @chart.title.text = "&><'\""
+    doc = Nokogiri::XML(@chart.to_xml_string)
+    errors = doc.errors.map { |error| puts error.message; error }
+    assert(errors.empty?, "escape special characters")
+  end
+
+  def test_to_xml_string_for_special_characters_in_cell
+    cell = @row.cells.first
+    cell.value = "&><'\""
+
+    @chart.title.cell = cell
+    doc = Nokogiri::XML(@chart.to_xml_string)
+    errors = doc.errors.map { |error| puts error.message; error }
+    assert(errors.empty?, "escape special characters")
+  end
 end

--- a/test/tc_axlsx.rb
+++ b/test/tc_axlsx.rb
@@ -24,8 +24,12 @@ class TestAxlsx < Test::Unit::TestCase
 
 
   def test_trust_input_can_be_set_to_true
+    old = Axlsx.trust_input
+
     Axlsx.trust_input = true
     assert_equal true, Axlsx.trust_input
+
+    Axlsx.trust_input = old
   end
   def test_cell_range_relative
     p = Axlsx::Package.new

--- a/test/tc_axlsx.rb
+++ b/test/tc_axlsx.rb
@@ -24,6 +24,8 @@ class TestAxlsx < Test::Unit::TestCase
 
 
   def test_trust_input_can_be_set_to_true
+    # Class variables like this are not reset between test runs, so we have
+    # to save and restore the original value manually.
     old = Axlsx.trust_input
 
     Axlsx.trust_input = true


### PR DESCRIPTION
I'm making this PR to fix #37. 

There's an old test that required some changes: test/tc_axlsx.rb set the `Axlsx.trust_input` value to true which lead to ignore the CGI escapes.

All the other (new) tests are checking if the generated XMLs are valid or not with xml-specific special characters in the given title or cell.