### PR TITLE
feature: manageable markers for scatter series

### DIFF
--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -97,15 +97,12 @@ module Axlsx
           str << '<a:ln><a:solidFill>'
           str << ('<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
           str << '</c:spPr>'
-
-          if !@show_marker
-            str << '<c:marker><c:symbol val="none"/></c:marker>'
-          elsif @marker_symbol != :default
-            str << '<c:marker><c:symbol val="' + @marker_symbol.to_s + '"/></c:marker>'
-          end
-
+          str << marker_xml
           str << '</c:marker>'
+        else
+          str << "<c:marker>#{marker_xml}</c:marker>"
         end
+
         if ln_width
           str << '<c:spPr>'
           str << '<a:ln w="' << ln_width.to_s << '"/>'
@@ -116,6 +113,16 @@ module Axlsx
         str << ('<c:smooth val="' << ((smooth) ? '1' : '0') << '"/>')
       end
       str
+    end
+
+    private
+
+    def marker_xml
+      if !@show_marker
+        '<c:symbol val="none"/>'
+      elsif @marker_symbol != :default
+        '<c:symbol val="' + @marker_symbol.to_s + '"/>'
+      end
     end
   end
 end

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -30,11 +30,15 @@ module Axlsx
 
     # Line markers presence
     # @return [Boolean]
-    attr_reader :marker
+    attr_reader :show_marker
+
+    # custom marker symbol
+    # @return [String]
+    attr_reader :marker_symbol
 
     # Creates a new ScatterSeries
     def initialize(chart, options={})
-      @xData, @yData = nil
+      @xData, @yData, @marker_symbol = nil
       if options[:smooth].nil?
         # If caller hasn't specified smoothing or not, turn smoothing on or off based on scatter style
         @smooth = [:smooth, :smoothMarker].include?(chart.scatter_style)
@@ -44,7 +48,7 @@ module Axlsx
         @smooth = options[:smooth]
       end
       @ln_width = options[:ln_width] unless options[:ln_width].nil?
-      @marker = [:lineMarker, :marker, :smoothMarker].include?(chart.scatter_style)
+      @show_marker = [:lineMarker, :marker, :smoothMarker].include?(chart.scatter_style)
 
       super(chart, options)
       @xData = AxDataSource.new(:tag_name => :xVal, :data => options[:xData]) unless options[:xData].nil?
@@ -67,6 +71,12 @@ module Axlsx
       @ln_width = v
     end
 
+    # @see marker_symbol
+    def marker_symbol=(v)
+      Axlsx::validate_marker_symbol(v)
+      @marker_symbol = v
+    end
+
     # Serializes the object
     # @param [String] str
     # @return [String]
@@ -87,7 +97,13 @@ module Axlsx
           str << '<a:ln><a:solidFill>'
           str << ('<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
           str << '</c:spPr>'
-          str << '<c:symbol val="none"/>' unless marker
+
+          if !@show_marker
+            str << '<c:marker><c:symbol val="none"/></c:marker>'
+          elsif @marker_symbol != :default
+            str << '<c:marker><c:symbol val="' + @marker_symbol.to_s + '"/></c:marker>'
+          end
+
           str << '</c:marker>'
         end
         if ln_width

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -49,7 +49,7 @@ module Axlsx
       end
       @ln_width = options[:ln_width] unless options[:ln_width].nil?
       @show_marker = [:lineMarker, :marker, :smoothMarker].include?(chart.scatter_style)
-      @marker_symbol = options[:marker_symbol] || :default
+      @marker_symbol = :default
 
       super(chart, options)
       @xData = AxDataSource.new(:tag_name => :xVal, :data => options[:xData]) unless options[:xData].nil?

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -38,7 +38,7 @@ module Axlsx
 
     # Creates a new ScatterSeries
     def initialize(chart, options={})
-      @xData, @yData, @marker_symbol = nil
+      @xData, @yData = nil
       if options[:smooth].nil?
         # If caller hasn't specified smoothing or not, turn smoothing on or off based on scatter style
         @smooth = [:smooth, :smoothMarker].include?(chart.scatter_style)
@@ -49,6 +49,7 @@ module Axlsx
       end
       @ln_width = options[:ln_width] unless options[:ln_width].nil?
       @show_marker = [:lineMarker, :marker, :smoothMarker].include?(chart.scatter_style)
+      @marker_symbol = options[:marker_symbol] || :default
 
       super(chart, options)
       @xData = AxDataSource.new(:tag_name => :xVal, :data => options[:xData]) unless options[:xData].nil?

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -28,6 +28,10 @@ module Axlsx
     # @return [Boolean]
     attr_reader :smooth
 
+    # Line markers presence
+    # @return [Boolean]
+    attr_reader :marker
+
     # Creates a new ScatterSeries
     def initialize(chart, options={})
       @xData, @yData = nil
@@ -40,6 +44,8 @@ module Axlsx
         @smooth = options[:smooth]
       end
       @ln_width = options[:ln_width] unless options[:ln_width].nil?
+      @marker = [:lineMarker, :marker, :smoothMarker].include?(chart.scatter_style)
+
       super(chart, options)
       @xData = AxDataSource.new(:tag_name => :xVal, :data => options[:xData]) unless options[:xData].nil?
       @yData = NumDataSource.new({:tag_name => :yVal, :data => options[:yData]}) unless options[:yData].nil?
@@ -81,6 +87,7 @@ module Axlsx
           str << '<a:ln><a:solidFill>'
           str << ('<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
           str << '</c:spPr>'
+          str << '<c:symbol val="none"/>' unless marker
           str << '</c:marker>'
         end
         if ln_width

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -123,7 +123,7 @@ module Axlsx
         '<c:symbol val="none"/>'
       elsif @marker_symbol != :default
         '<c:symbol val="' + @marker_symbol.to_s + '"/>'
-      end
+      end.to_s
     end
   end
 end

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -98,10 +98,10 @@ module Axlsx
           str << '<a:ln><a:solidFill>'
           str << ('<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
           str << '</c:spPr>'
-          str << marker_xml
+          str << marker_symbol_xml
           str << '</c:marker>'
         else
-          str << "<c:marker>#{marker_xml}</c:marker>"
+          str << "<c:marker>#{marker_symbol_xml}</c:marker>"
         end
 
         if ln_width
@@ -118,7 +118,7 @@ module Axlsx
 
     private
 
-    def marker_xml
+    def marker_symbol_xml
       if !@show_marker
         '<c:symbol val="none"/>'
       elsif @marker_symbol != :default

--- a/test/drawing/tc_scatter_series.rb
+++ b/test/drawing/tc_scatter_series.rb
@@ -54,21 +54,21 @@ class TestScatterSeries < Test::Unit::TestCase
   end
 
   def test_false_show_marker
-    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Smooth Chart", :scatter_style => :smoothMarker
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => 'Smooth Chart', :scatter_style => :smoothMarker
     @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9]
-    assert(@series.show_marker, "markers are enabled for marker-related styles")
+    assert(@series.show_marker, 'markers are enabled for marker-related styles')
   end
 
   def test_true_show_marker
-    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Line chart", :scatter_style => :line
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => 'Line chart', :scatter_style => :line
     @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9]
-    assert(!@series.show_marker, "markers are disabled for markerless scatter styles")
+    assert(!@series.show_marker, 'markers are disabled for markerless scatter styles')
   end
 
   def test_marker_symbol
-    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Line chart", :scatter_style => :line
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => 'Line chart', :scatter_style => :line
     @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9], :marker_symbol => :diamond
-    assert_equal(@series.marker_symbol, :diamond, "markers are disabled for markerless scatter styles")
+    assert_equal(@series.marker_symbol, :diamond, 'series could have own custom marker symbol')
   end
 
 end

--- a/test/drawing/tc_scatter_series.rb
+++ b/test/drawing/tc_scatter_series.rb
@@ -53,4 +53,16 @@ class TestScatterSeries < Test::Unit::TestCase
     assert_equal(doc.xpath("//a:ln[@w='#{@series.ln_width}']").length, 1)
   end
 
+  def test_chart_style_with_marker
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Smooth Chart", :scatter_style => :smoothMarker
+    @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9]
+    assert(@series.marker, "markers are enabled for marker-related styles")
+  end
+
+  def test_chart_style_without_marker
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Line chart", :scatter_style => :line
+    @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9]
+    assert(!@series.marker, "markers are disabled for markerless scatter styles")
+  end
+
 end

