### PR TITLE
Do not close stale PRs and issues automatically [ci skip]

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,16 +14,14 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 90
-        days-before-close: 7
+        days-before-close: -1
         stale-issue-message: >
-          This issue has been automatically marked as stale because it has not been commented on for at least three months. 
-          It will be automatically closed in 7 days.
-          
-          If you have any new information or updates please reply in order to keep the issue open. 
+          This issue has been automatically marked as stale because it has not been commented on for at least three months.
+
+          If you have any new information or updates please reply in order to keep the issue open.
         stale-pr-message: >
-          This pull request has been automatically marked as stale because has been no activity for at least three months. 
-          It will be automatically closed in 7 days.
-          
-          If you have any new information or updates please reply in order to keep the pull request open. 
+          This pull request has been automatically marked as stale because has been no activity for at least three months.
+
+          If you have any new information or updates please reply in order to keep the pull request open.
         stale-issue-label: stale
         stale-pr-label: stale


### PR DESCRIPTION
### Description

We talked about not closing stale PRs and issues on Slack as this might discourage peaople trying to contribute.

Docs about the changed config: https://github.com/actions/stale#days-before-close

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).