### PR TITLE
Fix bug in BorderCreator when second arg is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 ---------
 - **Unreleased**
+  - Fix bug when calling `worksheet.add_border("A1:B2", nil)`
+  - Change `BorderCreator#initialize` arguments handling
+  - Fix `add_border` to work with singluar cell refs
 
 - **October.21.22**: 3.3.0
   - [PR #168](https://github.com/caxlsx/caxlsx/pull/168) - Merge in the gem [`axlsx_styler`](https://github.com/axlsx-styler-gem/axlsx_styler)

--- a/examples/add_border_example.md
+++ b/examples/add_border_example.md
@@ -18,6 +18,13 @@ wb.add_worksheet do |sheet|
   sheet.add_border "B2:D5"
   sheet.add_border "B3:D3", { edges: [:top], style: :thick }
   sheet.add_border ["C3:C4", "D3:D4"]
+
+  #sheet.add_border "E1"
+  #sheet.add_border "E1:E5", [:top, :bottom, :left, :right]
+  #sheet.add_border "E1:E5", :all
+  #sheet.add_border "E1:E5", Axlsx::Border::EDGES
+  #sheet.add_border "E1:E5", {edges: :all, style: :thick}
+  #sheet.add_border "E1:E5", {edges: [:top], style: :thick, color: "FFFFF00"}
 end
 
 p.serialize "add_border.xlsx"

--- a/lib/axlsx/stylesheet/styles.rb
+++ b/lib/axlsx/stylesheet/styles.rb
@@ -231,8 +231,12 @@ module Axlsx
 
       raise ArgumentError, "Type must be one of [:xf, :dxf]" unless [:xf, :dxf].include?(options[:type] )
 
-      if options[:border].is_a?(Hash) && options[:border][:edges] == :all
-        options[:border][:edges] = Axlsx::Border::EDGES
+      if options[:border].is_a?(Hash)
+        if options[:border][:edges] == :all
+          options[:border][:edges] = Axlsx::Border::EDGES
+        elsif options[:border][:edges]
+          options[:border][:edges] = options[:border][:edges].map(&:to_sym) ### normalize for style caching
+        end
       end
 
       if options[:type] == :xf

--- a/lib/axlsx/workbook/worksheet/border_creator.rb
+++ b/lib/axlsx/workbook/worksheet/border_creator.rb
@@ -4,7 +4,7 @@ module Axlsx
   class BorderCreator
     attr_reader :worksheet, :cells, :edges, :width, :color
 
-    def initialize(worksheet, cells, args)
+    def initialize(worksheet, cells, args=nil)
       @worksheet = worksheet
       @cells     = cells
       if args.is_a?(Hash)
@@ -12,7 +12,7 @@ module Axlsx
         @width = args[:style] || :thin
         @color = args[:color] || '000000'
       else
-        @edges = args || Axlsx::Border::Edges
+        @edges = args || Axlsx::Border::EDGES
         @width = :thin
         @color = '000000'
       end

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -587,14 +587,25 @@ module Axlsx
     # Set the style for cells in a specific column
     # @param [String|Array] cell references
     # @param [Hash|Array|Symbol] border options
-    def add_border(cell_refs, options = Axlsx::Border::EDGES)
+    def add_border(cell_refs, options=nil)
+      if options.is_a?(Hash)
+        border_edges = options[:edges]
+        border_style = options[:style]
+        border_color = options[:color]
+      else
+        border_edges = options
+      end
+
       if !cell_refs.is_a?(Array)
         cell_refs = [cell_refs]
       end
 
       cell_refs.each do |cell_ref|
-        cells = self[cell_ref]
-        Axlsx::BorderCreator.new(self, cells, options).draw
+        item = self[cell_ref]
+
+        cells = item.is_a?(Array) ? item : [item]
+
+        Axlsx::BorderCreator.new(worksheet: self, cells: cells, edges: border_edges, style: border_style, color: border_color).draw
       end
     end
 

--- a/test/workbook/worksheet/tc_border_creator.rb
+++ b/test/workbook/worksheet/tc_border_creator.rb
@@ -7,45 +7,43 @@ class TestBorderCreator < Test::Unit::TestCase
     @ws = @wb.add_worksheet
   end
 
-  def test_defaults
-    3.times do
-      @ws.add_row [1,2,3]
+  def test_initialize
+    @ws.add_row [1,2,3]
+
+    bc = Axlsx::BorderCreator.new(worksheet: @ws, cells: @ws["A1:B1"])
+    assert_equal bc.instance_variable_get(:@edges), Axlsx::Border::EDGES
+    assert_equal bc.instance_variable_get(:@style), :thin
+    assert_equal bc.instance_variable_get(:@color), "000000"
+
+    bc = Axlsx::BorderCreator.new(worksheet: @ws, cells: @ws["A1:B1"], edges: [:top], style: :thick, color: "ffffff")
+    assert_equal bc.instance_variable_get(:@edges), [:top]
+    assert_equal bc.instance_variable_get(:@style), :thick
+    assert_equal bc.instance_variable_get(:@color), "ffffff"
+  end
+
+  def test_initialize_edges
+    @ws.add_row [1,2,3]
+
+    bc = Axlsx::BorderCreator.new(worksheet: @ws, cells: @ws["A1:B1"], edges: nil)
+    assert_equal bc.instance_variable_get(:@edges), Axlsx::Border::EDGES
+
+    bc = Axlsx::BorderCreator.new(worksheet: @ws, cells: @ws["A1:B1"], edges: :all)
+    assert_equal bc.instance_variable_get(:@edges), Axlsx::Border::EDGES
+
+    bc = Axlsx::BorderCreator.new(worksheet: @ws, cells: @ws["A1:B1"], edges: [])
+    assert_equal bc.instance_variable_get(:@edges), []
+
+    assert_raises(ArgumentError) do
+      bc = Axlsx::BorderCreator.new(worksheet: @ws, cells: @ws["A1:B1"], edges: [:foo])
     end
 
-    bc = Axlsx::BorderCreator.new(@ws, @ws["A1:B2"], {})
-    assert_equal bc.instance_variable_get(:@edges), Axlsx::Border::EDGES
-    assert_equal bc.instance_variable_get(:@width), :thin
-    assert_equal bc.instance_variable_get(:@color), "000000"
+    assert_raises(ArgumentError) do
+      bc = Axlsx::BorderCreator.new(worksheet: @ws, cells: @ws["A1:B1"], edges: :foo)
+    end
 
-    bc = Axlsx::BorderCreator.new(@ws, @ws["A1:B2"], ["top"])
-    assert_equal bc.instance_variable_get(:@edges), [:top]
-    assert_equal bc.instance_variable_get(:@width), :thin
-    assert_equal bc.instance_variable_get(:@color), "000000"
-
-    bc = Axlsx::BorderCreator.new(@ws, @ws["A1:B2"], :all)
-    assert_equal bc.instance_variable_get(:@edges), Axlsx::Border::EDGES
-    assert_equal bc.instance_variable_get(:@width), :thin
-    assert_equal bc.instance_variable_get(:@color), "000000"
-
-    bc = Axlsx::BorderCreator.new(@ws, @ws["A1:B2"], [:foo])
-    assert_equal bc.instance_variable_get(:@edges), []
-    assert_equal bc.instance_variable_get(:@width), :thin
-    assert_equal bc.instance_variable_get(:@color), "000000"
-
-    bc = Axlsx::BorderCreator.new(@ws, @ws["A1:B2"], {edges: ["top"], style: :thick, color: "ffffff"})
-    assert_equal bc.instance_variable_get(:@edges), [:top]
-    assert_equal bc.instance_variable_get(:@width), :thick
-    assert_equal bc.instance_variable_get(:@color), "ffffff"
-
-    bc = Axlsx::BorderCreator.new(@ws, @ws["A1:B2"], nil)
-    assert_equal bc.instance_variable_get(:@edges), Axlsx::Border::EDGES
-    assert_equal bc.instance_variable_get(:@width), :thin
-    assert_equal bc.instance_variable_get(:@color), "000000"
-
-    bc = Axlsx::BorderCreator.new(@ws, @ws["A1:B2"])
-    assert_equal bc.instance_variable_get(:@edges), Axlsx::Border::EDGES
-    assert_equal bc.instance_variable_get(:@width), :thin
-    assert_equal bc.instance_variable_get(:@color), "000000"
+    assert_raises(ArgumentError) do
+      bc = Axlsx::BorderCreator.new(worksheet: @ws, cells: @ws["A1:B1"], edges: [nil])
+    end
   end
 
   def test_draw
@@ -53,7 +51,7 @@ class TestBorderCreator < Test::Unit::TestCase
       @ws.add_row [1,2,3,4,5]
     end
 
-    bc = Axlsx::BorderCreator.new(@ws, @ws["A1:C3"], {edges: ["top", :left], style: :thick, color: "ffffff"})
+    bc = Axlsx::BorderCreator.new(worksheet: @ws, cells: @ws["A1:C3"], edges: ["top", :left], style: :thick, color: "ffffff")
 
     bc.draw
 

--- a/test/workbook/worksheet/tc_border_creator.rb
+++ b/test/workbook/worksheet/tc_border_creator.rb
@@ -36,6 +36,16 @@ class TestBorderCreator < Test::Unit::TestCase
     assert_equal bc.instance_variable_get(:@edges), [:top]
     assert_equal bc.instance_variable_get(:@width), :thick
     assert_equal bc.instance_variable_get(:@color), "ffffff"
+
+    bc = Axlsx::BorderCreator.new(@ws, @ws["A1:B2"], nil)
+    assert_equal bc.instance_variable_get(:@edges), Axlsx::Border::EDGES
+    assert_equal bc.instance_variable_get(:@width), :thin
+    assert_equal bc.instance_variable_get(:@color), "000000"
+
+    bc = Axlsx::BorderCreator.new(@ws, @ws["A1:B2"])
+    assert_equal bc.instance_variable_get(:@edges), Axlsx::Border::EDGES
+    assert_equal bc.instance_variable_get(:@width), :thin
+    assert_equal bc.instance_variable_get(:@color), "000000"
   end
 
   def test_draw

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -716,6 +716,30 @@ class TestWorksheet < Test::Unit::TestCase
     assert_equal 12 + 2, wb.styles.style_index.keys.max
   end
 
+  def test_add_border_arguments
+    p = Axlsx::Package.new
+    wb = p.workbook
+
+    wb.add_worksheet do |sheet|
+      20.times.each do
+        sheet.add_row [1,2,3,4,5]
+      end
+
+      sheet.add_border "B2:D5"
+      sheet.add_border ["C3:C4", "D3:D4", "A2"], {color: "FF00000"}
+      sheet.add_border "B10:E10", [:top, :bottom, :left, :right]
+      sheet.add_border "B12:E12", :all
+      sheet.add_border "B14:E14", Axlsx::Border::EDGES
+      sheet.add_border "B16:E16", {edges: :all, style: :thick}
+      sheet.add_border "B18:E18", {edges: [:top], style: :thick, color: "FFFFF00"}
+    end
+
+    wb.apply_styles
+
+    assert_equal true, wb.styles_applied
+    assert_equal 17, wb.styles.style_index.count
+  end
+
   def test_duplicate_borders
     p = Axlsx::Package.new
     wb = p.workbook


### PR DESCRIPTION
### Description

- Fix bug when calling `worksheet.add_border("A1:B2", nil)`

```
NameError: uninitialized constant Axlsx::Border::Edges
Did you mean?  Axlsx::Border::EDGES
    caxlsx (3.3.0) lib/axlsx/workbook/worksheet/border_creator.rb:15:in `initialize'
```

- Change `BorderCreator#initialize` arguments handling
- Fix `add_border` to work with singluar cell refs


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).