### PR TITLE
Update Ruby versions on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,11 @@ notifications:
 
 matrix:
   include:
-    - rvm: 2.3.5
-    - rvm: 2.4.7
-    - rvm: 2.5.6
-    - rvm: 2.6.4
+    - rvm: 2.3.8
+    - rvm: 2.4.10
+    - rvm: 2.5.8
+    - rvm: 2.6.6
+    - rvm: 2.7.1
     - rvm: rbx-3
     - rvm: jruby-19mode
     - rvm: jruby-9.1.17.0


### PR DESCRIPTION
I thought that we should keep our CI up-to-date, so
- added ruby 2.7.1
- moved every minor version to its latest patch