### PR TITLE
Feature: Secondary Y axis support for scatter chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tmp
 *.pfx
 examples/sprk2012
 .ruby-version
+.ruby-gemset
 .bundle/config
 .~lock*
 *.qcachegrind

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -62,6 +62,14 @@ module Axlsx
     end
   end
 
+  # sorts the array of cells provided to start from the minimum x,y to
+  # the maximum x.y#
+  # @param [Array] cells
+  # @return [Array]
+  def self.sort_cells(cells)
+    cells.sort_by(&:pos)
+  end
+
   #global reference html entity encoding
   # @return [HtmlEntities]
   def self.coder

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -51,22 +51,15 @@ module Axlsx
   # determines the cell range for the items provided
   def self.cell_range(cells, absolute=true)
     return "" unless cells.first.is_a? Cell
-    cells = sort_cells(cells)
-    reference = "#{cells.first.reference(absolute)}:#{cells.last.reference(absolute)}"
+
+    first_cell, last_cell = cells.minmax_by(&:pos)
+    reference = "#{first_cell.reference(absolute)}:#{last_cell.reference(absolute)}"
     if absolute
-      escaped_name = cells.first.row.worksheet.name.gsub '&apos;', "''"
+      escaped_name = first_cell.row.worksheet.name.gsub '&apos;', "''"
       "'#{escaped_name}'!#{reference}"
     else
       reference
     end
-  end
-
-  # sorts the array of cells provided to start from the minimum x,y to
-  # the maximum x.y#
-  # @param [Array] cells
-  # @return [Array]
-  def self.sort_cells(cells)
-    cells.sort { |x, y| [x.index, x.row.row_index] <=> [y.index, y.row.row_index] }
   end
 
   #global reference html entity encoding

--- a/lib/axlsx/drawing/num_data_source.rb
+++ b/lib/axlsx/drawing/num_data_source.rb
@@ -33,7 +33,7 @@ module Axlsx
     # allowed element tag names
     # @return [Array]
     def self.allowed_tag_names
-      [:yVal, :val, :bubbleSize]
+      [:yVal, :val, :bubbleSize, :xVal]
     end
 
      # sets the tag name for this data source
@@ -59,4 +59,3 @@ module Axlsx
     end
   end
 end
-

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -30,11 +30,15 @@ module Axlsx
 
     # Line markers presence
     # @return [Boolean]
-    attr_reader :marker
+    attr_reader :show_marker
+
+    # custom marker symbol
+    # @return [String]
+    attr_reader :marker_symbol
 
     # Creates a new ScatterSeries
     def initialize(chart, options={})
-      @xData, @yData = nil
+      @xData, @yData, @marker_symbol = nil
       if options[:smooth].nil?
         # If caller hasn't specified smoothing or not, turn smoothing on or off based on scatter style
         @smooth = [:smooth, :smoothMarker].include?(chart.scatter_style)
@@ -44,7 +48,7 @@ module Axlsx
         @smooth = options[:smooth]
       end
       @ln_width = options[:ln_width] unless options[:ln_width].nil?
-      @marker = [:lineMarker, :marker, :smoothMarker].include?(chart.scatter_style)
+      @show_marker = [:lineMarker, :marker, :smoothMarker].include?(chart.scatter_style)
 
       super(chart, options)
 
@@ -68,6 +72,12 @@ module Axlsx
       @ln_width = v
     end
 
+    # @see marker_symbol
+    def marker_symbol=(v)
+      Axlsx::validate_marker_symbol(v)
+      @marker_symbol = v
+    end
+
     # Serializes the object
     # @param [String] str
     # @return [String]
