### PR TITLE
Move worksheet name forbidden chars to a constant

### DIFF
--- a/lib/axlsx/util/constants.rb
+++ b/lib/axlsx/util/constants.rb
@@ -278,7 +278,7 @@ module Axlsx
   WORKSHEET_MAX_NAME_LENGTH = 31
 
   # worksheet name forbidden characters
-  WORKSHEET_NAME_FORBIDDEN_CHARS = '[]*/\?:'.freeze
+  WORKSHEET_NAME_FORBIDDEN_CHARS = '[]*/\?:'.chars.freeze
 
   # error messages RestrictionValidor
   ERR_RESTRICTION = "Invalid Data: %s. %s must be one of %s.".freeze

--- a/lib/axlsx/util/constants.rb
+++ b/lib/axlsx/util/constants.rb
@@ -277,6 +277,9 @@ module Axlsx
   # worksheet maximum name length
   WORKSHEET_MAX_NAME_LENGTH = 31
 
+  # worksheet name forbidden characters
+  WORKSHEET_NAME_FORBIDDEN_CHARS = '[]*/\?:'.freeze
+
   # error messages RestrictionValidor
   ERR_RESTRICTION = "Invalid Data: %s. %s must be one of %s.".freeze
 

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -686,7 +686,7 @@ module Axlsx
       raise ArgumentError, (ERR_SHEET_NAME_EMPTY) if name.empty?
       character_length = name.encode("utf-16")[1..-1].encode("utf-16").bytesize / 2
       raise ArgumentError, (ERR_SHEET_NAME_TOO_LONG % name) if character_length > WORKSHEET_MAX_NAME_LENGTH
-      raise ArgumentError, (ERR_SHEET_NAME_CHARACTER_FORBIDDEN % name) if WORKSHEET_NAME_FORBIDDEN_CHARS.chars.any? { |char| name.include? char }
+      raise ArgumentError, (ERR_SHEET_NAME_CHARACTER_FORBIDDEN % name) if WORKSHEET_NAME_FORBIDDEN_CHARS.any? { |char| name.include? char }
       name = Axlsx::coder.encode(name)
       sheet_names = @workbook.worksheets.reject { |s| s == self }.map { |s| s.name }
       raise ArgumentError, (ERR_DUPLICATE_SHEET_NAME % name) if sheet_names.include?(name)

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -686,7 +686,7 @@ module Axlsx
       raise ArgumentError, (ERR_SHEET_NAME_EMPTY) if name.empty?
       character_length = name.encode("utf-16")[1..-1].encode("utf-16").bytesize / 2
       raise ArgumentError, (ERR_SHEET_NAME_TOO_LONG % name) if character_length > WORKSHEET_MAX_NAME_LENGTH
-      raise ArgumentError, (ERR_SHEET_NAME_CHARACTER_FORBIDDEN % name) if '[]*/\?:'.chars.any? { |char| name.include? char }
+      raise ArgumentError, (ERR_SHEET_NAME_CHARACTER_FORBIDDEN % name) if WORKSHEET_NAME_FORBIDDEN_CHARS.chars.any? { |char| name.include? char }
       name = Axlsx::coder.encode(name)
       sheet_names = @workbook.worksheets.reject { |s| s == self }.map { |s| s.name }
       raise ArgumentError, (ERR_DUPLICATE_SHEET_NAME % name) if sheet_names.include?(name)


### PR DESCRIPTION
### Description
Moves forbidden chars to a constant for easier usage in external helpers (e.g: name sanitization)

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).