### PR TITLE
[sec] Resolves nokogiri security vulnerability by upgrading version to the latest

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir.glob("{lib/**/*,examples/**/*.rb,examples/**/*.jpeg}") + %w{ LICENSE README.md Rakefile CHANGELOG.md .yardopts .yardopts_guide }
   s.test_files  = Dir.glob("{test/**/*}")
 
-  s.add_runtime_dependency 'nokogiri', '~> 1.10', '>= 1.10.4'
+  s.add_runtime_dependency 'nokogiri', '~> 1.11', '>= 1.11.1'
   s.add_runtime_dependency 'rubyzip', '>= 1.3.0', '< 3'
   s.add_runtime_dependency "htmlentities", "~> 4.3", '>= 4.3.4'
   s.add_runtime_dependency "mimemagic", '~> 0.3'


### PR DESCRIPTION
Problem: Nokogiri version below 1.11.0rc4 suffer from the following two security vulnerabilities:

1) DoS- https://snyk.io/vuln/SNYK-RUBY-NOKOGIRI-552159
2) XXE - https://snyk.io/vuln/SNYK-RUBY-NOKOGIRI-1055008

Fix: Upgrade Nokogiri version to  >= 1.11.1. 


Was wondering how quickly we could get this merged, seeing as it is related to a security vulnerability?  Assuming your team is ok with dropping Ruby 2.3 and Ruby 1.9 support in this new version? 

It does appear that Ruby <= 2.4 support has ended in 2020. https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/#:~:text=We%20announce%20that%20all%20support,Ruby%202.4%20series%20has%20ended.