### PR TITLE
Fix gap width validator for bar charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 - **Unreleased**
   - [PR #107](https://github.com/caxlsx/caxlsx/pull/107) - Add overlap to bar charts
+  - [PR #108](https://github.com/caxlsx/caxlsx/pull/108) - Fix gap depth and gap depth validators for bar charts and 3D bar charts
 
 - **March.27.21**: 3.1.0
   - [PR #95](https://github.com/caxlsx/caxlsx/pull/95) - Replace mimemagic with marcel  

--- a/lib/axlsx/drawing/bar_3D_chart.rb
+++ b/lib/axlsx/drawing/bar_3D_chart.rb
@@ -31,17 +31,17 @@ module Axlsx
     alias :barDir :bar_dir
 
     # space between bar or column clusters, as a percentage of the bar or column width.
-    # @return [String]
+    # @return [Integer]
     attr_reader :gap_depth
     alias :gapDepth :gap_depth
 
     # space between bar or column clusters, as a percentage of the bar or column width.
-    # @return [String]
+    # @return [Integer]
     def gap_width
       @gap_width ||= 150
     end
     alias :gapWidth :gap_width
-    
+
     #grouping for a column, line, or area chart.
     # must be one of  [:percentStacked, :clustered, :standard, :stacked]
     # @return [Symbol]
@@ -55,9 +55,6 @@ module Axlsx
     def shape
       @shape ||= :box
     end
-
-    # validation regex for gap amount percent
-    GAP_AMOUNT_PERCENT = /0*(([0-9])|([1-9][0-9])|([1-4][0-9][0-9])|500)%/
 
     # Creates a new bar chart object
     # @param [GraphicFrame] frame The workbook that owns this chart.
@@ -102,14 +99,14 @@ module Axlsx
 
     # space between bar or column clusters, as a percentage of the bar or column width.
     def gap_width=(v)
-      RegexValidator.validate "Bar3DChart.gap_width", GAP_AMOUNT_PERCENT, v
+      RangeValidator.validate "Bar3DChart.gap_width", 0, 500, v
       @gap_width=(v)
     end
     alias :gapWidth= :gap_width=
 
     # space between bar or column clusters, as a percentage of the bar or column width.
     def gap_depth=(v)
-      RegexValidator.validate "Bar3DChart.gap_didth", GAP_AMOUNT_PERCENT, v
+      RangeValidator.validate "Bar3DChart.gap_depth", 0, 500, v
       @gap_depth=(v)
     end
     alias :gapDepth= :gap_depth=

--- a/lib/axlsx/drawing/bar_chart.rb
+++ b/lib/axlsx/drawing/bar_chart.rb
@@ -31,11 +31,6 @@ module Axlsx
     alias :barDir :bar_dir
 
     # space between bar or column clusters, as a percentage of the bar or column width.
-    # @return [String]
-    attr_reader :gap_depth
-    alias :gapDepth :gap_depth
-
-    # space between bar or column clusters, as a percentage of the bar or column width.
     # @return [Integer]
     def gap_width
       @gap_width ||= 150
@@ -62,9 +57,6 @@ module Axlsx
       @shape ||= :box
     end
 
-    # validation regex for gap amount percent
-    GAP_AMOUNT_PERCENT = /0*(([0-9])|([1-9][0-9])|([1-4][0-9][0-9])|500)%/
-
     # Creates a new bar chart object
     # @param [GraphicFrame] frame The workbook that owns this chart.
     # @option options [Cell, String] title
@@ -72,12 +64,11 @@ module Axlsx
     # @option options [Symbol] bar_dir
     # @option options [Symbol] grouping
     # @option options [String] gap_width
-    # @option options [String] gap_depth
     # @option options [Symbol] shape
     # @see Chart
     def initialize(frame, options={})
       @vary_colors = true
-      @gap_width, @gap_depth, @overlap, @shape = nil, nil, nil, nil
+      @gap_width, @overlap, @shape = nil, nil, nil
       super(frame, options)
       @series_type = BarSeries
       @d_lbls = nil
@@ -105,13 +96,6 @@ module Axlsx
     end
     alias :gapWidth= :gap_width=
 
-    # space between bar or column clusters, as a percentage of the bar or column width.
-    def gap_depth=(v)
-      RegexValidator.validate "BarChart.gap_didth", GAP_AMOUNT_PERCENT, v
-      @gap_depth=(v)
-    end
-    alias :gapDepth= :gap_depth=
-
     def overlap=(v)
       RangeValidator.validate "BarChart.overlap", -100, 100, v
       @overlap=(v)
@@ -137,7 +121,6 @@ module Axlsx
         @d_lbls.to_xml_string(str) if @d_lbls
         str << ('<c:overlap val="' << @overlap.to_s << '"/>') unless @overlap.nil?
         str << ('<c:gapWidth val="' << @gap_width.to_s << '"/>') unless @gap_width.nil?
-        str << ('<c:gapDepth val="' << @gap_depth.to_s << '"/>') unless @gap_depth.nil?
         str << ('<c:shape val="' << @shape.to_s << '"/>') unless @shape.nil?
         axes.to_xml_string(str, :ids => true)
         str << '</c:barChart>'

--- a/lib/axlsx/drawing/bar_chart.rb
+++ b/lib/axlsx/drawing/bar_chart.rb
@@ -36,7 +36,7 @@ module Axlsx
     alias :gapDepth :gap_depth
 
     # space between bar or column clusters, as a percentage of the bar or column width.
-    # @return [String]
+    # @return [Integer]
     def gap_width
       @gap_width ||= 150
     end
@@ -100,7 +100,7 @@ module Axlsx
 
     # space between bar or column clusters, as a percentage of the bar or column width.
     def gap_width=(v)
-      RegexValidator.validate "BarChart.gap_width", GAP_AMOUNT_PERCENT, v
+      RangeValidator.validate "BarChart.gap_width", 0, 500, v
       @gap_width=(v)
     end
     alias :gapWidth= :gap_width=

--- a/test/drawing/tc_bar_3D_chart.rb
+++ b/test/drawing/tc_bar_3D_chart.rb
@@ -32,18 +32,19 @@ class TestBar3DChart < Test::Unit::TestCase
    assert(@chart.grouping == :standard)
  end
 
+  def test_gap_width
+    assert_raise(ArgumentError, "require valid gap width") { @chart.gap_width = -1 }
+    assert_raise(ArgumentError, "require valid gap width") { @chart.gap_width = 501 }
+    assert_nothing_raised("allow valid gapWidth") { @chart.gap_width = 200 }
+    assert_equal(@chart.gap_width, 200, 'gap width is incorrect')
+  end
 
- def test_gapWidth
-   assert_raise(ArgumentError, "require valid gap width") { @chart.gap_width = 200 }
-   assert_nothing_raised("allow valid gapWidth") { @chart.gap_width = "200%" }
-   assert(@chart.gap_width == "200%")
- end
-
- def test_gapDepth
-   assert_raise(ArgumentError, "require valid gap_depth") { @chart.gap_depth = 200 }
-   assert_nothing_raised("allow valid gap_depth") { @chart.gap_depth = "200%" }
-   assert(@chart.gap_depth == "200%")
- end
+  def test_gap_depth
+    assert_raise(ArgumentError, "require valid gap_depth") { @chart.gap_depth = -1 }
+    assert_raise(ArgumentError, "require valid gap_depth") { @chart.gap_depth = 501 }
+    assert_nothing_raised("allow valid gap_depth") { @chart.gap_depth = 200 }
+    assert_equal(@chart.gap_depth, 200, 'gap depth is incorrect')
+  end
 
   def test_shape
     assert_raise(ArgumentError, "require valid shape") { @chart.shape = :star }
@@ -67,5 +68,19 @@ class TestBar3DChart < Test::Unit::TestCase
     cat_axis_position = str.index(@chart.axes[:cat_axis].id.to_s)
     val_axis_position = str.index(@chart.axes[:val_axis].id.to_s)
     assert(cat_axis_position < val_axis_position, "cat_axis must occur earlier than val_axis in the XML")
+  end
+
+  def test_to_xml_string_has_gap_depth
+    gap_depth_value = rand(0..500)
+    @chart.gap_depth = gap_depth_value
+    doc = Nokogiri::XML(@chart.to_xml_string)
+    assert_equal(doc.xpath("//c:bar3DChart/c:gapDepth").first.attribute('val').value, gap_depth_value.to_s)
+  end
+
+  def test_to_xml_string_has_gap_width
+    gap_width_value = rand(0..500)
+    @chart.gap_width = gap_width_value
+    doc = Nokogiri::XML(@chart.to_xml_string)
+    assert_equal(doc.xpath("//c:bar3DChart/c:gapWidth").first.attribute('val').value, gap_width_value.to_s)
   end
 end

--- a/test/drawing/tc_bar_chart.rb
+++ b/test/drawing/tc_bar_chart.rb
@@ -39,12 +39,6 @@ class TestBarChart < Test::Unit::TestCase
     assert_equal(@chart.gap_width, 200, 'gap width is incorrect')
   end
 
- def test_gapDepth
-   assert_raise(ArgumentError, "require valid gap_depth") { @chart.gap_depth = 200 }
-   assert_nothing_raised("allow valid gap_depth") { @chart.gap_depth = "200%" }
-   assert(@chart.gap_depth == "200%")
- end
-
   def test_overlap
     assert_raise(ArgumentError, "require valid overlap") { @chart.overlap = -101 }
     assert_raise(ArgumentError, "require valid overlap") { @chart.overlap = 101 }

--- a/test/drawing/tc_bar_chart.rb
+++ b/test/drawing/tc_bar_chart.rb
@@ -32,12 +32,12 @@ class TestBarChart < Test::Unit::TestCase
    assert(@chart.grouping == :standard)
  end
 
-
- def test_gapWidth
-   assert_raise(ArgumentError, "require valid gap width") { @chart.gap_width = 200 }
-   assert_nothing_raised("allow valid gapWidth") { @chart.gap_width = "200%" }
-   assert(@chart.gap_width == "200%")
- end
+  def test_gap_width
+    assert_raise(ArgumentError, "require valid gap width") { @chart.gap_width = -1 }
+    assert_raise(ArgumentError, "require valid gap width") { @chart.gap_width = 501 }
+    assert_nothing_raised("allow valid gap width") { @chart.gap_width = 200 }
+    assert_equal(@chart.gap_width, 200, 'gap width is incorrect')
+  end
 
  def test_gapDepth
    assert_raise(ArgumentError, "require valid gap_depth") { @chart.gap_depth = 200 }
@@ -74,6 +74,13 @@ class TestBarChart < Test::Unit::TestCase
     cat_axis_position = str.index(@chart.axes[:cat_axis].id.to_s)
     val_axis_position = str.index(@chart.axes[:val_axis].id.to_s)
     assert(cat_axis_position < val_axis_position, "cat_axis must occur earlier than val_axis in the XML")
+  end
+
+  def test_to_xml_string_has_gap_width
+    gap_width_value = rand(0..500)
+    @chart.gap_width = gap_width_value
+    doc = Nokogiri::XML(@chart.to_xml_string)
+    assert_equal(doc.xpath("//c:barChart/c:gapWidth").first.attribute('val').value, gap_width_value.to_s)
   end
 
   def test_to_xml_string_has_overlap


### PR DESCRIPTION
While I was working on #107 , I found that we have a `gap_width` option for `BarChart`s, however the validator seems to be off.

Given I have this code, and I need to figure out what should be instead of `something`

```ruby
require 'axlsx'

p = Axlsx::Package.new
wb = p.workbook

wb.add_worksheet(name: 'Bar Chart') do |sheet|
  sheet.add_row ['A Simple Bar Chart', 'X', 'Y']

  sheet.add_row ['A', 3, 4]
  sheet.add_row ['B', 10, 6]
  sheet.add_row ['C', 7, 2]

  sheet.add_chart(Axlsx::BarChart, start_at: 'A6', end_at: 'F20') do |chart|
    chart.add_series data: sheet['B2:B4'], labels: sheet['A2:A4'], title: sheet['B1']
    chart.add_series data: sheet['C2:C4'], labels: sheet['A2:A4'], title: sheet['C1']

    chart.bar_dir = :col
    chart.gap_width = 10
    chart.gap_width = something # <<- this is the problematic line
    chart.grouping = :clustered
  end
end

p.serialize 'gap_bar_chart_example.xlsx'
```

When I put there `10%` as the validator suggests, then the file got generated, but Excel complains about the file

![image](https://user-images.githubusercontent.com/1900366/125080673-6144a580-e0c5-11eb-9e30-ddd5a51760cd.png)

If I change it to `10`, then the validator throws an error:

```
Executing gap bar chart example
Traceback (most recent call last):
        10: from ./generate.rb:9:in `<main>'
         9: from ./generate.rb:9:in `each'
         8: from ./generate.rb:13:in `block in <main>'
         7: from ./generate.rb:13:in `eval'
         6: from (eval):8:in `block in <main>'
         5: from caxlsx/lib/axlsx/workbook/workbook.rb:270:in `add_worksheet'
         4: from (eval):15:in `block (2 levels) in <main>'
         3: from caxlsx/lib/axlsx/workbook/worksheet/worksheet.rb:471:in `add_chart'
         2: from (eval):20:in `block (3 levels) in <main>'
         1: from caxlsx/lib/axlsx/drawing/bar_chart.rb:97:in `gap_width='
```

Finally I changed the validator to be a RangeValidator which accepts numbers between 0 and 500 and I was able to generate this chart:

![image](https://user-images.githubusercontent.com/1900366/125080969-c13b4c00-e0c5-11eb-9fc5-2e785691e428.png)

In the BarChart class, there's an other field having the same validator, but I _think_ it doesn't do anything, the name suggests that it's only used for Bar3DCharts (Excel doesn't complain about having wrong value there)

TODO:
* [x] Fix BarChart#gap_width
* [x] Delete BarChart#gap_depth if it's not used anywhere (need confirmation)
* [x] Fix Bar3DChart#gap_width
* [x] Fix Bar3DChart#gap_depth
