### PR TITLE
Remove Known Bugs Section in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,6 @@ p.use_shared_strings = true
 p.serialize('simple.xlsx')
 ```
 
-## Known Bugs
-
-There’s a [list of known bugs](https://github.com/caxlsx/caxlsx/issues?q=label%3A%22known+bug%22). (If you want to contribute to caxlsx, this is a good place to start!)
-
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/caxlsx/caxlsx/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
Currently the link to known bugs, results in a list of 3 closed issues and no open issues. I think this link doesnt serve its purpose correctly.