### PR TITLE
Fix special characters in table header

### DIFF
--- a/lib/axlsx/workbook/worksheet/table.rb
+++ b/lib/axlsx/workbook/worksheet/table.rb
@@ -80,7 +80,7 @@ module Axlsx
       str << ('<autoFilter ref="' << @ref << '"/>')
       str << ('<tableColumns count="' << header_cells.length.to_s << '">')
       header_cells.each_with_index do |cell,index|
-        str << ('<tableColumn id ="' << (index+1).to_s << '" name="' << cell.value << '"/>')
+        str << ('<tableColumn id ="' << (index+1).to_s << '" name="' << cell.clean_value << '"/>')
       end
       str << '</tableColumns>'
       table_style_info.to_xml_string(str)

--- a/test/workbook/worksheet/tc_table.rb
+++ b/test/workbook/worksheet/tc_table.rb
@@ -64,4 +64,19 @@ class TestTable < Test::Unit::TestCase
     end
     assert(errors.empty?, "error free validation")
   end
+
+  def test_to_xml_string_for_special_characters
+    cell = @ws.rows.first.cells.first
+    cell.value = "&><'\""
+
+    table = @ws.add_table("A1:D5")
+    schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
+    doc = Nokogiri::XML(table.to_xml_string)
+    errors = []
+    schema.validate(doc).each do |error|
+      errors.push error
+      puts error.message
+    end
+    assert(errors.empty?, "error free validation")
+  end
 end

--- a/test/workbook/worksheet/tc_table.rb
+++ b/test/workbook/worksheet/tc_table.rb
@@ -70,13 +70,8 @@ class TestTable < Test::Unit::TestCase
     cell.value = "&><'\""
 
     table = @ws.add_table("A1:D5")
-    schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
     doc = Nokogiri::XML(table.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
-    assert(errors.empty?, "error free validation")
+    errors = doc.errors
+    assert(errors.empty?, "invalid xml: #{errors.map(&:to_s).join(', ')}")
   end
 end


### PR DESCRIPTION
Previous to this PR, special characters in table headers would generate invalid XML due to the use of the `cell.value` instead of `cell.clean_value` in table serialization.

This PR adds a test and fix for this.

Before the fix, the new test failed with:

```
1:0: ERROR: Element '{http://schemas.openxmlformats.org/spreadsheetml/2006/main}tableColumns': Character content other than whitespace is not allowed because the content type is 'element-only'.
F
===============================================================================
Failure: test_to_xml_string_for_special_characters(TestTable):
  error free validation.
  <false> is not true.
/home/rfdonnelly/repos/caxlsx/test/workbook/worksheet/tc_table.rb:80:in `test_to_xml_string_for_special_characters'
     77:       errors.push error
     78:       puts error.message
     79:     end
  => 80:     assert(errors.empty?, "error free validation")
     81:   end
     82: end
===============================================================================
```

After the fix, the new test passes.