### PR TITLE
Fix empty chart title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 ---------
 
 - **Unreleased**
+  - [PR #144](https://github.com/caxlsx/caxlsx/pull/144) - Completely hide chart titles if blank; Fix missing cell reference for chart title when cell empty,.
 
 - **February.23.22**: 3.2.0
   - [PR #75](https://github.com/caxlsx/caxlsx/pull/85) - Added manageable markers for scatter series

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -189,7 +189,7 @@ module Axlsx
       str << ('<c:date1904 val="' << Axlsx::Workbook.date1904.to_s << '"/>')
       str << ('<c:style val="' << style.to_s << '"/>')
       str << '<c:chart>'
-      @title.to_xml_string str
+      @title.to_xml_string(str) unless @title.empty?
       str << ('<c:autoTitleDeleted val="' << (@title == nil).to_s << '"/>')
       @view_3D.to_xml_string(str) if @view_3D
       str << '<c:floor><c:thickness val="0"/></c:floor>'

--- a/lib/axlsx/drawing/title.rb
+++ b/lib/axlsx/drawing/title.rb
@@ -51,6 +51,16 @@ module Axlsx
       v
     end
 
+    # Check if the title is empty.
+    #
+    # A title is considered empty if it is an empty string. If the title references a cell it is *not* empty,
+    # even if the referenced cell is blank (because the cell’s value could still change later).
+    #
+    # @return [Boolean]
+    def empty?
+      @text.empty? && @cell.nil?
+    end
+
     # Not implemented at this time.
     #def layout=(v) DataTypeValidator.validate 'Title.layout', Layout, v; @layout = v; end
     #def overlay=(v) Axlsx::validate_boolean v; @overlay=v; end
@@ -61,7 +71,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<c:title>'
-      unless @text.empty? && @cell.nil?
+      unless empty?
         clean_value = Axlsx::trust_input ? @text.to_s : ::CGI.escapeHTML(Axlsx::sanitize(@text.to_s))
         str << '<c:tx>'
         if @cell.is_a?(Cell)

--- a/lib/axlsx/drawing/title.rb
+++ b/lib/axlsx/drawing/title.rb
@@ -61,7 +61,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<c:title>'
-      unless @text.empty?
+      unless @text.empty? && @cell.nil?
         clean_value = Axlsx::trust_input ? @text.to_s : ::CGI.escapeHTML(Axlsx::sanitize(@text.to_s))
         str << '<c:tx>'
         if @cell.is_a?(Cell)

--- a/test/drawing/tc_chart.rb
+++ b/test/drawing/tc_chart.rb
@@ -1,3 +1,5 @@
+$LOAD_PATH.unshift "#{File.dirname(__FILE__)}/../"
+
 require 'tc_helper.rb'
 
 class TestChart < Test::Unit::TestCase
@@ -25,6 +27,8 @@ class TestChart < Test::Unit::TestCase
     @chart.title = @row.cells.first
     assert_equal(@chart.title.text, "one", "the title text was set via cell reference")
     assert_equal(@chart.title.cell, @row.cells.first)
+    @chart.title = ""
+    assert(@chart.title.empty?)
   end
 
   def test_style
@@ -120,5 +124,15 @@ class TestChart < Test::Unit::TestCase
     @chart.display_blanks_as = :span
     doc = Nokogiri::XML(@chart.to_xml_string)
     assert_equal("span", doc.xpath("//c:dispBlanksAs").attr("val").value, "did not use the display_blanks_as configuration")
+  end
+
+  def test_to_xml_string_for_title
+    @chart.title = "foobar"
+    doc = Nokogiri::XML(@chart.to_xml_string)
+    assert_equal("foobar", doc.xpath("//c:title//c:tx//a:t").text)
+
+    @chart.title = ""
+    doc = Nokogiri::XML(@chart.to_xml_string)
+    assert_equal(0, doc.xpath("//c:title").size)
   end
 end

--- a/test/drawing/tc_title.rb
+++ b/test/drawing/tc_title.rb
@@ -47,8 +47,18 @@ class TestTitle < Test::Unit::TestCase
   def test_to_xml_string_cell
     @chart.title.cell = @row.cells.first
     doc = Nokogiri::XML(@chart.to_xml_string)
+    assert_equal("'Sheet1'!$A$1:$A$1", doc.xpath('//c:strRef/c:f').text)
     assert_equal(1, doc.xpath('//c:strCache').size)
-    assert_equal(1, doc.xpath('//c:v[text()="one"]').size)
+    assert_equal('one', doc.xpath('//c:strCache/c:pt//c:v').text)
+  end
+
+  def test_to_xml_string_empty_cell
+    @row.cells.first.value = ""
+    @chart.title.cell = @row.cells.first
+    doc = Nokogiri::XML(@chart.to_xml_string)
+    assert_equal("'Sheet1'!$A$1:$A$1", doc.xpath('//c:strRef/c:f').text)
+    assert_equal(1, doc.xpath('//c:strCache').size)
+    assert_equal('', doc.xpath('//c:strCache/c:pt//c:v').text)
   end
 
   def test_to_xml_string_for_special_characters


### PR DESCRIPTION
Before this change, a chart with a empty title would show up in Excel with a default title like “Chart title” or “Diagrammtitel”.

It was not possible to completely hide a chart title: Setting it for example to a string consisting of a single space would override Excel’s default, but the empty title did still occupy vertical space.

Per OOXML standard the `title` element is optional, so omitting it if the title is blank looks like the right thing to do and seems to work correctly in Excel:

<img width="1039" alt="grafik" src="https://user-images.githubusercontent.com/244158/168486938-2764e41a-cc43-430f-9d57-87f5d03f072b.png">

A note about __`autoTitleDeleted`__: The standard says _“This element specifies the title shall not be shown for this chart.”_ – and so I first tried to fix this issue by changing `Chart#to_xml_string` to render this element as `true` if the title is blank (right now the element is always `false` because `@title` can never be nil): https://github.com/caxlsx/caxlsx/blob/39ae1467c0345ac619caa5af5e6727372d30b217/lib/axlsx/drawing/chart.rb#L193

However this didn’t work out in MS Excel: The chart still showed Excel’s default title string. Digging further revealed that Microsoft even states this as one of their deviations from the standard: 

> In Office, this element only applies if a title element ("[ISO/IEC-29500-1] §21.2.2.210; title") is not present on the parent chart element ("[ISO/IEC-29500-1] §21.2.2.27; chart").

In the end I decided to leave the (arguably broken) code for generating this element untouched to not introduce any backward-incompatible changes.