### PR TITLE
Prevent Excel from crashing when multiple data columns added to PivotTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 ---------
 
 - **Unreleased**
+  - [PR #156](https://github.com/caxlsx/caxlsx/pull/156) - Prevent Excel from crashing when multiple data columns added to PivotTable
   - [PR #155](https://github.com/caxlsx/caxlsx/pull/155) - Add `hideDropDown` alias for `showDropDown` setting, as the latter is confusing to use (because its logic seems inverted).
   - [PR #143](https://github.com/caxlsx/caxlsx/pull/143) - Add setting `sort_on_headers` for pivot tables
   - [PR #132](https://github.com/caxlsx/caxlsx/pull/132) - Remove monkey patch from Object#instance_values

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -217,8 +217,18 @@ module Axlsx
         end
         str << '</rowItems>'
       end
-      if columns.empty? && data.size <= 1
-        str << '<colItems count="1"><i/></colItems>'
+      if columns.empty?
+        if data.size > 1
+          str << '<colFields count="1"><field x="-2"/></colFields>'
+          str << "<colItems count=\"#{data.size}\">"
+          str << '<i><x/></i>'
+          data[1..-1].each_with_index do |datum_value,i|
+            str << "<i i=\"#{i + 1}\"><x v=\"#{i + 1}\"/></i>"
+          end
+          str << '</colItems>'
+        else
+          str << '<colItems count="1"><i/></colItems>'
+        end
       else
         str << ('<colFields count="' << columns.size.to_s << '">')
         columns.each do |column_value|

--- a/test/workbook/worksheet/tc_pivot_table.rb
+++ b/test/workbook/worksheet/tc_pivot_table.rb
@@ -162,15 +162,27 @@ class TestPivotTable < Test::Unit::TestCase
       pt.data = [
         {ref: "Gross amount", num_fmt: 2},
         {ref: "Net amount", num_fmt: 2},
+        {ref: "Margin", num_fmt: 2},
       ]
     end
 
     xml = pivot_table.to_xml_string
 
-    assert(xml.include?('colFields'))
-
     assert(!xml.include?('dataOnRows'))
-    assert(!xml.include?('colItems'))
+    assert(xml.include?('colFields'))
+    assert(xml.include?('colItems'))
+
+    doc = Nokogiri::XML(pivot_table.to_xml_string)
+
+    assert_equal('1', doc.at_css('colFields')['count'])
+    assert_equal('-2', doc.at_css('colFields field')['x'])
+
+    assert_equal('3', doc.at_css('colItems')['count'])
+    assert_equal( 3, doc.at_css('colItems').children.size)
+    assert_nil( doc.at_css('colItems i')['x'])
+    assert_equal('1', doc.at_css('colItems i[i=1] x')['v'])
+    assert_equal('2', doc.at_css('colItems i[i=2] x')['v'])
+
   end
 
   def test_pivot_table_with_only_one_data_row


### PR DESCRIPTION

Excel will crash unless both `colFields` and `colItems` are declared in the PivotTable xml.

First `field` of `colFields` needs to be set to -2 to tell Excel that the value columns comes from individual columns (data) and not groups (columns).
I do not know why `colItems` are needed, but when set, the Excel document opens without crashing.

Related to:
https://github.com/caxlsx/caxlsx/issues/110

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).