### PR TITLE
Deprecate using `#serialize` with boolean argument

### DIFF
--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -93,9 +93,9 @@ module Axlsx
     #   p.serialize("example.xlsx")
     #
     #   # Serialize to a file, using a system zip binary
-    #   p.serialize("example.xlsx", false, zip_command: "zip")
-    #   p.serialize("example.xlsx", false, zip_command: "/path/to/zip")
-    #   p.serialize("example.xlsx", false, zip_command: "zip -1")
+    #   p.serialize("example.xlsx", zip_command: "zip", confirm_valid: false)
+    #   p.serialize("example.xlsx", zip_command: "/path/to/zip")
+    #   p.serialize("example.xlsx", zip_command: "zip -1")
     #
     #   # Serialize to a stream
     #   s = p.to_stream()

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -100,8 +100,8 @@ module Axlsx
     #   # Serialize to a stream
     #   s = p.to_stream()
     #   File.open('example_streamed.xlsx', 'w') { |f| f.write(s.read) }
-    def serialize(output, options = {})
-      confirm_valid, zip_command = parse_serialize_options(options)
+    def serialize(output, options = {}, secondary_options = nil)
+      confirm_valid, zip_command = parse_serialize_options(options, secondary_options)
       return false unless !confirm_valid || self.validate.empty?
       zip_provider = if zip_command
                        ZipCommand.new(zip_command)
@@ -366,8 +366,13 @@ module Axlsx
     # @return [Boolean, (String or nil)] Returns an array where the first value is
     #   `confirm_valid` and the second is the `zip_command`.
     # @private
-    def parse_serialize_options(options)
+    def parse_serialize_options(options, secondary_options)
+      if secondary_options
+        warn "[DEPRECATION] Axlsx::Package#serialize with 3 arguments is deprecated. " +
+          "Use keyword args instead e.g., package.serialize(output, confirm_valid: false, zip_command: 'zip')"
+      end
       if options.is_a?(Hash)
+        options.merge!(secondary_options || {})
         invalid_keys = options.keys - [:confirm_valid, :zip_command]
         if invalid_keys.any?
           raise ArgumentError.new("Invalid keyword arguments: #{invalid_keys}")
@@ -376,7 +381,7 @@ module Axlsx
       else
         warn "[DEPRECATION] Axlsx::Package#serialize with confirm_valid as a boolean is deprecated. " +
           "Use keyword args instead e.g., package.serialize(output, confirm_valid: false)"
-        [options, nil]
+        parse_serialize_options((secondary_options || {}).merge(confirm_valid: options), nil)
       end
     end
   end

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -74,13 +74,14 @@ module Axlsx
     # Serialize your workbook to disk as an xlsx document.
     #
     # @param [String] output The name of the file you want to serialize your package to
-    # @param [Boolean] confirm_valid Validate the package prior to serialization.
-    # @param [String, nil] zip_command When `nil`, `#serialize` with RubyZip to
+    # @param [Hash] options
+    # @option options [Boolean] :confirm_valid Validate the package prior to serialization.
+    # @option options [String] :zip_command When `nil`, `#serialize` with RubyZip to
     #   zip the XLSX file contents. When a String, the provided zip command (e.g.,
     #   "zip") is used to zip the file contents (may be faster for large files)
     # @return [Boolean] False if confirm_valid and validation errors exist. True if the package was serialized
     # @note A tremendous amount of effort has gone into ensuring that you cannot create invalid xlsx documents.
-    #   confirm_valid should be used in the rare case that you cannot open the serialized file.
+    #   options[:confirm_valid] should be used in the rare case that you cannot open the serialized file.
     # @see Package#validate
     # @example
     #   # This is how easy it is to create a valid xlsx file. Of course you might want to add a sheet or two, and maybe some data, styles and charts.
@@ -99,7 +100,8 @@ module Axlsx
     #   # Serialize to a stream
     #   s = p.to_stream()
     #   File.open('example_streamed.xlsx', 'w') { |f| f.write(s.read) }
-    def serialize(output, confirm_valid=false, zip_command: nil)
+    def serialize(output, options = {})
+      confirm_valid, zip_command = parse_serialize_options(options)
       return false unless !confirm_valid || self.validate.empty?
       zip_provider = if zip_command
                        ZipCommand.new(zip_command)
@@ -358,6 +360,24 @@ module Axlsx
       rels << Relationship.new(self, APP_R, APP_PN)
       rels.lock
       rels
+    end
+
+    # Parse the arguments of `#serialize`
+    # @return [Boolean, (String or nil)] Returns an array where the first value is
+    #   `confirm_valid` and the second is the `zip_command`.
+    # @private
+    def parse_serialize_options(options)
+      if options.is_a?(Hash)
+        invalid_keys = options.keys - [:confirm_valid, :zip_command]
+        if invalid_keys.any?
+          raise ArgumentError.new("Invalid keyword arguments: #{invalid_keys}")
+        end
+        [options.fetch(:confirm_valid, false), options.fetch(:zip_command, nil)]
+      else
+        warn "[DEPRECATION] Axlsx::Package#serialize with confirm_valid as a boolean is deprecated. " +
+          "Use keyword args instead e.g., package.serialize(output, confirm_valid: false)"
+        [options, nil]
+      end
     end
   end
 end

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -165,21 +165,15 @@ class TestPackage < Test::Unit::TestCase
   end
 
   def capture_warnings(&block)
