### PR TITLE
CI: Add JRuby 9.2.15.0 (latest release)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,13 @@ matrix:
     - rvm: 3.0.0
     - rvm: jruby-19mode
     - rvm: jruby-9.1.17.0
+    - rvm: jruby-9.2.15.0
     - rvm: ruby-head
     - rvm: jruby-head
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-9.1.17.0
+    - rvm: jruby-9.2.15.0
     - rvm: jruby-head
 
 env:


### PR DESCRIPTION
This PR ~~updates~~ **adds** JRuby **9.2.15.0** to the CI matrix.

[JRuby 9.2.15.0 release blog post](https://www.jruby.org/2021/02/24/jruby-9-2-15-0.html)