### PR TITLE
Fix Layout/HeredocIndentation offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,12 +23,6 @@ Layout/HashAlignment:
     - 'test/tc_axlsx.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
-Layout/HeredocIndentation:
-  Exclude:
-    - 'lib/axlsx/drawing/vml_drawing.rb'
-    - 'lib/axlsx/drawing/vml_shape.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 Lint/AmbiguousOperatorPrecedence:
   Exclude:
     - 'lib/axlsx/drawing/area_series.rb'

--- a/lib/axlsx/drawing/vml_drawing.rb
+++ b/lib/axlsx/drawing/vml_drawing.rb
@@ -19,19 +19,19 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << <<BAD_PROGRAMMER
-<xml xmlns:v="urn:schemas-microsoft-com:vml"
- xmlns:o="urn:schemas-microsoft-com:office:office"
- xmlns:x="urn:schemas-microsoft-com:office:excel">
- <o:shapelayout v:ext="edit">
-  <o:idmap v:ext="edit" data="#{@comments.worksheet.index + 1}"/>
- </o:shapelayout>
- <v:shapetype id="_x0000_t202" coordsize="21600,21600" o:spt="202"
-  path="m0,0l0,21600,21600,21600,21600,0xe">
-  <v:stroke joinstyle="miter"/>
-  <v:path gradientshapeok="t" o:connecttype="rect"/>
- </v:shapetype>
-BAD_PROGRAMMER
+      str << <<~XML
+        <xml xmlns:v="urn:schemas-microsoft-com:vml"
+         xmlns:o="urn:schemas-microsoft-com:office:office"
+         xmlns:x="urn:schemas-microsoft-com:office:excel">
+         <o:shapelayout v:ext="edit">
+          <o:idmap v:ext="edit" data="#{@comments.worksheet.index + 1}"/>
+         </o:shapelayout>
+         <v:shapetype id="_x0000_t202" coordsize="21600,21600" o:spt="202"
+          path="m0,0l0,21600,21600,21600,21600,0xe">
+          <v:stroke joinstyle="miter"/>
+          <v:path gradientshapeok="t" o:connecttype="rect"/>
+         </v:shapetype>
+      XML
       @comments.each { |comment| comment.vml_shape.to_xml_string str }
       str << "</xml>"
     end

--- a/lib/axlsx/drawing/vml_shape.rb
+++ b/lib/axlsx/drawing/vml_shape.rb
@@ -36,28 +36,28 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << <<SHAME_ON_YOU
+      str << <<~XML
 
-<v:shape id="#{@id}" type="#_x0000_t202" fillcolor="#ffffa1 [80]" o:insetmode="auto"
-  style="visibility:#{@visible ? 'visible' : 'hidden'}">
-  <v:fill color2="#ffffa1 [80]"/>
-  <v:shadow on="t" obscured="t"/>
-  <v:path o:connecttype="none"/>
-  <v:textbox style='mso-fit-text-with-word-wrap:t'>
-   <div style='text-align:left'></div>
-  </v:textbox>
+        <v:shape id="#{@id}" type="#_x0000_t202" fillcolor="#ffffa1 [80]" o:insetmode="auto"
+          style="visibility:#{@visible ? 'visible' : 'hidden'}">
+          <v:fill color2="#ffffa1 [80]"/>
+          <v:shadow on="t" obscured="t"/>
+          <v:path o:connecttype="none"/>
+          <v:textbox style='mso-fit-text-with-word-wrap:t'>
+           <div style='text-align:left'></div>
+          </v:textbox>
 
-  <x:ClientData ObjectType="Note">
-   <x:MoveWithCells/>
-   <x:SizeWithCells/>
-   <x:Anchor>#{left_column}, #{left_offset}, #{top_row}, #{top_offset}, #{right_column}, #{right_offset}, #{bottom_row}, #{bottom_offset}</x:Anchor>
-   <x:AutoFill>False</x:AutoFill>
-   <x:Row>#{row}</x:Row>
-   <x:Column>#{column}</x:Column>
-   #{@visible ? '<x:Visible/>' : ''}
-  </x:ClientData>
- </v:shape>
-SHAME_ON_YOU
+          <x:ClientData ObjectType="Note">
+           <x:MoveWithCells/>
+           <x:SizeWithCells/>
+           <x:Anchor>#{left_column}, #{left_offset}, #{top_row}, #{top_offset}, #{right_column}, #{right_offset}, #{bottom_row}, #{bottom_offset}</x:Anchor>
+           <x:AutoFill>False</x:AutoFill>
+           <x:Row>#{row}</x:Row>
+           <x:Column>#{column}</x:Column>
+           #{@visible ? '<x:Visible/>' : ''}
+          </x:ClientData>
+         </v:shape>
+      XML
     end
   end
 end


