### PR TITLE
Remove global variables from example #32

### DIFF
--- a/examples/colored_links.rb
+++ b/examples/colored_links.rb
@@ -1,59 +1,45 @@
-require 'axlsx' 
+require 'axlsx'
 
-############################### 
-# Function to output results data row to summary spreadsheet 
-def outputRow (sid, type) 
+p = Axlsx::Package.new
+wb = p.workbook
 
-  $sumSheet.add_row [ sid, type, "1", "2", "3", "4", "5" ], :style => $black_cell 
+#   Each style only needs to be declared once in the workbook.
+s = wb.styles
+title_cell = s.add_style sz: 14, alignment: { horizontal: :center }
+black_cell = s.add_style sz: 10, alignment: { horizontal: :center }
+blue_link = s.add_style fg_color: '0000FF'
+
+# Create summary sheet
+sum_sheet = wb.add_worksheet name: 'Summary'
+sum_sheet.add_row ['Test Results'], sz: 16
+sum_sheet.add_row
+sum_sheet.add_row
+sum_sheet.add_row ['Note: Blue cells below are links to the Log sheet'], sz: 10
+sum_sheet.add_row
+sum_sheet.add_row ['ID', 'Type', 'Match', 'Mismatch', 'Diffs', 'Errors', 'Result'], style: title_cell
+
+sum_sheet.column_widths 10, 10, 1 0, 11, 10, 10, 10
+
+# Starting data row in summary spreadsheet (after header info)
+current_row = 7
+
+# Create Log Sheet
+log_sheet = wb.add_worksheet name: 'Log'
+log_sheet.column_widths 10
+log_sheet.add_row ['Log Detail'], sz: 16
+log_sheet.add_row
+
+# Add rows to summary sheet
+(1..10).each do |sid|
+  sum_sheet.add_row [sid, 'test', '1', '2', '3', '4', '5'], style: black_cell
 
   if sid.odd?
-    link = "A#{$curRow}" 
-    puts "outputRow: sid: #{sid}, link: #{link}" 
-    # Setting the style for the link will apply the xf that we created in the Main Program block
-    $sumSheet[link].style = $blue_link
-    $sumSheet.add_hyperlink :location => "'Log'!A#{$curRow}", :target => :sheet, :ref => link 
+    link = "A#{current_row}"
+    sum_sheet[link].style = blue_link
+    sum_sheet.add_hyperlink location: "'Log'!A#{current_row}", target: :sheet, ref: link
   end
-  $curRow += 1 
-end 
 
-############################## 
-#   Main Program 
+  current_row += 1
+end
 
-$package = Axlsx::Package.new 
-$workbook = $package.workbook 
-##  We want to create our sytles outside of the outputRow method
-#   Each style only needs to be declared once in the workbook.
-$workbook.styles do |s|
-  $black_cell = s.add_style :sz => 10, :alignment => { :horizontal=> :center } 
-  $blue_link = s.add_style :fg_color => '0000FF'
-end 
-
-
-# Create summary sheet 
-$sumSheet = $workbook.add_worksheet(:name => 'Summary') 
-$sumSheet.add_row ["Test Results"], :sz => 16 
-$sumSheet.add_row 
-$sumSheet.add_row 
-$sumSheet.add_row ["Note: Blue cells below are links to the Log sheet"], :sz => 10 
-$sumSheet.add_row 
-$workbook.styles do |s| 
-  black_cell = s.add_style :sz => 14, :alignment => { :horizontal=> :center } 
-  $sumSheet.add_row ["ID","Type","Match","Mismatch","Diffs","Errors","Result"], :style => black_cell 
-end 
-$sumSheet.column_widths 10, 10, 10, 11, 10, 10, 10 
-
-# Starting data row in summary spreadsheet (after header info) 
-$curRow = 7 
-
-# Create Log Sheet 
-$logSheet = $workbook.add_worksheet(:name => 'Log') 
-$logSheet.column_widths 10 
-$logSheet.add_row ['Log Detail'], :sz => 16 
-$logSheet.add_row 
-
-# Add rows to summary sheet 
-for i in 1..10 do 
-  outputRow(i, 'test') 
-end 
-
-$package.serialize 'where_is_my_color.xlsx'
+p.serialize 'where_is_my_color.xlsx'


### PR DESCRIPTION
I tidied up the example mentioned in #32 to match most of the current guides of rubocop. It resolves the given issue, however the example directory remains a mess.

There are a lot of snippets in the `examples/example.rb` (in a hardly readable format). Some of the examples are in separate files (I guess it was easier to create a new file than follow the pattern in the examples.rb). The comments around the snippets not always tell you what it really does, etc.

I'm suggesting that we should move the examples from the repository to the github wiki with better categorization and more unified format (e.g.: call the package `p` and workbook `wb`, etc).

I'm making a demo of what I imagined and link it here in the PR soon