### PR TITLE
Use File.read instead of IO.read

### DIFF
--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -187,7 +187,7 @@ module Axlsx
         end
         unless part[:path].nil?
           zip.put_next_entry(zip_entry_for_part(part))
-          zip.write IO.read(part[:path], mode: "rb")
+          zip.write File.read(part[:path], mode: "rb")
         end
       end
       zip


### PR DESCRIPTION
If argument starts with a pipe character (`'|'`) and the receiver is the `IO` class, a subprocess is created in the same way as `Kernel#open`, and its output is returned. `Kernel#open` may allow unintentional command injection, which is the reason these `IO` methods are a security risk. Consider to use `File.read` to disable the behavior of subprocess invocation.

Close #193

Ref: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Security/IoMethods

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).