### PR TITLE
Return output stream in binmode

### DIFF
--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -124,7 +124,7 @@ module Axlsx
     def to_stream(confirm_valid=false)
       return false unless !confirm_valid || self.validate.empty?
       Relationship.initialize_ids_cache
-      zip = write_parts(Zip::OutputStream.new(StringIO.new, true))
+      zip = write_parts(Zip::OutputStream.new(StringIO.new.binmode, true))
       stream = zip.close_buffer
       stream.rewind
       stream

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -304,6 +304,7 @@ class TestPackage < Test::Unit::TestCase
     # in testing.
     assert(stream.size > 80000)
     # Stream (of zipped contents) should have appropriate default encoding
+    assert stream.string.valid_encoding?
     assert_equal(stream.external_encoding, Encoding::ASCII_8BIT)
     # Cached ids should be cleared
     assert(Axlsx::Relationship.ids_cache.empty?)

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -303,6 +303,8 @@ class TestPackage < Test::Unit::TestCase
     # this is just a roundabout guess for a package as it is build now
     # in testing.
     assert(stream.size > 80000)
+    # Stream (of zipped contents) should have appropriate default encoding
+    assert_equal(stream.external_encoding, Encoding::ASCII_8BIT)
     # Cached ids should be cleared
     assert(Axlsx::Relationship.ids_cache.empty?)
   end


### PR DESCRIPTION
Addresses issues as described in https://github.com/rubyzip/rubyzip/issues/438 where the default encoding is UTF-8 but the actual zipped/deflated contents are not necessarily valid UTF-8.

As a minimal example:
```ruby
require 'axlsx.rb'
p = Axlsx::Package.new
p.workbook.add_worksheet(name: 'Test Sheet') do |ws|
  ws.add_row(['A Title', 'Another Title', 'A Third Title'])
  ws.add_row(['Value', 1.0, nil])
end

puts p.to_stream.string.valid_encoding?
```