-    # Only capture warnings on versions of ruby that expose `:define_method` as
-    # a public method
-    if Kernel.respond_to?(:define_method)
-      original_warn = Kernel.method(:warn)
-      warnings = []
-      Kernel.define_method(:warn){ |string| warnings << string }
-      block.call
-      original_verbose = $VERBOSE
-      $VERBOSE = nil
-      Kernel.define_method(:warn, &original_warn)
-      $VERBOSE = original_verbose
-      warnings
-    else
-      &block.call
-    end
+    original_warn = Kernel.method(:warn)
+    warnings = []
+    Kernel.send(:define_method, :warn) { |string| warnings << string }
+    block.call
+    original_verbose = $VERBOSE
+    $VERBOSE = nil
+    Kernel.send(:define_method, :warn, &original_warn)
+    $VERBOSE = original_verbose
+    warnings
   end
 
   # See comment for Package#zip_entry_for_part

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -129,12 +129,14 @@ class TestPackage < Test::Unit::TestCase
   def test_serialization
     @package.serialize(@fname)
     assert_zip_file_matches_package(@fname, @package)
+    assert_created_with_rubyzip(@fname, @package)
     File.delete(@fname)
   end
 
   def test_serialization_with_zip_command
     @package.serialize(@fname, zip_command: "zip")
     assert_zip_file_matches_package(@fname, @package)
+    assert_created_with_zip_command(@fname, @package)
     File.delete(@fname)
   end
 
@@ -142,6 +144,7 @@ class TestPackage < Test::Unit::TestCase
     fname = "#{Dir.tmpdir}/#{@fname}"
     @package.serialize(fname, zip_command: "zip")
     assert_zip_file_matches_package(fname, @package)
+    assert_created_with_zip_command(fname, @package)
     File.delete(fname)
   end
 
@@ -154,6 +157,21 @@ class TestPackage < Test::Unit::TestCase
   def assert_zip_file_matches_package(fname, package)
     zf = Zip::File.open(fname)
     package.send(:parts).each{ |part| zf.get_entry(part[:entry]) }
+  end
+
+  def assert_created_with_rubyzip(fname, package)
+    assert_equal 2098, get_mtime(fname, package).year, "XLSX files created with RubyZip have 2098 as the file mtime"
+  end
+
+  def assert_created_with_zip_command(fname, package)
+    assert_equal Time.now.utc.year, get_mtime(fname, package).year, "XLSX files created with a zip command have the current year as the file mtime"
+  end
+
+  def get_mtime(fname, package)
+    zf = Zip::File.open(fname)
+    part = package.send(:parts).first
+    entry = zf.get_entry(part[:entry])
+    entry.mtime.utc
   end
 
   def test_serialization_with_deprecated_argument

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -180,6 +180,18 @@ class TestPackage < Test::Unit::TestCase
     end
     assert_equal 1, warnings.size
     assert_includes warnings.first, "confirm_valid as a boolean is deprecated"
+    File.delete(@fname)
+  end
+
+  def test_serialization_with_deprecated_three_arguments
+    warnings = capture_warnings do
+      @package.serialize(@fname, true, zip_command: "zip")
+    end
+    assert_zip_file_matches_package(@fname, @package)
+    assert_created_with_zip_command(@fname, @package)
+    assert_equal 2, warnings.size
+    assert_includes warnings.first, "with 3 arguments is deprecated"
+    File.delete(@fname)
   end
 
   def capture_warnings(&block)

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -165,15 +165,21 @@ class TestPackage < Test::Unit::TestCase
   end
 
   def capture_warnings(&block)
-    original_warn = Kernel.method(:warn)
-    warnings = []
-    Kernel.define_method(:warn){ |string| warnings << string }
-    block.call
-    original_verbose = $VERBOSE
-    $VERBOSE = nil
-    Kernel.define_method(:warn, &original_warn)
-    $VERBOSE = original_verbose
-    warnings
+    # Only capture warnings on versions of ruby that expose `:define_method` as
+    # a public method
+    if Kernel.respond_to?(:define_method)
+      original_warn = Kernel.method(:warn)
+      warnings = []
+      Kernel.define_method(:warn){ |string| warnings << string }
+      block.call
+      original_verbose = $VERBOSE
+      $VERBOSE = nil
+      Kernel.define_method(:warn, &original_warn)
+      $VERBOSE = original_verbose
+      warnings
+    else
+      &block.call
+    end
   end
 
   # See comment for Package#zip_entry_for_part

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -195,13 +195,13 @@ class TestPackage < Test::Unit::TestCase
   end
 
   def capture_warnings(&block)
-    original_warn = Kernel.method(:warn)
+    original_warn = Kernel.instance_method(:warn)
     warnings = []
     Kernel.send(:define_method, :warn) { |string| warnings << string }
     block.call
     original_verbose = $VERBOSE
     $VERBOSE = nil
-    Kernel.send(:define_method, :warn, &original_warn)
+    Kernel.send(:define_method, :warn, original_warn)
     $VERBOSE = original_verbose
     warnings
   end


### PR DESCRIPTION
Update `Axlsx::Package#serialize` to accept the second argument as a
boolean (being deprecated) or an options hash.

In order to transition toward using keyword arguments for
`Axlsx::Package#serialize`, change the documented method signature to an
options hash, while still parsing the second argument as `confirm_valid`
if a boolean is provided (in which case we also warn the user that a
boolean argument is deprecated).