### PR TITLE
Relaxes Ruby dependency to work with Ruby 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - rvm: 2.5.8
     - rvm: 2.6.6
     - rvm: 2.7.1
-    - rvm: 3.0.0-preview1
+    - rvm: 3.0.0
     - rvm: rbx-3
     - rvm: jruby-19mode
     - rvm: jruby-9.1.17.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,11 @@ matrix:
     - rvm: 2.6.6
     - rvm: 2.7.1
     - rvm: 3.0.0
-    - rvm: rbx-3
     - rvm: jruby-19mode
     - rvm: jruby-9.1.17.0
     - rvm: ruby-head
     - rvm: jruby-head
   allow_failures:
-    - rvm: rbx-3
     - rvm: ruby-head
     - rvm: jruby-9.1.17.0
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 sudo: required
-dist: trusty
-group: beta
+dist: bionic
+group: edge
 cache: bundler
 bundler_args: --without profile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
     - rvm: 2.5.8
     - rvm: 2.6.6
     - rvm: 2.7.1
+    - rvm: 3.0.0-preview1
     - rvm: rbx-3
     - rvm: jruby-19mode
     - rvm: jruby-9.1.17.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,9 @@ env:
     - JRUBY_OPTS="-Xcli.debug=true --debug"
 
 # https://github.com/jruby/jruby/wiki/FAQs#why-is-jruby-so-slow-to-install-via-rvm
-# https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon
-addons:
-  apt:
-    packages:
-    - haveged
-    - gnupg2
-  script:
-    - gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-    - gpg2 --verify binscripts/rvm-installer.asc binscripts/rvm-installer
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y install haveged gnupg2
+  - gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+  - gpg2 --verify binscripts/rvm-installer.asc binscripts/rvm-installer

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,6 @@ notifications:
       - noel@peden.biz
     on_success: always
 
-before_install:
-  - sudo apt-get update
-  - sudo apt-get -y install haveged gnupg2
-  - gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-  - gpg2 --verify binscripts/rvm-installer.asc binscripts/rvm-installer
-
 matrix:
   include:
     - rvm: 2.3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,7 @@ addons:
   apt:
     packages:
     - haveged
+    - gnupg2
+  script:
+    - gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+    - gpg2 --verify binscripts/rvm-installer.asc binscripts/rvm-installer

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ notifications:
       - noel@peden.biz
     on_success: always
 
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y install haveged gnupg2
+  - gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+  - gpg2 --verify binscripts/rvm-installer.asc binscripts/rvm-installer
+
 matrix:
   include:
     - rvm: 2.3.8
@@ -36,9 +42,3 @@ env:
     - JRUBY_OPTS="-Xcli.debug=true --debug"
 
 # https://github.com/jruby/jruby/wiki/FAQs#why-is-jruby-so-slow-to-install-via-rvm
-
-before_install:
-  - sudo apt-get update
-  - sudo apt-get -y install haveged gnupg2
-  - gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-  - gpg2 --verify binscripts/rvm-installer.asc binscripts/rvm-installer

--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,3 @@ end
 group :profile do
   gem 'ruby-prof', :platforms => :ruby
 end
-
-platforms :rbx do
-  gem 'rubysl'
-  gem 'rubysl-test-unit'
-  gem 'racc'
-  gem 'rubinius-coverage', '~> 2.0'
-end

--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'yard', "~> 0.9.8"
   s.add_development_dependency 'kramdown', '~> 2.3'
   s.add_development_dependency 'timecop', "~> 0.8.1"
-  s.required_ruby_version = '~> 2.3'
+  s.required_ruby_version = '>= 2.3'
   s.require_path = 'lib'
 end


### PR DESCRIPTION
Tested with `3.0.0-preview1` and all tests are green:

```
Loaded suite /Users/walski/.rubies/ruby-3.0.0-preview1/lib/ruby/gems/3.0.0/gems/rake-13.0.1/lib/rake/rake_test_loader
Started
................................................................................................................................................................................
................................................................................................................................................................................
................................................................................................................................................................................
................................................................................................................................................................................
................................................................................................................................................................................
.......................
Finished in 4.225482 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
903 tests, 2962 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
213.70 tests/s, 700.99 assertions/s
Coverage report generated for Unit Tests to /Users/walski/projects/os/caxlsx/coverage. 5160 / 5161 LOC (99.98%) covered.
```

