### PR TITLE
Fix special characters in pivot table cache definition

### DIFF
--- a/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
@@ -53,7 +53,7 @@ module Axlsx
       str <<   '</cacheSource>'
       str << (  '<cacheFields count="' << pivot_table.header_cells_count.to_s << '">')
       pivot_table.header_cells.each do |cell|
-        str << (  '<cacheField name="' << cell.value << '" numFmtId="0">')
+        str << (  '<cacheField name="' << cell.clean_value << '" numFmtId="0">')
         str <<     '<sharedItems count="0">'
         str <<     '</sharedItems>'
         str <<   '</cacheField>'

--- a/test/workbook/worksheet/tc_pivot_table_cache_definition.rb
+++ b/test/workbook/worksheet/tc_pivot_table_cache_definition.rb
@@ -51,4 +51,12 @@ class TestPivotTableCacheDefinition < Test::Unit::TestCase
     assert(errors.empty?, "error free validation")
   end
 
+  def test_to_xml_string_for_special_characters
+    cell = @ws.rows.first.cells.first
+    cell.value = "&><'\""
+
+    doc = Nokogiri::XML(@cache_definition.to_xml_string)
+    errors = doc.errors
+    assert(errors.empty?, "invalid xml: #{errors.map(&:to_s).join(', ')}")
+  end
 end


### PR DESCRIPTION
Previous to this PR, special characters in pivot table headers would generate invalid XML due to the use of the cell.value instead of cell.clean_value in pivot table cache definition serialization.

This PR adds a test and fix for this.

Before the fix, the new test failed with:

```
Failure: test_to_xml_string_for_special_characters(TestPivotTableCacheDefinition):
  invalid xml: 1:382: FATAL: xmlParseEntityRef: no name, 1:383: FATAL: Unescaped '<' not allowed in attributes values, 1:383: FATAL: attributes construct error, 1:383: FATAL: Couldn't find end of Start Tag cacheField line 1, 1:384: FATAL: StartTag: invalid element name, 1:461: FATAL: Opening and ending tag mismatch: cacheFields line 1 and cacheField, 1:730: FATAL: Opening and ending tag mismatch: pivotCacheDefinition line 1 and cacheFields, 1:730: FATAL: Extra content at the end of the document.
  <false> is not true.
/home/rfdonnelly/repos/caxlsx/test/workbook/worksheet/tc_pivot_table_cache_definition.rb:60:in `test_to_xml_string_for_special_characters'
     57:
     58:     doc = Nokogiri::XML(@cache_definition.to_xml_string)
     59:     errors = doc.errors
  => 60:     assert(errors.empty?, "invalid xml: #{errors.map(&:to_s).join(', ')}")
     61:   end
     62: end
```

After the fix, the new test passes.