### PR TITLE
Sort archive entries for correct MIME detection with `file` command

### DIFF
--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -206,12 +206,10 @@ module Axlsx
     # @private
     def parts
       parts = [
-       {:entry => RELS_PN, :doc => relationships, :schema => RELS_XSD},
        {:entry => "xl/#{STYLES_PN}", :doc => workbook.styles, :schema => SML_XSD},
        {:entry => CORE_PN, :doc => @core, :schema => CORE_XSD},
        {:entry => APP_PN, :doc => @app, :schema => APP_XSD},
        {:entry => WORKBOOK_RELS_PN, :doc => workbook.relationships, :schema => RELS_XSD},
-       {:entry => CONTENT_TYPES_PN, :doc => content_types, :schema => CONTENT_TYPES_XSD},
        {:entry => WORKBOOK_PN, :doc => workbook, :schema => SML_XSD}
       ]
 
@@ -256,7 +254,11 @@ module Axlsx
       end
 
       # Sort parts for correct MIME detection
-      parts.sort_by { |part| part[:entry] }
+      [
+        {:entry => CONTENT_TYPES_PN, :doc => content_types, :schema => CONTENT_TYPES_XSD},
+        {:entry => RELS_PN, :doc => relationships, :schema => RELS_XSD},
+        *(parts.sort_by { |part| part[:entry] }.reverse)
+      ]
     end
 
     # Performs xsd validation for a signle document

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -262,6 +262,10 @@ class TestPackage < Test::Unit::TestCase
     #no mystery parts
     assert_equal(25, p.size)
 