@@ -88,7 +98,13 @@ module Axlsx
           str << '<a:ln><a:solidFill>'
           str << ('<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
           str << '</c:spPr>'
-          str << '<c:symbol val="none"/>' unless marker
+
+          if !@show_marker
+            str << '<c:marker><c:symbol val="none"/></c:marker>'
+          elsif @marker_symbol != :default
+            str << '<c:marker><c:symbol val="' + @marker_symbol.to_s + '"/></c:marker>'
+          end
+
           str << '</c:marker>'
         end
         if ln_width

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -28,6 +28,10 @@ module Axlsx
     # @return [Boolean]
     attr_reader :smooth
 
+    # Line markers presence
+    # @return [Boolean]
+    attr_reader :marker
+
     # Creates a new ScatterSeries
     def initialize(chart, options={})
       @xData, @yData = nil
@@ -40,6 +44,8 @@ module Axlsx
         @smooth = options[:smooth]
       end
       @ln_width = options[:ln_width] unless options[:ln_width].nil?
+      @marker = [:lineMarker, :marker, :smoothMarker].include?(chart.scatter_style)
+
       super(chart, options)
 
       @xData = NumDataSource.new(:tag_name => :xVal, :data => options[:xData]) unless options[:xData].nil?
@@ -82,6 +88,7 @@ module Axlsx
           str << '<a:ln><a:solidFill>'
           str << ('<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
           str << '</c:spPr>'
+          str << '<c:symbol val="none"/>' unless marker
           str << '</c:marker>'
         end
         if ln_width

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -98,15 +98,12 @@ module Axlsx
           str << '<a:ln><a:solidFill>'
           str << ('<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
           str << '</c:spPr>'
-
-          if !@show_marker
-            str << '<c:marker><c:symbol val="none"/></c:marker>'
-          elsif @marker_symbol != :default
-            str << '<c:marker><c:symbol val="' + @marker_symbol.to_s + '"/></c:marker>'
-          end
-
+          str << marker_xml
           str << '</c:marker>'
+        else
+          str << "<c:marker>#{marker_xml}</c:marker>"
         end
+
         if ln_width
           str << '<c:spPr>'
           str << '<a:ln w="' << ln_width.to_s << '"/>'
@@ -117,6 +114,16 @@ module Axlsx
         str << ('<c:smooth val="' << ((smooth) ? '1' : '0') << '"/>')
       end
       str
+    end
+
+    private
+
+    def marker_xml
+      if !@show_marker
+        '<c:symbol val="none"/>'
+      elsif @marker_symbol != :default
+        '<c:symbol val="' + @marker_symbol.to_s + '"/>'
+      end
     end
   end
 end

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -36,9 +36,13 @@ module Axlsx
     # @return [String]
     attr_reader :marker_symbol
 
+    # @return [Boolean]
+    attr_reader :on_primary_y_axis
+
+
     # Creates a new ScatterSeries
     def initialize(chart, options={})
-      @xData, @yData, @marker_symbol = nil
+      @xData, @yData = nil
       if options[:smooth].nil?
         # If caller hasn't specified smoothing or not, turn smoothing on or off based on scatter style
         @smooth = [:smooth, :smoothMarker].include?(chart.scatter_style)
@@ -49,6 +53,8 @@ module Axlsx
       end
       @ln_width = options[:ln_width] unless options[:ln_width].nil?
       @show_marker = [:lineMarker, :marker, :smoothMarker].include?(chart.scatter_style)
+      @on_primary_y_axis = true
+      @marker_symbol = options[:marker_symbol] || :default
 
       super(chart, options)
 
@@ -76,6 +82,12 @@ module Axlsx
     def marker_symbol=(v)
       Axlsx::validate_marker_symbol(v)
       @marker_symbol = v
+    end
+
+    # is it on the primary axis?
+    def on_primary_y_axis=(v)
+      Axlsx.validate_boolean(v)
+      @on_primary_y_axis = v
     end
 
     # Serializes the object
@@ -123,7 +135,7 @@ module Axlsx
         '<c:symbol val="none"/>'
       elsif @marker_symbol != :default
         '<c:symbol val="' + @marker_symbol.to_s + '"/>'
-      end
+      end.to_s
     end
   end
 end

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -41,7 +41,8 @@ module Axlsx
       end
       @ln_width = options[:ln_width] unless options[:ln_width].nil?
       super(chart, options)
-      @xData = AxDataSource.new(:tag_name => :xVal, :data => options[:xData]) unless options[:xData].nil?
+
+      @xData = NumDataSource.new(:tag_name => :xVal, :data => options[:xData]) unless options[:xData].nil?
       @yData = NumDataSource.new({:tag_name => :yVal, :data => options[:yData]}) unless options[:yData].nil?
     end
 

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -327,7 +327,7 @@ module Axlsx
       start, stop = if target.is_a?(String)
                       [self.r, target]
                     elsif(target.is_a?(Cell))
-                      [self, target].sort_by(&:pos).map { |c| c.r }
+                      Axlsx.sort_cells([self, target]).map { |c| c.r }
                     end
       self.row.worksheet.merge_cells "#{start}:#{stop}" unless stop.nil?
     end

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -327,7 +327,7 @@ module Axlsx
       start, stop = if target.is_a?(String)
                       [self.r, target]
                     elsif(target.is_a?(Cell))
-                      Axlsx.sort_cells([self, target]).map { |c| c.r }
+                      [self, target].sort_by(&:pos).map { |c| c.r }
                     end
       self.row.worksheet.merge_cells "#{start}:#{stop}" unless stop.nil?
     end

--- a/test/drawing/tc_scatter_chart.rb
+++ b/test/drawing/tc_scatter_chart.rb
@@ -3,7 +3,7 @@ require 'tc_helper.rb'
 class TestScatterChart < Test::Unit::TestCase
   def setup
     @p = Axlsx::Package.new
-    @chart = nil
+
     @p.workbook.add_worksheet do |sheet|
       sheet.add_row ["First",  1,  5,  7,  9]
       sheet.add_row ["",       1, 25, 49, 81]
@@ -13,7 +13,7 @@ class TestScatterChart < Test::Unit::TestCase
         chart.start_at 0, 4
         chart.end_at 10, 19
         chart.add_series :xData => sheet["B1:E1"], :yData => sheet["B2:E2"], :title => sheet["A1"]
-        chart.add_series :xData => sheet["B3:E3"], :yData => sheet["B4:E4"], :title => sheet["A3"]
+        chart.add_series :xData => sheet["B3:E3"], :yData => sheet["B4:E4"], :title => sheet["A3"], on_primary_y_axis: false
         @chart = chart
       end
     end
@@ -27,22 +27,26 @@ class TestScatterChart < Test::Unit::TestCase
     assert(@chart.scatterStyle == :marker)
     assert_raise(ArgumentError) { @chart.scatterStyle = :buckshot }
   end
+
   def test_initialization
-    assert_equal(@chart.scatterStyle, :lineMarker, "scatterStyle defualt incorrect")
-    assert_equal(@chart.series_type, Axlsx::ScatterSeries, "series type incorrect")
-    assert(@chart.xValAxis.is_a?(Axlsx::ValAxis), "independant value axis not created")
-    assert(@chart.yValAxis.is_a?(Axlsx::ValAxis), "dependant value axis not created")
+    assert_equal(@chart.scatterStyle, :lineMarker, 'scatterStyle defualt incorrect')
+    assert_equal(@chart.series_type, Axlsx::ScatterSeries, 'series type incorrect')
+    assert(@chart.x_val_axis.is_a?(Axlsx::ValAxis), 'independant value axis not created')
+    assert(@chart.y_val_axis.is_a?(Axlsx::ValAxis), 'dependant value axis not created')
+    assert(@chart.secondary_y_val_axis.is_a?(Axlsx::ValAxis), 'secondary value axis not created')
   end
 
   def test_to_xml_string
     schema = Nokogiri::XML::Schema(File.open(Axlsx::DRAWING_XSD))
     doc = Nokogiri::XML(@chart.to_xml_string)
     errors = []
+
     schema.validate(doc).each do |error|
       errors.push error
       puts error.message
     end
-    assert(errors.empty?, "error free validation")
-  end
 
+    assert(errors.empty?, 'error free validation')
+    assert_equal(doc.xpath('//c:scatterChart').size, 2)
+  end
 end

--- a/test/drawing/tc_scatter_series.rb
+++ b/test/drawing/tc_scatter_series.rb
@@ -54,21 +54,21 @@ class TestScatterSeries < Test::Unit::TestCase
   end
 
   def test_false_show_marker
-    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Smooth Chart", :scatter_style => :smoothMarker
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => 'Smooth Chart', :scatter_style => :smoothMarker
     @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9]
-    assert(@series.show_marker, "markers are enabled for marker-related styles")
+    assert(@series.show_marker, 'markers are enabled for marker-related styles')
   end
 
   def test_true_show_marker
-    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Line chart", :scatter_style => :line
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => 'Line chart', :scatter_style => :line
     @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9]
-    assert(!@series.show_marker, "markers are disabled for markerless scatter styles")
+    assert(!@series.show_marker, 'markers are disabled for markerless scatter styles')
   end
 
   def test_marker_symbol
-    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Line chart", :scatter_style => :line
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => 'Line chart', :scatter_style => :line
     @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9], :marker_symbol => :diamond
