### PR TITLE
Allow to set cell type to `date`

### DIFF
--- a/lib/axlsx/util/validators.rb
+++ b/lib/axlsx/util/validators.rb
@@ -269,7 +269,7 @@ module Axlsx
   # valid types must be one of custom, data, decimal, list, none, textLength, time, whole
   # @param [Any] v The value validated
   def self.validate_data_validation_type(v)
-    RestrictionValidator.validate :data_validation_type, [:custom, :data, :decimal, :list, :none, :textLength, :time, :whole], v
+    RestrictionValidator.validate :data_validation_type, [:custom, :data, :decimal, :list, :none, :textLength, :date, :time, :whole], v
   end
 
   # Requires that the value is a valid sheet view type.

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -475,7 +475,11 @@ module Axlsx
       case type
       when :date
         self.style = STYLE_DATE if self.style == 0
-        v
+        if !v.is_a?(Date) && v.respond_to?(:to_date)
+          v.to_date
+        else
+          v
+        end
       when :time
         self.style = STYLE_DATE if self.style == 0
         if !v.is_a?(Time) && v.respond_to?(:to_time)

--- a/lib/axlsx/workbook/worksheet/data_validation.rb
+++ b/lib/axlsx/workbook/worksheet/data_validation.rb
@@ -171,7 +171,7 @@ module Axlsx
     def formula1=(v); Axlsx::validate_string(v); @formula1 = v end
 
     # @see formula2
-    def formula2=(v); Axlsx::validate_string(v); @formula2 = v end 
+    def formula2=(v); Axlsx::validate_string(v); @formula2 = v end
 
     # @see allowBlank
     def allowBlank=(v); Axlsx::validate_boolean(v); @allowBlank = v end
@@ -216,8 +216,8 @@ module Axlsx
       valid_attributes = get_valid_attributes
 
       str << '<dataValidation '
-      str << instance_values.map do |key, value| 
-        '' << key << '="' << Axlsx.booleanize(value).to_s << '"' if (valid_attributes.include?(key.to_sym) && !CHILD_ELEMENTS.include?(key.to_sym)) 
+      str << instance_values.map do |key, value|
+        '' << key << '="' << Axlsx.booleanize(value).to_s << '"' if (valid_attributes.include?(key.to_sym) && !CHILD_ELEMENTS.include?(key.to_sym))
       end.join(' ')
       str << '>'
       str << ('<formula1>' << self.formula1 << '</formula1>') if @formula1 and valid_attributes.include?(:formula1)
@@ -229,7 +229,7 @@ module Axlsx
     def get_valid_attributes
       attributes = [:allowBlank, :error, :errorStyle, :errorTitle, :prompt, :promptTitle, :showErrorMessage, :showInputMessage, :sqref, :type ]
 
-      if [:whole, :decimal, :data, :time, :textLength].include?(@type)
+      if [:whole, :decimal, :data, :time, :date, :textLength].include?(@type)
         attributes << [:operator, :formula1]
         attributes << [:formula2] if [:between, :notBetween].include?(@operator)
       elsif @type == :list

--- a/test/util/tc_validators.rb
+++ b/test/util/tc_validators.rb
@@ -127,7 +127,7 @@ class TestValidators < Test::Unit::TestCase
     assert_raise(ArgumentError) { Axlsx.validate_data_validation_error_style 0 }
 
     #data_validation_type
-    [:custom, :data, :decimal, :list, :none, :textLength, :time, :whole].each do |sym|
+    [:custom, :data, :decimal, :list, :none, :textLength, :date, :time, :whole].each do |sym|
       assert_nothing_raised { Axlsx.validate_data_validation_type sym }
     end
     assert_raise(ArgumentError) { Axlsx.validate_data_validation_error_style :other_symbol }

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -71,6 +71,13 @@ class TestCell < Test::Unit::TestCase
     assert_equal(@c.value, now.to_time)
   end
 
+  def test_date
+    @c.type = :date
+    now = Time.now
+    @c.value = now
+    assert_equal(@c.value, now.to_date)
+  end
+
   def test_style
     assert_raise(ArgumentError, "must reject invalid style indexes") { @c.style=@c.row.worksheet.workbook.styles.cellXfs.size }
     assert_nothing_raised("must allow valid style index changes") {@c.style=1}


### PR DESCRIPTION
`date` type is valid cell type, but is missing in validator. It's impossible to set it explicitly.

Fixes https://github.com/caxlsx/caxlsx/issues/26

If this can be tested somehow, please let me know, not sure what test to add for this small change