+    #sorted for correct MIME detection
+    assert_equal("[Content_Types].xml", p[0][:entry], "first entry should be `[Content_Types].xml`")
+    assert_equal("_rels/.rels", p[1][:entry], "second entry should be `_rels/.rels`")
+    assert_match(/\Axl\//, p[2][:entry], "third entry should begin with `xl/`")
   end
 
   def test_shared_strings_requires_part


### PR DESCRIPTION
Hi. Thanks for maintaining this great gem.

Fixes #130 

According to [these lines](https://github.com/file/file/blob/ec41083645689a787cdd00cb3b5bf578aa79e46c/magic/Magdir/msooxml#L28-L38), `file` checks the **third** entry to detect the MIME type. 

> make sure the first file is correct
> skip to the second local file header
> since some documents include a 520-byte extra field following the file
> header, we need to scan for the next header
> now skip to the *third* local file header; again, we need to scan due to a
> 520-byte extra field following the file header
> and check the subdirectory name to determine which type of OOXML

`caxlsx` currently generates archive entries with wrong order: the third entry is `docProps/app.xml`.

```
$ zipinfo caxlsx.xlsx
Archive:  caxlsx.xlsx
Zip file size: 5335 bytes, number of entries: 12
-rw-r--r--  5.2 unx     1144 t- defN 98-Jan-01 09:00 [Content_Types].xml
-rw-r--r--  5.2 unx      569 t- defN 98-Jan-01 09:00 _rels/.rels
-rw-r--r--  5.2 unx      225 t- defN 98-Jan-01 09:00 docProps/app.xml
-rw-r--r--  5.2 unx      485 t- defN 98-Jan-01 09:00 docProps/core.xml
-rw-r--r--  5.2 unx      406 t- defN 98-Jan-01 09:00 xl/_rels/workbook.xml.rels
-rw-r--r--  5.2 unx     2018 t- defN 98-Jan-01 09:00 xl/charts/chart1.xml
-rw-r--r--  5.2 unx      274 t- defN 98-Jan-01 09:00 xl/drawings/_rels/drawing1.xml.rels
-rw-r--r--  5.2 unx      982 t- defN 98-Jan-01 09:00 xl/drawings/drawing1.xml
-rw-r--r--  5.2 unx     1288 t- defN 98-Jan-01 09:00 xl/styles.xml
-rw-r--r--  5.2 unx      306 t- defN 98-Jan-01 09:00 xl/workbook.xml
-rw-r--r--  5.2 unx      280 t- defN 98-Jan-01 09:00 xl/worksheets/_rels/sheet1.xml.rels
-rw-r--r--  5.2 unx     1588 t- defN 98-Jan-01 09:00 xl/worksheets/sheet1.xml

$ file -b --mime caxlsx.xlsx
application/octet-stream; charset=binary
```

On the other hand, the third entry generated by MS Excel begins with `xl/`, and `file` can correctly detect MIME type.

```
$ zipinfo excel.xlsx
Archive:  excel.xlsx
Zip file size: 8253 bytes, number of entries: 9
-rw----     4.5 fat     1032 b- defS 80-Jan-01 00:00 [Content_Types].xml
-rw----     4.5 fat      588 b- defS 80-Jan-01 00:00 _rels/.rels
-rw----     4.5 fat      557 b- defS 80-Jan-01 00:00 xl/_rels/workbook.xml.rels
-rw----     4.5 fat     1742 b- defS 80-Jan-01 00:00 xl/workbook.xml
-rw----     4.5 fat     1806 b- defS 80-Jan-01 00:00 xl/styles.xml
-rw----     4.5 fat     8394 b- defS 80-Jan-01 00:00 xl/theme/theme1.xml
-rw----     4.5 fat      951 b- defS 80-Jan-01 00:00 xl/worksheets/sheet1.xml
-rw----     4.5 fat      635 b- defS 80-Jan-01 00:00 docProps/core.xml
-rw----     4.5 fat      803 b- defS 80-Jan-01 00:00 docProps/app.xml
9 files, 16508 bytes uncompressed, 5395 bytes compressed:  67.3%

$ file -b --mime excel/excel.xlsx
application/vnd.openxmlformats-officedocument.spreadsheetml.sheet; charset=binary
```

I fixed the archive entries order and confirmed `file` can correctly detect MIME type.

```
$ file --version
file-5.40

$ file -b --mime caxlsx.xlsx
application/vnd.openxmlformats-officedocument.spreadsheetml.sheet; charset=binary

$ zipinfo caxlsx.xlsx
Archive:  caxlsx.xlsx
Zip file size: 5342 bytes, number of entries: 12
-rw-r--r--  5.2 unx     1144 t- defN 98-Jan-01 09:00 [Content_Types].xml
-rw-r--r--  5.2 unx      569 t- defN 98-Jan-01 09:00 _rels/.rels
-rw-r--r--  5.2 unx      406 t- defN 98-Jan-01 09:00 xl/_rels/workbook.xml.rels
-rw-r--r--  5.2 unx     2018 t- defN 98-Jan-01 09:00 xl/charts/chart1.xml
-rw-r--r--  5.2 unx      274 t- defN 98-Jan-01 09:00 xl/drawings/_rels/drawing1.xml.rels
-rw-r--r--  5.2 unx      982 t- defN 98-Jan-01 09:00 xl/drawings/drawing1.xml
-rw-r--r--  5.2 unx     1288 t- defN 98-Jan-01 09:00 xl/styles.xml
-rw-r--r--  5.2 unx      306 t- defN 98-Jan-01 09:00 xl/workbook.xml
-rw-r--r--  5.2 unx      280 t- defN 98-Jan-01 09:00 xl/worksheets/_rels/sheet1.xml.rels
-rw-r--r--  5.2 unx     1588 t- defN 98-Jan-01 09:00 xl/worksheets/sheet1.xml
-rw-r--r--  5.2 unx      485 t- defN 98-Jan-01 09:00 docProps/core.xml
-rw-r--r--  5.2 unx      225 t- defN 98-Jan-01 09:00 docProps/app.xml
12 files, 9565 bytes uncompressed, 3898 bytes compressed:  59.2%
```

ref:
https://github.com/box/spout/issues/149#issuecomment-162049588
https://github.com/thoughtbot/paperclip/issues/1530#issuecomment-276632869