### PR TITLE
Add option to `#serialize` with system zip command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 ---------
 
 - **Unreleased**
+  - [PR #56](https://github.com/caxlsx/caxlsx/pull/56) - Add `zip_command` option to `#serialize` for faster serialization of large Excel files by using a zip binary
   - [PR #54](https://github.com/caxlsx/caxlsx/pull/54) - Fix type detection for floats with out-of-rage exponents
   
 - **July.16.20**: 3.0.2

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -10,6 +10,7 @@ require 'axlsx/util/accessors.rb'
 require 'axlsx/util/serialized_attributes'
 require 'axlsx/util/options_parser'
 require 'axlsx/util/mime_type_utils'
+require 'axlsx/util/zip_command'
 
 require 'axlsx/stylesheet/styles.rb'
 

--- a/lib/axlsx/util/zip_command.rb
+++ b/lib/axlsx/util/zip_command.rb
@@ -1,0 +1,73 @@
+# encoding: UTF-8
+require 'open3'
+require 'shellwords'
+
+module Axlsx
+
+  # The ZipCommand class supports zipping the Excel file contents using
+  # a binary zip program instead of RubyZip's `Zip::OutputStream`.
+  #
+  # The methods provided here mimic `Zip::OutputStream` so that `ZipCommand` can
+  # be used as a drop-in replacement. Note that method signatures are not
+  # identical to `Zip::OutputStream`, they are only sufficiently close so that
+  # `ZipCommand` and `Zip::OutputStream` can be interchangeably used within
+  # `caxlsx`.
+  class ZipCommand
+    # Raised when the zip command exits with a non-zero status.
+    class ZipError < StandardError; end
+
+    def initialize(zip_command)
+      @current_file = nil
+      @files = []
+      @zip_command = zip_command
+    end
+
+    # Create a temporary directory for writing files to.
+    #
+    # The directory and its contents are removed at the end of the block.
+    def open(output, &block)
+      Dir.mktmpdir do |dir|
+        @dir = dir
+        block.call(self)
+        write_file
+        zip_parts(output)
+      end
+    end
+
+    # Closes the current entry and opens a new for writing.
+    def put_next_entry(entry)
+      write_file
+      @current_file = "#{@dir}/#{entry.name}"
+      @files << entry.name
+      FileUtils.mkdir_p(File.dirname(@current_file))
+    end
+
+    # Write to a buffer that will be written to the current entry
+    def write(content)
+      @buffer << content
+    end
+    alias << write
+
+    private
+
+    def write_file
+      if @current_file
+        @buffer.rewind
+        File.open(@current_file, "wb") { |f| f.write @buffer.read }
+      end
+      @current_file = nil
+      @buffer = StringIO.new
+    end
+
+    def zip_parts(output)
+      output = Shellwords.shellescape(File.absolute_path(output))
+      inputs = Shellwords.shelljoin(@files)
+      escaped_dir = Shellwords.shellescape(@dir)
+      command = "cd #{escaped_dir} && #{@zip_command} #{output} #{inputs}"
+      stdout_and_stderr, status = Open3.capture2e(command)
+      if !status.success?
+        raise(ZipError.new(stdout_and_stderr))
+      end
+    end
+  end
+end

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -128,9 +128,32 @@ class TestPackage < Test::Unit::TestCase
 
   def test_serialization
     @package.serialize(@fname)
-    zf = Zip::File.open(@fname)
-    @package.send(:parts).each{ |part| zf.get_entry(part[:entry]) }
+    assert_zip_file_matches_package(@fname, @package)
     File.delete(@fname)
+  end
+
+  def test_serialization_with_zip_command
+    @package.serialize(@fname, false, zip_command: "zip")
+    assert_zip_file_matches_package(@fname, @package)
+    File.delete(@fname)
+  end
+
+  def test_serialization_with_zip_command_and_absolute_path
+    fname = "#{Dir.tmpdir}/#{@fname}"
+    @package.serialize(fname, false, zip_command: "zip")
+    assert_zip_file_matches_package(fname, @package)
+    File.delete(fname)
+  end
+
+  def test_serialization_with_invalid_zip_command
+    assert_raises Axlsx::ZipCommand::ZipError do
+      @package.serialize(@fname, false, zip_command: "invalid_zip")
+    end
+  end
+
+  def assert_zip_file_matches_package(fname, package)
+    zf = Zip::File.open(fname)
+    package.send(:parts).each{ |part| zf.get_entry(part[:entry]) }
   end
 
   # See comment for Package#zip_entry_for_part

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -127,16 +127,10 @@ class TestPackage < Test::Unit::TestCase
   end
 
   def test_serialization
-    assert_nothing_raised do
-      begin
-        @package.serialize(@fname)
-        zf = Zip::File.open(@fname)
-        @package.send(:parts).each{ |part| zf.get_entry(part[:entry]) }
-        File.delete(@fname)
-      rescue Errno::EACCES
-        puts "WARNING:: test_serialization requires write access."
-      end
-    end
+    @package.serialize(@fname)
+    zf = Zip::File.open(@fname)
+    @package.send(:parts).each{ |part| zf.get_entry(part[:entry]) }
+    File.delete(@fname)
   end
 
   # See comment for Package#zip_entry_for_part


### PR DESCRIPTION
Add a `:zip_command` option to `Axlsx::Package#serialize` that allows
the user to specify an alternate command to use to perform the zip
operation on the XLSX file contents.

The default zip operation is provided by RubyZip. On large documents
users may experience faster zip times using a zip binary.

Resolves #55 