### PR TITLE
Update gemspec to recent styles

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -7,14 +7,12 @@ Gem::Specification.new do |s|
   s.email       = 'noel@peden.biz'
   s.homepage    = 'https://github.com/caxlsx/caxlsx'
   s.platform    = Gem::Platform::RUBY
-  s.date        = Time.now.strftime('%Y-%m-%d')
   s.summary     = "Excel OOXML (xlsx) with charts, styles, images and autowidth columns."
   s.license     = 'MIT'
   s.description = <<-eof
     xlsx spreadsheet generation with charts, images, automated column width, customizable styles and full schema validation. Axlsx helps you create beautiful Office Open XML Spreadsheet documents ( Excel, Google Spreadsheets, Numbers, LibreOffice) without having to understand the entire ECMA specification. Check out the README for some examples of how easy it is. Best of all, you can validate your xlsx file before serialization so you know for sure that anything generated is going to load on your client's machine.
   eof
   s.files = Dir.glob("{lib/**/*,examples/**/*.rb,examples/**/*.jpeg}") + %w{ LICENSE README.md Rakefile CHANGELOG.md .yardopts .yardopts_guide }
-  s.test_files  = Dir.glob("{test/**/*}")
 
   s.add_runtime_dependency 'nokogiri', '~> 1.10', '>= 1.10.4'
   s.add_runtime_dependency 'rubyzip', '>= 1.3.0', '< 3'


### PR DESCRIPTION
This PR updates gemspec file to recent styles. Here are the details:
- `date` should not be set
  - RubyGems says not to set the value to [`date`](https://github.com/rubygems/rubygems/blob/fe96fb6e2ac5a8b6df5e852470d11fa854301eca/lib/rubygems/specification.rb#L1677-L1682).
- Remove deprecated `test_files` to shrink gem size
  - Please see the following for details.
    -  rubygems/guides#90
    - rubygems/bundler#3207