### PR DESCRIPTION
Also use `XML` as delimiter to highlight syntax in supported editors

### Description

As usual, please review with whitespaces hidden

<img width="652" alt="image" src="https://user-images.githubusercontent.com/556268/236258540-ca2bfc75-75b1-4793-b5f3-833ebdf56fce.png">

This has also been manually tested with

```rb
      old_s = <<BAD_PROGRAMMER
<xml xmlns:v="urn:schemas-microsoft-com:vml"
 xmlns:o="urn:schemas-microsoft-com:office:office"
 xmlns:x="urn:schemas-microsoft-com:office:excel">
 <o:shapelayout v:ext="edit">
  <o:idmap v:ext="edit" data="#{@comments.worksheet.index + 1}"/>
 </o:shapelayout>
 <v:shapetype id="_x0000_t202" coordsize="21600,21600" o:spt="202"
  path="m0,0l0,21600,21600,21600,21600,0xe">
  <v:stroke joinstyle="miter"/>
  <v:path gradientshapeok="t" o:connecttype="rect"/>
 </v:shapetype>
BAD_PROGRAMMER
      new_s = <<~XML
        <xml xmlns:v="urn:schemas-microsoft-com:vml"
         xmlns:o="urn:schemas-microsoft-com:office:office"
         xmlns:x="urn:schemas-microsoft-com:office:excel">
         <o:shapelayout v:ext="edit">
          <o:idmap v:ext="edit" data="#{@comments.worksheet.index + 1}"/>
         </o:shapelayout>
         <v:shapetype id="_x0000_t202" coordsize="21600,21600" o:spt="202"
          path="m0,0l0,21600,21600,21600,21600,0xe">
          <v:stroke joinstyle="miter"/>
          <v:path gradientshapeok="t" o:connecttype="rect"/>
         </v:shapetype>
      XML

      raise if old_s != new_s
      str << new_s
```

```rb
      old_s = <<SHAME_ON_YOU

<v:shape id="#{@id}" type="#_x0000_t202" fillcolor="#ffffa1 [80]" o:insetmode="auto"
  style="visibility:#{@visible ? 'visible' : 'hidden'}">
  <v:fill color2="#ffffa1 [80]"/>
  <v:shadow on="t" obscured="t"/>
  <v:path o:connecttype="none"/>
  <v:textbox style='mso-fit-text-with-word-wrap:t'>
   <div style='text-align:left'></div>
  </v:textbox>

  <x:ClientData ObjectType="Note">
   <x:MoveWithCells/>
   <x:SizeWithCells/>
   <x:Anchor>#{left_column}, #{left_offset}, #{top_row}, #{top_offset}, #{right_column}, #{right_offset}, #{bottom_row}, #{bottom_offset}</x:Anchor>
   <x:AutoFill>False</x:AutoFill>
   <x:Row>#{row}</x:Row>
   <x:Column>#{column}</x:Column>
   #{@visible ? '<x:Visible/>' : ''}
  </x:ClientData>
 </v:shape>
SHAME_ON_YOU

      new_s = <<~XML

        <v:shape id="#{@id}" type="#_x0000_t202" fillcolor="#ffffa1 [80]" o:insetmode="auto"
          style="visibility:#{@visible ? 'visible' : 'hidden'}">
          <v:fill color2="#ffffa1 [80]"/>
          <v:shadow on="t" obscured="t"/>
          <v:path o:connecttype="none"/>
          <v:textbox style='mso-fit-text-with-word-wrap:t'>
           <div style='text-align:left'></div>
          </v:textbox>

          <x:ClientData ObjectType="Note">
           <x:MoveWithCells/>
           <x:SizeWithCells/>
           <x:Anchor>#{left_column}, #{left_offset}, #{top_row}, #{top_offset}, #{right_column}, #{right_offset}, #{bottom_row}, #{bottom_offset}</x:Anchor>
           <x:AutoFill>False</x:AutoFill>
           <x:Row>#{row}</x:Row>
           <x:Column>#{column}</x:Column>
           #{@visible ? '<x:Visible/>' : ''}
          </x:ClientData>
         </v:shape>
      XML

      raise if new_s != old_s
      str << new_s
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).