### PR TITLE
Add 'require' option to gem line

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ and Numbers
 ## Install
 
 ```ruby
-gem 'caxlsx'
+gem 'caxlsx', :require => 'axlsx'
 ```
 
 ## Usage


### PR DESCRIPTION
When I attempt a drop-in replacement of the 'axlsx' gem with 'caxlsx' in my Rails project, I get exceptions to do with the 'Axlsx' constant not being defined.

The 'Axlsx' module is not auto-required because the module is not the same name as the gem anymore.

This can be easily fixed (in Rails, using Bundler) by adding the `:require` option in the Gemfile.