### PR TITLE
Extend cell_type_from_value with sanity checks

### DIFF
--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -451,11 +451,11 @@ module Axlsx
         :time
       elsif v.is_a?(TrueClass) || v.is_a?(FalseClass)
         :boolean
-      elsif v.to_s =~ Axlsx::NUMERIC_REGEX
+      elsif v.to_s =~ Axlsx::NUMERIC_REGEX && v.respond_to?(:to_i)
         :integer
-      elsif v.to_s =~ Axlsx::SAFE_FLOAT_REGEX
+      elsif v.to_s =~ Axlsx::SAFE_FLOAT_REGEX && v.respond_to?(:to_f)
         :float
-      elsif (matchdata = v.to_s.match(MAYBE_FLOAT_REGEX)) && (Float::MIN_10_EXP..Float::MAX_10_EXP).cover?(matchdata[:exp].to_i)
+      elsif (matchdata = v.to_s.match(MAYBE_FLOAT_REGEX)) && (Float::MIN_10_EXP..Float::MAX_10_EXP).cover?(matchdata[:exp].to_i) && v.respond_to?(:to_f)
         :float
       elsif v.to_s =~ Axlsx::ISO_8601_REGEX
         :iso_8601

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -120,6 +120,31 @@ class TestCell < Test::Unit::TestCase
     assert_equal(:iso_8601, @c.send(:cell_type_from_value, '2008-08-30T01:45:36.123+09:00'))
   end
 
+  def test_cell_type_from_value_looks_like_number_but_is_not
+    mimic_number = Class.new do
+      def initialize(to_s_value)
+        @to_s_value = to_s_value
+      end
+
+      def to_s
+        @to_s_value
+      end
+    end
+
+    number_strings = [
+      '1',
+      '1234567890',
+      '1.0',
+      '1e1',
+      '0',
+      "1e#{Float::MIN_10_EXP}"
+    ]
+
+    number_strings.each do |number_string|
+      assert_equal(@c.send(:cell_type_from_value, mimic_number.new(number_string)), :string)
+    end
+  end
+
   def test_cast_value
     @c.type = :string
     assert_equal(@c.send(:cast_value, 1.0), "1.0")


### PR DESCRIPTION
Ran into an issue today - `caxlsx` was trying to call `to_i` on an object that does not respond to it, an ActiveRecord instance.

Turns out, the `to_s` of that particular instance was returning a string consisting of only numericals.

This change ensures that only objects that respond to `to_i` / `to_f` methods used in `cast_value` can be autodetected to `:integer` / `:float` values by `cell_type_from_value`, based on the string representation.

Should not break existing use cases, since this would have previously ended in an exception. Well, at least use cases that did not rely on formatting crashing out :D