-    assert_equal(@series.marker_symbol, :diamond, "markers are disabled for markerless scatter styles")
+    assert_equal(@series.marker_symbol, :diamond, 'series could have own custom marker symbol')
   end
 
 end

--- a/test/drawing/tc_scatter_series.rb
+++ b/test/drawing/tc_scatter_series.rb
@@ -53,4 +53,16 @@ class TestScatterSeries < Test::Unit::TestCase
     assert_equal(doc.xpath("//a:ln[@w='#{@series.ln_width}']").length, 1)
   end
 
+  def test_chart_style_with_marker
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Smooth Chart", :scatter_style => :smoothMarker
+    @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9]
+    assert(@series.marker, "markers are enabled for marker-related styles")
+  end
+
+  def test_chart_style_without_marker
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Line chart", :scatter_style => :line
+    @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9]
+    assert(!@series.marker, "markers are disabled for markerless scatter styles")
+  end
+
 end

--- a/test/drawing/tc_scatter_series.rb
+++ b/test/drawing/tc_scatter_series.rb
@@ -53,16 +53,22 @@ class TestScatterSeries < Test::Unit::TestCase
     assert_equal(doc.xpath("//a:ln[@w='#{@series.ln_width}']").length, 1)
   end
 
-  def test_chart_style_with_marker
+  def test_false_show_marker
     @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Smooth Chart", :scatter_style => :smoothMarker
     @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9]
-    assert(@series.marker, "markers are enabled for marker-related styles")
+    assert(@series.show_marker, "markers are enabled for marker-related styles")
   end
 
-  def test_chart_style_without_marker
+  def test_true_show_marker
     @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Line chart", :scatter_style => :line
     @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9]
-    assert(!@series.marker, "markers are disabled for markerless scatter styles")
+    assert(!@series.show_marker, "markers are disabled for markerless scatter styles")
+  end
+
+  def test_marker_symbol
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Line chart", :scatter_style => :line
+    @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9], :marker_symbol => :diamond
+    assert_equal(@series.marker_symbol, :diamond, "markers are disabled for markerless scatter styles")
   end
 
 end


### PR DESCRIPTION
Inspired by unmerged https://github.com/randym/axlsx/pull/431/files this PR introduces support of secondary `Y` axis for scatter charts.

Additionally, it contains changes from https://github.com/caxlsx/caxlsx/pull/85 and https://github.com/caxlsx/caxlsx/pull/82 (as I'm still not sure if it's correct to have `AxDataSource` instead of `NumDataSource` for `X` axis)  - for sure these ones could be removed from this PR