### PR TITLE
Caxlsx 4.0: Escape formulas by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 ---------
-- **Unreleased**
+- **Unreleased**: 4.0.0
+  - [PR #189](https://github.com/caxlsx/caxlsx/pull/189) - Make `Axlsx::escape_formulas` true by default to mitigate [Formula Injection](https://www.owasp.org/index.php/CSV_Injection) vulnerabilities.
+
+- **Unreleased**: 3.4.0
   - [PR #186](https://github.com/caxlsx/caxlsx/pull/186) - Add `escape_formulas` to global, workbook, worksheet, row and cell levels, and standardize behavior.
   - [PR #186](https://github.com/caxlsx/caxlsx/pull/186) - `escape_formulas` should handle all [OWASP-designated formula prefixes](https://owasp.org/www-community/attacks/CSV_Injection).
   - Fix bug when calling `worksheet.add_border("A1:B2", nil)`

--- a/README.md
+++ b/README.md
@@ -121,23 +121,19 @@ Currently the following additional gems are available:
 
 ## Security
 
-To prevent [Formula Injection](https://www.owasp.org/index.php/CSV_Injection) vulnerabilities, set the following in an initializer:
+To prevent [Formula Injection](https://www.owasp.org/index.php/CSV_Injection) vulnerabilities, as of version 4.0, axlsx escapes all formulas by default. To permit formulas on a specific cell, please use:
 
 ```ruby
-Axlsx.escape_formulas = true
+cell.escape_formulas = false
 ```
 
-Then, set the following on each cell you'd like to add a formula:
+You may set `escape_formulas` on the workbook, worksheet, row and/or cell level. Refer to examples/escape_formula.md for details.
+
+To allow formulas globally by default (which was the behavior in axlsx 3.x and prior), you may set the following in an initializer:
 
 ```ruby
-cell.escape_formulas = true
+Axlsx.escape_formulas = false
 ```
-
-Refer to examples/escape_formula.md for how to set `escape_formulas` on the workbook, worksheet, row and/or cell level.
-
-**Important:** The global setting `Axlsx.escape_formulas = true` will become the default in the next major release (Axlsx 4.0).
-If you do not wish to set `Axlsx.escape_formulas = true` now, at a minimum, please set `Axlsx.escape_formulas = false` to
-ensure continuity when upgrading.
 
 ## Known Software Interoperability Issues
 

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -206,7 +206,7 @@ module Axlsx
   # See https://www.owasp.org/index.php/CSV_Injection for details.
   # @return [Boolean]
   def self.escape_formulas
-    @escape_formulas.nil? ? false : @escape_formulas
+    @escape_formulas.nil? ? true : @escape_formulas
   end
 
   # Sets whether to treat values starting with an equals sign as formulas or as literal strings.

--- a/lib/axlsx/version.rb
+++ b/lib/axlsx/version.rb
@@ -1,4 +1,4 @@
 module Axlsx
   # The current version
-  VERSION = "3.3.0"
+  VERSION = "4.0.0"
 end

--- a/test/tc_axlsx.rb
+++ b/test/tc_axlsx.rb
@@ -142,7 +142,7 @@ class TestAxlsx < Test::Unit::TestCase
 
   def test_escape_formulas
     Axlsx.instance_variable_set(:@escape_formulas, nil)
-    assert_equal false, Axlsx::escape_formulas
+    assert_equal true, Axlsx::escape_formulas
 
     Axlsx::escape_formulas = true
     assert_equal true, Axlsx::escape_formulas

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -376,7 +376,7 @@ class TestCell < Test::Unit::TestCase
 
   def test_to_xml_string_formula
     p = Axlsx::Package.new
-    ws = p.workbook.add_worksheet do |sheet|
+    ws = p.workbook.add_worksheet(escape_formulas: false) do |sheet|
       sheet.add_row ["=IF(2+2=4,4,5)"]
     end
     doc = Nokogiri::XML(ws.to_xml_string)

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -444,7 +444,7 @@ class TestCell < Test::Unit::TestCase
 
   def test_to_xml_string_array_formula
     p = Axlsx::Package.new
-    ws = p.workbook.add_worksheet do |sheet|
+    ws = p.workbook.add_worksheet(escape_formulas: false) do |sheet|
       sheet.add_row ["{=SUM(C2:C11*D2:D11)}"]
     end
     doc = Nokogiri::XML(ws.to_xml_string)


### PR DESCRIPTION
This is a follow-up to https://github.com/caxlsx/caxlsx/pull/186.

It its the follow-up fix to https://github.com/caxlsx/caxlsx/issues/174 which sets the global default of `escape_formulas` to true.

It should be released as version 4.0.