### PR TITLE
CI: Use jruby-9.2.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,13 @@ matrix:
     - rvm: 3.0.0
     - rvm: jruby-19mode
     - rvm: jruby-9.1.17.0
-    - rvm: jruby-9.2.15.0
+    - rvm: jruby-9.2.16.0
     - rvm: ruby-head
     - rvm: jruby-head
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-9.1.17.0
-    - rvm: jruby-9.2.15.0
+    - rvm: jruby-9.2.16.0
     - rvm: jruby-head
 
 env:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.16.0**.

[JRuby 9.2.16.0 release blog post](https://www.jruby.org/2021/03/03/jruby-9-2-16-0.html)