--- a/test/drawing/tc_scatter_series.rb
+++ b/test/drawing/tc_scatter_series.rb
@@ -53,16 +53,22 @@ class TestScatterSeries < Test::Unit::TestCase
     assert_equal(doc.xpath("//a:ln[@w='#{@series.ln_width}']").length, 1)
   end
 
-  def test_chart_style_with_marker
+  def test_false_show_marker
     @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Smooth Chart", :scatter_style => :smoothMarker
     @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9]
-    assert(@series.marker, "markers are enabled for marker-related styles")
+    assert(@series.show_marker, "markers are enabled for marker-related styles")
   end
 
-  def test_chart_style_without_marker
+  def test_true_show_marker
     @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Line chart", :scatter_style => :line
     @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9]
-    assert(!@series.marker, "markers are disabled for markerless scatter styles")
+    assert(!@series.show_marker, "markers are disabled for markerless scatter styles")
+  end
+
+  def test_marker_symbol
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Line chart", :scatter_style => :line
+    @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9], :marker_symbol => :diamond
+    assert_equal(@series.marker_symbol, :diamond, "markers are disabled for markerless scatter styles")
   end
 
 end


### PR DESCRIPTION
Currently, scatter series would have the markers despite the style of scatter chart. This PR introduces the possibility to hide the markers if scatter style implies markers' absence. 
Additionally, it would allow customizing marker symbol in the same way as LineSeries allows