### PR TITLE
Implement “plot visible only” setting for charts

### DIFF
--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -14,6 +14,7 @@ module Axlsx
     # @option options [Symbol] legend_position
     # @option options [Array|String|Cell] start_at The X, Y coordinates defining the top left corner of the chart.
     # @option options [Array|String|Cell] end_at The X, Y coordinates defining the bottom right corner of the chart.
+    # @option options [Boolean] plot_visible_only (true) Whether only data from visible cells should be plotted.
     def initialize(frame, options={})
       @style = 18
       @view_3D = nil
@@ -26,6 +27,7 @@ module Axlsx
       @series_type = Series
       @title = Title.new
       @bg_color = nil
+      @plot_visible_only = true
       parse_options options
       start_at(*options[:start_at]) if options[:start_at]
       end_at(*options[:end_at]) if options[:end_at]
@@ -97,6 +99,10 @@ module Axlsx
     # Background color for the chart
     # @return [String]
     attr_reader :bg_color
+
+    # Whether only data from visible cells should be plotted.
+    # @return [Boolean]
+    attr_reader :plot_visible_only
 
     # The relationship object for this chart.
     # @return [Relationship]
@@ -180,6 +186,11 @@ module Axlsx
       @bg_color = v
     end
 
+    # Whether only data from visible cells should be plotted.
+    # @param [Boolean] v
+    # @return [Boolean]
+    def plot_visible_only=(v) Axlsx::validate_boolean(v); @plot_visible_only = v; end
+
     # Serializes the object
     # @param [String] str
     # @return [String]
@@ -206,7 +217,7 @@ module Axlsx
         str << '<c:overlay val="0"/>'
         str << '</c:legend>'
       end
-      str << '<c:plotVisOnly val="1"/>'
+      str << ('<c:plotVisOnly val="' << @plot_visible_only.to_s << '"/>')
       str << ('<c:dispBlanksAs val="' << display_blanks_as.to_s << '"/>')
       str << '<c:showDLblsOverMax val="1"/>'
       str << '</c:chart>'

--- a/test/drawing/tc_chart.rb
+++ b/test/drawing/tc_chart.rb
@@ -107,10 +107,17 @@ class TestChart < Test::Unit::TestCase
   end
 
   def test_d_lbls
-    
+
     assert_equal(nil, Axlsx.instance_values_for(@chart)[:d_lbls])
     @chart.d_lbls.d_lbl_pos = :t
     assert(@chart.d_lbls.is_a?(Axlsx::DLbls), 'DLbls instantiated on access')
+  end
+
+  def test_plot_visible_only
+    assert(@chart.plot_visible_only, "default should be true")
+    @chart.plot_visible_only = false
+    assert_false(@chart.plot_visible_only)
+    assert_raise(ArgumentError) { @chart.plot_visible_only = "" }
   end
 
   def test_to_xml_string
@@ -134,5 +141,11 @@ class TestChart < Test::Unit::TestCase
     @chart.title = ""
     doc = Nokogiri::XML(@chart.to_xml_string)
     assert_equal(0, doc.xpath("//c:title").size)
+  end
+
+  def test_to_xml_string_for_plot_visible_only
+    assert_equal("true", Nokogiri::XML(@chart.to_xml_string).xpath("//c:plotVisOnly").attr("val").value)
+    @chart.plot_visible_only = false
+    assert_equal("false", Nokogiri::XML(@chart.to_xml_string).xpath("//c:plotVisOnly").attr("val").value)
   end
 end


### PR DESCRIPTION
Until now this setting was hardcoded to `true`.

The setting affects whether data from hidden cells (cells with zero height or width) is used when plotting the chart.

Should be a straight forward change.