### PR TITLE
Replace mimemagic with marcel

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'nokogiri', '~> 1.10', '>= 1.10.4'
   s.add_runtime_dependency 'rubyzip', '>= 1.3.0', '< 3'
   s.add_runtime_dependency "htmlentities", "~> 4.3", '>= 4.3.4'
-  s.add_runtime_dependency "mimemagic", '~> 0.3'
+  s.add_runtime_dependency "marcel", '~> 1.0'
 
   s.add_development_dependency 'yard', "~> 0.9.8"
   s.add_development_dependency 'kramdown', '~> 2.3'

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 require 'htmlentities'
 require 'axlsx/version.rb'
-require 'mimemagic'
+require 'marcel'
 
 require 'axlsx/util/simple_typed_list.rb'
 require 'axlsx/util/constants.rb'

--- a/lib/axlsx/util/mime_type_utils.rb
+++ b/lib/axlsx/util/mime_type_utils.rb
@@ -5,7 +5,7 @@ module Axlsx
     # @param [String] v File path
     # @return [String] File mime type
     def self.get_mime_type(v)
-      MimeMagic.by_magic(File.open(v)).to_s
+      Marcel::MimeType.for(Pathname.new(v))
     end
   end
 end

--- a/test/tc_helper.rb
+++ b/test/tc_helper.rb
@@ -8,5 +8,3 @@ end
 require 'test/unit'
 require "timecop"
 require "axlsx.rb"
-# MIME detection for Microsoft Office 2007+ formats
-require 'mimemagic/overlay'

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -228,7 +228,7 @@ class TestPackage < Test::Unit::TestCase
   end
 
   def test_serialization_creates_files_with_excel_mime_type
-    assert_equal(MimeMagic.by_magic(@package.to_stream).type,
+    assert_equal(Marcel::MimeType.for(@package.to_stream),
                  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
   end
 


### PR DESCRIPTION
Mimemagic requires users to download or install additional files.

Rails used Marcel as an abstration layer on this library. Marcel
was updated to another file matching database. Following Rails in
this matter will remove the need for users to do additional work,
just to use caxlsx.

Fixes #92 