### PR TITLE
Remove Low-order non-printable ASCII characters in worksheet name

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'nokogiri', '~> 1.10', '>= 1.10.4'
   s.add_runtime_dependency 'rubyzip', '>= 1.3.0', '< 3'
-  s.add_runtime_dependency "htmlentities", "~> 4.3", '>= 4.3.4'
+  s.add_runtime_dependency 'builder', '~> 3.2', '>= 3.2.4'
   s.add_runtime_dependency "marcel", '~> 1.0'
 
   s.add_development_dependency 'yard', "~> 0.9.8"

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
-require 'htmlentities'
 require 'axlsx/version.rb'
+require 'axlsx/coder'
 require 'marcel'
 
 require 'axlsx/util/simple_typed_list.rb'
@@ -55,7 +55,7 @@ module Axlsx
     first_cell, last_cell = cells.minmax_by(&:pos)
     reference = "#{first_cell.reference(absolute)}:#{last_cell.reference(absolute)}"
     if absolute
-      escaped_name = first_cell.row.worksheet.name.gsub '&apos;', "''"
+      escaped_name = first_cell.row.worksheet.name.gsub "'", "''"
       "'#{escaped_name}'!#{reference}"
     else
       reference
@@ -70,10 +70,10 @@ module Axlsx
     cells.sort_by(&:pos)
   end
 
-  #global reference html entity encoding
-  # @return [HtmlEntities]
+  #global reference xml entity encoding
+  # @return [Axlsx::Coder]
   def self.coder
-    @@coder ||= ::HTMLEntities.new
+    @@coder ||= Coder.new
   end
 
   # returns the x, y position of a cell

--- a/lib/axlsx/coder.rb
+++ b/lib/axlsx/coder.rb
@@ -1,0 +1,9 @@
+require 'builder'
+
+module Axlsx
+  class Coder < Builder::XmlBase
+    def encode(str)
+      _escape_attribute(str).tr(::Builder::XChar::REPLACEMENT_CHAR, '')
+    end
+  end
+end

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -19,6 +19,11 @@ class TestWorksheet < Test::Unit::TestCase
     assert_equal(@ws.name, '&lt;foo&gt; &amp; &lt;bar&gt;')
   end
 
+  def test_non_printable_ascii_characters_are_removed
+    @ws.name = "foo\bbar"
+    assert_equal(@ws.name, 'foobar')
+  end
+
   def test_name_exception_on_invalid_character
     assert_raises(ArgumentError) { @ws.name = 'foo:bar' }
     assert_raises(ArgumentError) { @ws.name = 'foo[bar' }


### PR DESCRIPTION
Resolve https://github.com/caxlsx/caxlsx/issues/75

I have tested it with the following script. Looks great.
```rb
require 'caxlsx'
require 'builder'

module Axlsx
  class Coder < Builder::XmlBase
    def encode(str)
      _escape_attribute(str).tr(::Builder::XChar::REPLACEMENT_CHAR, '')
    end
  end
end

def Axlsx.coder
  Axlsx::Coder.new
end

a = Axlsx::Package.new
a.workbook.add_worksheet(:name => "Sheet <'>\" 1") do |sheet|
  sheet.add_row ["Data1", "Data2"]
end
a.workbook.add_worksheet(:name => "Sheet \b 2 ") do |sheet|
  sheet.add_row ["Data1", "Data2"]
end
  
a.serialize('simple.xlsx')
```
[simple.xlsx](https://github.com/caxlsx/caxlsx/files/6397134/simple.xlsx)
