### PR TITLE
Pipe directly to output

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -441,7 +441,6 @@ Style/ParenthesesAroundCondition:
     - 'lib/axlsx/stylesheet/font.rb'
     - 'lib/axlsx/util/validators.rb'
     - 'lib/axlsx/workbook/worksheet/cell.rb'
-    - 'lib/axlsx/workbook/worksheet/data_validation.rb'
     - 'lib/axlsx/workbook/worksheet/rich_text_run.rb'
 
 # This cop supports safe autocorrection (--autocorrect).

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -215,7 +215,6 @@ Style/ConditionalAssignment:
     - 'lib/axlsx/stylesheet/styles.rb'
     - 'lib/axlsx/workbook/workbook.rb'
     - 'lib/axlsx/workbook/worksheet/data_bar.rb'
-    - 'lib/axlsx/workbook/worksheet/rich_text_run.rb'
 
 Style/DocumentDynamicEvalDefinition:
   Exclude:
@@ -241,11 +240,6 @@ Style/Documentation:
 Style/ExpandPathArguments:
   Exclude:
     - 'axlsx.gemspec'
-
-# This cop supports safe autocorrection (--autocorrect).
-Style/FileWrite:
-  Exclude:
-    - 'lib/axlsx/util/zip_command.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
@@ -351,17 +345,13 @@ Style/MultipleComparison:
 # SupportedStyles: literals, strict
 Style/MutableConstant:
   Exclude:
-    - 'lib/axlsx/content_type/default.rb'
-    - 'lib/axlsx/content_type/override.rb'
     - 'lib/axlsx/drawing/cat_axis.rb'
     - 'lib/axlsx/drawing/line_3D_chart.rb'
     - 'lib/axlsx/drawing/pic.rb'
     - 'lib/axlsx/drawing/view_3D.rb'
     - 'lib/axlsx/stylesheet/dxf.rb'
-    - 'lib/axlsx/util/constants.rb'
     - 'lib/axlsx/util/simple_typed_list.rb'
     - 'lib/axlsx/util/storage.rb'
-    - 'lib/axlsx/version.rb'
     - 'lib/axlsx/workbook/worksheet/auto_filter/filter_column.rb'
     - 'lib/axlsx/workbook/worksheet/auto_filter/filters.rb'
     - 'lib/axlsx/workbook/worksheet/data_bar.rb'
@@ -648,7 +638,6 @@ Style/SymbolProc:
     - 'lib/axlsx/stylesheet/styles.rb'
     - 'lib/axlsx/workbook/workbook.rb'
     - 'lib/axlsx/workbook/worksheet/cell.rb'
-    - 'lib/axlsx/workbook/worksheet/conditional_formatting.rb'
     - 'lib/axlsx/workbook/worksheet/worksheet.rb'
     - 'lib/axlsx/workbook/worksheet/worksheet_hyperlinks.rb'
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,6 @@ group :test do
 end
 
 group :profile do
-  gem 'ruby-prof', :platforms => :ruby
+  gem 'memory_profiler'
+  gem 'ruby-prof', platforms: :ruby
 end

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -11,6 +11,7 @@ require 'axlsx/util/accessors.rb'
 require 'axlsx/util/serialized_attributes'
 require 'axlsx/util/options_parser'
 require 'axlsx/util/mime_type_utils'
+require 'axlsx/util/buffered_zip_output_stream'
 require 'axlsx/util/zip_command'
 
 require 'axlsx/stylesheet/styles.rb'

--- a/lib/axlsx/content_type/abstract_content_type.rb
+++ b/lib/axlsx/content_type/abstract_content_type.rb
@@ -23,8 +23,11 @@ module Axlsx
 
     # Serialize the contenty type to xml
     def to_xml_string(node_name = '', str = +'')
-      str << "<#{node_name} "
-      Axlsx.instance_values_for(self).each { |key, value| str << Axlsx::camel(key) << '="' << value.to_s << '" ' }
+      str << '<' << node_name << ' '
+      Axlsx.instance_values_for(self).each_with_index do |key_value, index|
+        str << ' ' unless index.zero?
+        str << Axlsx::camel(key_value.first) << '="' << key_value.last.to_s << '"'
+      end
       str << '/>'
     end
   end

--- a/lib/axlsx/content_type/abstract_content_type.rb
+++ b/lib/axlsx/content_type/abstract_content_type.rb
@@ -24,7 +24,7 @@ module Axlsx
     # Serialize the contenty type to xml
     def to_xml_string(node_name = '', str = +'')
       str << "<#{node_name} "
-      str << Axlsx.instance_values_for(self).map { |key, value| Axlsx::camel(key) << '="' << value.to_s << '"' }.join(' ')
+      Axlsx.instance_values_for(self).each { |key, value| str << Axlsx::camel(key) << '="' << value.to_s << '" ' }
       str << '/>'
     end
   end

--- a/lib/axlsx/content_type/content_type.rb
+++ b/lib/axlsx/content_type/content_type.rb
@@ -16,7 +16,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << (+'<Types xmlns="' << XML_NS_T << '">')
+      str << '<Types xmlns="' << XML_NS_T << '">'
       each { |type| type.to_xml_string(str) }
       str << '</Types>'
     end

--- a/lib/axlsx/doc_props/app.rb
+++ b/lib/axlsx/doc_props/app.rb
@@ -221,7 +221,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << (+'<Properties xmlns="' << APP_NS << '" xmlns:vt="' << APP_NS_VT << '">')
+      str << '<Properties xmlns="' << APP_NS << '" xmlns:vt="' << APP_NS_VT << '">'
       Axlsx.instance_values_for(self).each do |key, value|
         node_name = Axlsx.camel(key)
         str << "<#{node_name}>#{value}</#{node_name}>"

--- a/lib/axlsx/doc_props/core.rb
+++ b/lib/axlsx/doc_props/core.rb
@@ -24,11 +24,11 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << (+'<cp:coreProperties xmlns:cp="' << CORE_NS << '" xmlns:dc="' << CORE_NS_DC << '" ')
-      str << (+'xmlns:dcmitype="' << CORE_NS_DCMIT << '" xmlns:dcterms="' << CORE_NS_DCT << '" ')
-      str << (+'xmlns:xsi="' << CORE_NS_XSI << '">')
-      str << (+'<dc:creator>' << self.creator << '</dc:creator>')
-      str << (+'<dcterms:created xsi:type="dcterms:W3CDTF">' << (created || Time.now).strftime('%Y-%m-%dT%H:%M:%S') << 'Z</dcterms:created>')
+      str << '<cp:coreProperties xmlns:cp="' << CORE_NS << '" xmlns:dc="' << CORE_NS_DC << '" '
+      str << 'xmlns:dcmitype="' << CORE_NS_DCMIT << '" xmlns:dcterms="' << CORE_NS_DCT << '" '
+      str << 'xmlns:xsi="' << CORE_NS_XSI << '">'
+      str << '<dc:creator>' << self.creator << '</dc:creator>'
+      str << '<dcterms:created xsi:type="dcterms:W3CDTF">' << (created || Time.now).strftime('%Y-%m-%dT%H:%M:%S') << 'Z</dcterms:created>'
       str << '<cp:revision>0</cp:revision>'
       str << '</cp:coreProperties>'
     end

--- a/lib/axlsx/drawing/area_chart.rb
+++ b/lib/axlsx/drawing/area_chart.rb
@@ -76,14 +76,14 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       super(str) do
-        str << (+"<c:" << node_name << ">")
-        str << (+'<c:grouping val="' << grouping.to_s << '"/>')
-        str << (+'<c:varyColors val="' << vary_colors.to_s << '"/>')
+        str << "<c:" << node_name << ">"
+        str << '<c:grouping val="' << grouping.to_s << '"/>'
+        str << '<c:varyColors val="' << vary_colors.to_s << '"/>'
         @series.each { |ser| ser.to_xml_string(str) }
         @d_lbls.to_xml_string(str) if @d_lbls
         yield if block_given?
         axes.to_xml_string(str, :ids => true)
-        str << (+"</c:" << node_name << ">")
+        str << "</c:" << node_name << ">"
         axes.to_xml_string(str)
       end
     end

--- a/lib/axlsx/drawing/area_series.rb
+++ b/lib/axlsx/drawing/area_series.rb
@@ -75,11 +75,11 @@ module Axlsx
       super(str) do
         if color
           str << '<c:spPr><a:solidFill>'
-          str << (+'<a:srgbClr val="' << color << '"/>')
+          str << '<a:srgbClr val="' << color << '"/>'
           str << '</a:solidFill>'
           str << '<a:ln w="28800">'
           str << '<a:solidFill>'
-          str << (+'<a:srgbClr val="' << color << '"/>')
+          str << '<a:srgbClr val="' << color << '"/>'
           str << '</a:solidFill>'
           str << '</a:ln>'
           str << '<a:round/>'
@@ -94,7 +94,7 @@ module Axlsx
 
         @labels.to_xml_string(str) unless @labels.nil?
         @data.to_xml_string(str) unless @data.nil?
-        str << (+'<c:smooth val="' << ((smooth) ? '1' : '0') << '"/>')
+        str << '<c:smooth val="' << ((smooth) ? '1' : '0') << '"/>'
       end
     end
 

--- a/lib/axlsx/drawing/axes.rb
+++ b/lib/axlsx/drawing/axes.rb
@@ -33,7 +33,7 @@ module Axlsx
       if options[:ids]
         # CatAxis must come first in the XML (for Microsoft Excel at least)
         sorted = axes.sort_by { |name, axis| axis.kind_of?(CatAxis) ? 0 : 1 }
-        sorted.each { |axis| str << (+'<c:axId val="' << axis[1].id.to_s << '"/>') }
+        sorted.each { |axis| str << '<c:axId val="' << axis[1].id.to_s << '"/>' }
       else
         axes.each { |axis| axis[1].to_xml_string(str) }
       end

--- a/lib/axlsx/drawing/axis.rb
+++ b/lib/axlsx/drawing/axis.rb
@@ -149,10 +149,10 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = +'')
-      str << (+'<c:axId val="' << @id.to_s << '"/>')
+      str << '<c:axId val="' << @id.to_s << '"/>'
       @scaling.to_xml_string str
-      str << (+'<c:delete val="' << @delete.to_s << '"/>')
-      str << (+'<c:axPos val="' << @ax_pos.to_s << '"/>')
+      str << '<c:delete val="' << @delete.to_s << '"/>'
+      str << '<c:axPos val="' << @ax_pos.to_s << '"/>'
       str << '<c:majorGridlines>'
       # TODO: shape properties need to be extracted into a class
       if gridlines == false
@@ -167,21 +167,21 @@ module Axlsx
       # Need to set sourceLinked to 0 if we're setting a format code on this row
       # otherwise it will never take, as it will always prefer the 'General' formatting
       # of the cells themselves
-      str << (+'<c:numFmt formatCode="' << @format_code << '" sourceLinked="' << (@format_code.eql?('General') ? '1' : '0') << '"/>')
+      str << '<c:numFmt formatCode="' << @format_code << '" sourceLinked="' << (@format_code.eql?('General') ? '1' : '0') << '"/>'
       str << '<c:majorTickMark val="none"/>'
       str << '<c:minorTickMark val="none"/>'
-      str << (+'<c:tickLblPos val="' << @tick_lbl_pos.to_s << '"/>')
+      str << '<c:tickLblPos val="' << @tick_lbl_pos.to_s << '"/>'
       # TODO: this is also being used for series colors
       # time to extract this into a class spPr - Shape Properties
       if @color
         str << '<c:spPr><a:ln><a:solidFill>'
-        str << (+'<a:srgbClr val="' << @color << '"/>')
+        str << '<a:srgbClr val="' << @color << '"/>'
         str << '</a:solidFill></a:ln></c:spPr>'
       end
       # some potential value in implementing this in full. Very detailed!
-      str << (+'<c:txPr><a:bodyPr rot="' << @label_rotation.to_s << '"/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:endParaRPr/></a:p></c:txPr>')
-      str << (+'<c:crossAx val="' << @cross_axis.id.to_s << '"/>')
-      str << (+'<c:crosses val="' << @crosses.to_s << '"/>')
+      str << '<c:txPr><a:bodyPr rot="' << @label_rotation.to_s << '"/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:endParaRPr/></a:p></c:txPr>'
+      str << '<c:crossAx val="' << @cross_axis.id.to_s << '"/>'
+      str << '<c:crosses val="' << @crosses.to_s << '"/>'
     end
   end
 end

--- a/lib/axlsx/drawing/bar_3D_chart.rb
+++ b/lib/axlsx/drawing/bar_3D_chart.rb
@@ -123,14 +123,14 @@ module Axlsx
     def to_xml_string(str = +'')
       super(str) do
         str << '<c:bar3DChart>'
-        str << (+'<c:barDir val="' << bar_dir.to_s << '"/>')
-        str << (+'<c:grouping val="' << grouping.to_s << '"/>')
-        str << (+'<c:varyColors val="' << vary_colors.to_s << '"/>')
+        str << '<c:barDir val="' << bar_dir.to_s << '"/>'
+        str << '<c:grouping val="' << grouping.to_s << '"/>'
+        str << '<c:varyColors val="' << vary_colors.to_s << '"/>'
         @series.each { |ser| ser.to_xml_string(str) }
         @d_lbls.to_xml_string(str) if @d_lbls
-        str << (+'<c:gapWidth val="' << @gap_width.to_s << '"/>') unless @gap_width.nil?
-        str << (+'<c:gapDepth val="' << @gap_depth.to_s << '"/>') unless @gap_depth.nil?
-        str << (+'<c:shape val="' << @shape.to_s << '"/>') unless @shape.nil?
+        str << '<c:gapWidth val="' << @gap_width.to_s << '"/>' unless @gap_width.nil?
+        str << '<c:gapDepth val="' << @gap_depth.to_s << '"/>' unless @gap_depth.nil?
+        str << '<c:shape val="' << @shape.to_s << '"/>' unless @shape.nil?
         axes.to_xml_string(str, :ids => true)
         str << '</c:bar3DChart>'
         axes.to_xml_string(str)

--- a/lib/axlsx/drawing/bar_chart.rb
+++ b/lib/axlsx/drawing/bar_chart.rb
@@ -113,14 +113,14 @@ module Axlsx
     def to_xml_string(str = +'')
       super(str) do
         str << '<c:barChart>'
-        str << (+'<c:barDir val="' << bar_dir.to_s << '"/>')
-        str << (+'<c:grouping val="' << grouping.to_s << '"/>')
-        str << (+'<c:varyColors val="' << vary_colors.to_s << '"/>')
+        str << '<c:barDir val="' << bar_dir.to_s << '"/>'
+        str << '<c:grouping val="' << grouping.to_s << '"/>'
+        str << '<c:varyColors val="' << vary_colors.to_s << '"/>'
         @series.each { |ser| ser.to_xml_string(str) }
         @d_lbls.to_xml_string(str) if @d_lbls
-        str << (+'<c:overlap val="' << @overlap.to_s << '"/>') unless @overlap.nil?
-        str << (+'<c:gapWidth val="' << @gap_width.to_s << '"/>') unless @gap_width.nil?
-        str << (+'<c:shape val="' << @shape.to_s << '"/>') unless @shape.nil?
+        str << '<c:overlap val="' << @overlap.to_s << '"/>' unless @overlap.nil?
+        str << '<c:gapWidth val="' << @gap_width.to_s << '"/>' unless @gap_width.nil?
+        str << '<c:shape val="' << @shape.to_s << '"/>' unless @shape.nil?
         axes.to_xml_string(str, :ids => true)
         str << '</c:barChart>'
         axes.to_xml_string(str)

--- a/lib/axlsx/drawing/bar_series.rb
+++ b/lib/axlsx/drawing/bar_series.rb
@@ -62,15 +62,15 @@ module Axlsx
       super(str) do
         colors.each_with_index do |c, index|
           str << '<c:dPt>'
-          str << (+'<c:idx val="' << index.to_s << '"/>')
+          str << '<c:idx val="' << index.to_s << '"/>'
           str << '<c:spPr><a:solidFill>'
-          str << (+'<a:srgbClr val="' << c << '"/>')
+          str << '<a:srgbClr val="' << c << '"/>'
           str << '</a:solidFill></c:spPr></c:dPt>'
         end
 
         if series_color
           str << '<c:spPr><a:solidFill>'
-          str << (+'<a:srgbClr val="' << series_color << '"/>')
+          str << '<a:srgbClr val="' << series_color << '"/>'
           str << '</a:solidFill>'
           str << '</c:spPr>'
         end
@@ -78,7 +78,7 @@ module Axlsx
         @labels.to_xml_string(str) unless @labels.nil?
         @data.to_xml_string(str) unless @data.nil?
         # this is actually only required for shapes other than box
-        str << (+'<c:shape val="' << shape.to_s << '"></c:shape>')
+        str << '<c:shape val="' << shape.to_s << '"></c:shape>'
       end
     end
 

--- a/lib/axlsx/drawing/bubble_chart.rb
+++ b/lib/axlsx/drawing/bubble_chart.rb
@@ -38,7 +38,7 @@ module Axlsx
     def to_xml_string(str = +'')
       super(str) do
         str << '<c:bubbleChart>'
-        str << (+'<c:varyColors val="' << vary_colors.to_s << '"/>')
+        str << '<c:varyColors val="' << vary_colors.to_s << '"/>'
         @series.each { |ser| ser.to_xml_string(str) }
         d_lbls.to_xml_string(str) if @d_lbls
         axes.to_xml_string(str, :ids => true)

--- a/lib/axlsx/drawing/bubble_series.rb
+++ b/lib/axlsx/drawing/bubble_series.rb
@@ -46,10 +46,10 @@ module Axlsx
         # needs to override the super color here to push in ln/and something else!
         if color
           str << '<c:spPr><a:solidFill>'
-          str << (+'<a:srgbClr val="' << color << '"/>')
+          str << '<a:srgbClr val="' << color << '"/>'
           str << '</a:solidFill>'
           str << '<a:ln><a:solidFill>'
-          str << (+'<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
+          str << '<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>'
           str << '</c:spPr>'
         end
         @xData.to_xml_string(str) unless @xData.nil?

--- a/lib/axlsx/drawing/cat_axis.rb
+++ b/lib/axlsx/drawing/cat_axis.rb
@@ -71,11 +71,11 @@ module Axlsx
     def to_xml_string(str = +'')
       str << '<c:catAx>'
       super(str)
-      str << (+'<c:auto val="' << @auto.to_s << '"/>')
-      str << (+'<c:lblAlgn val="' << @lbl_algn.to_s << '"/>')
-      str << (+'<c:lblOffset val="' << @lbl_offset.to_i.to_s << '"/>')
-      str << (+'<c:tickLblSkip val="' << @tick_lbl_skip.to_s << '"/>')
-      str << (+'<c:tickMarkSkip val="' << @tick_mark_skip.to_s << '"/>')
+      str << '<c:auto val="' << @auto.to_s << '"/>'
+      str << '<c:lblAlgn val="' << @lbl_algn.to_s << '"/>'
+      str << '<c:lblOffset val="' << @lbl_offset.to_i.to_s << '"/>'
+      str << '<c:tickLblSkip val="' << @tick_lbl_skip.to_s << '"/>'
+      str << '<c:tickMarkSkip val="' << @tick_mark_skip.to_s << '"/>'
       str << '</c:catAx>'
     end
   end

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -206,13 +206,13 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << (+'<c:chartSpace xmlns:c="' << XML_NS_C << '" xmlns:a="' << XML_NS_A << '" xmlns:r="' << XML_NS_R << '">')
-      str << (+'<c:date1904 val="' << Axlsx::Workbook.date1904.to_s << '"/>')
-      str << (+'<c:roundedCorners val="' << rounded_corners.to_s << '"/>')
-      str << (+'<c:style val="' << style.to_s << '"/>')
+      str << '<c:chartSpace xmlns:c="' << XML_NS_C << '" xmlns:a="' << XML_NS_A << '" xmlns:r="' << XML_NS_R << '">'
+      str << '<c:date1904 val="' << Axlsx::Workbook.date1904.to_s << '"/>'
+      str << '<c:roundedCorners val="' << rounded_corners.to_s << '"/>'
+      str << '<c:style val="' << style.to_s << '"/>'
       str << '<c:chart>'
       @title.to_xml_string(str) unless @title.empty?
-      str << (+'<c:autoTitleDeleted val="' << @title.nil?.to_s << '"/>')
+      str << '<c:autoTitleDeleted val="' << @title.nil?.to_s << '"/>'
       @view_3D.to_xml_string(str) if @view_3D
       str << '<c:floor><c:thickness val="0"/></c:floor>'
       str << '<c:sideWall><c:thickness val="0"/></c:sideWall>'
@@ -223,13 +223,13 @@ module Axlsx
       str << '</c:plotArea>'
       if @show_legend
         str << '<c:legend>'
-        str << (+'<c:legendPos val="' << @legend_position.to_s << '"/>')
+        str << '<c:legendPos val="' << @legend_position.to_s << '"/>'
         str << '<c:layout/>'
         str << '<c:overlay val="0"/>'
         str << '</c:legend>'
       end
-      str << (+'<c:plotVisOnly val="' << @plot_visible_only.to_s << '"/>')
-      str << (+'<c:dispBlanksAs val="' << display_blanks_as.to_s << '"/>')
+      str << '<c:plotVisOnly val="' << @plot_visible_only.to_s << '"/>'
+      str << '<c:dispBlanksAs val="' << display_blanks_as.to_s << '"/>'
       str << '<c:showDLblsOverMax val="1"/>'
       str << '</c:chart>'
       if bg_color

--- a/lib/axlsx/drawing/drawing.rb
+++ b/lib/axlsx/drawing/drawing.rb
@@ -157,7 +157,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-      str << (+'<xdr:wsDr xmlns:xdr="' << XML_NS_XDR << '" xmlns:a="' << XML_NS_A << '">')
+      str << '<xdr:wsDr xmlns:xdr="' << XML_NS_XDR << '" xmlns:a="' << XML_NS_A << '">'
       anchors.each { |anchor| anchor.to_xml_string(str) }
       str << '</xdr:wsDr>'
     end

--- a/lib/axlsx/drawing/graphic_frame.rb
+++ b/lib/axlsx/drawing/graphic_frame.rb
@@ -35,7 +35,7 @@ module Axlsx
       # macro attribute should be optional!
       str << '<xdr:graphicFrame>'
       str << '<xdr:nvGraphicFramePr>'
-      str << (+'<xdr:cNvPr id="' << @anchor.drawing.index.to_s << '" name="' << 'item_' << @anchor.drawing.index.to_s << '"/>')
+      str << '<xdr:cNvPr id="' << @anchor.drawing.index.to_s << '" name="' << 'item_' << @anchor.drawing.index.to_s << '"/>'
       str << '<xdr:cNvGraphicFramePr/>'
       str << '</xdr:nvGraphicFramePr>'
       str << '<xdr:xfrm>'
@@ -43,8 +43,8 @@ module Axlsx
       str << '<a:ext cx="0" cy="0"/>'
       str << '</xdr:xfrm>'
       str << '<a:graphic>'
-      str << (+'<a:graphicData uri="' << XML_NS_C << '">')
-      str << (+'<c:chart xmlns:c="' << XML_NS_C << '" xmlns:r="' << XML_NS_R << '" r:id="' << rId << '"/>')
+      str << '<a:graphicData uri="' << XML_NS_C << '">'
+      str << '<c:chart xmlns:c="' << XML_NS_C << '" xmlns:r="' << XML_NS_R << '" r:id="' << rId << '"/>'
       str << '</a:graphicData>'
       str << '</a:graphic>'
       str << '</xdr:graphicFrame>'

--- a/lib/axlsx/drawing/line_3D_chart.rb
+++ b/lib/axlsx/drawing/line_3D_chart.rb
@@ -59,7 +59,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       super(str) do
-        str << (+'<c:gapDepth val="' << @gap_depth.to_s << '"/>') unless @gap_depth.nil?
+        str << '<c:gapDepth val="' << @gap_depth.to_s << '"/>' unless @gap_depth.nil?
       end
     end
   end

--- a/lib/axlsx/drawing/line_chart.rb
+++ b/lib/axlsx/drawing/line_chart.rb
@@ -76,14 +76,14 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       super(str) do
-        str << (+"<c:" << node_name << ">")
-        str << (+'<c:grouping val="' << grouping.to_s << '"/>')
-        str << (+'<c:varyColors val="' << vary_colors.to_s << '"/>')
+        str << "<c:" << node_name << ">"
+        str << '<c:grouping val="' << grouping.to_s << '"/>'
+        str << '<c:varyColors val="' << vary_colors.to_s << '"/>'
         @series.each { |ser| ser.to_xml_string(str) }
         @d_lbls.to_xml_string(str) if @d_lbls
         yield if block_given?
         axes.to_xml_string(str, :ids => true)
-        str << (+"</c:" << node_name << ">")
+        str << "</c:" << node_name << ">"
         axes.to_xml_string(str)
       end
     end

--- a/lib/axlsx/drawing/line_series.rb
+++ b/lib/axlsx/drawing/line_series.rb
@@ -75,11 +75,11 @@ module Axlsx
       super(str) do
         if color
           str << '<c:spPr><a:solidFill>'
-          str << (+'<a:srgbClr val="' << color << '"/>')
+          str << '<a:srgbClr val="' << color << '"/>'
           str << '</a:solidFill>'
           str << '<a:ln w="28800">'
           str << '<a:solidFill>'
-          str << (+'<a:srgbClr val="' << color << '"/>')
+          str << '<a:srgbClr val="' << color << '"/>'
           str << '</a:solidFill>'
           str << '</a:ln>'
           str << '<a:round/>'
@@ -94,7 +94,7 @@ module Axlsx
 
         @labels.to_xml_string(str) unless @labels.nil?
         @data.to_xml_string(str) unless @data.nil?
-        str << (+'<c:smooth val="' << ((smooth) ? '1' : '0') << '"/>')
+        str << '<c:smooth val="' << ((smooth) ? '1' : '0') << '"/>'
       end
     end
 

--- a/lib/axlsx/drawing/marker.rb
+++ b/lib/axlsx/drawing/marker.rb
@@ -58,7 +58,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       [:col, :colOff, :row, :rowOff].each do |k|
-        str << (+'<xdr:' << k.to_s << '>' << self.send(k).to_s << '</xdr:' << k.to_s << '>')
+        str << '<xdr:' << k.to_s << '>' << self.send(k).to_s << '</xdr:' << k.to_s << '>'
       end
     end
 

--- a/lib/axlsx/drawing/num_data.rb
+++ b/lib/axlsx/drawing/num_data.rb
@@ -37,13 +37,13 @@ module Axlsx
 
     # serialize the object
     def to_xml_string(str = +'')
-      str << (+'<c:' << @tag_name.to_s << '>')
-      str << (+'<c:formatCode>' << format_code.to_s << '</c:formatCode>')
-      str << (+'<c:ptCount val="' << @pt.size.to_s << '"/>')
+      str << '<c:' << @tag_name.to_s << '>'
+      str << '<c:formatCode>' << format_code.to_s << '</c:formatCode>'
+      str << '<c:ptCount val="' << @pt.size.to_s << '"/>'
       @pt.each_with_index do |num_val, index|
         num_val.to_xml_string index, str
       end
-      str << (+'</c:' << @tag_name.to_s << '>')
+      str << '</c:' << @tag_name.to_s << '>'
     end
   end
 end

--- a/lib/axlsx/drawing/num_data_source.rb
+++ b/lib/axlsx/drawing/num_data_source.rb
@@ -45,16 +45,16 @@ module Axlsx
     # serialize the object
     # @param [String] str
     def to_xml_string(str = +'')
-      str << (+'<c:' << tag_name.to_s << '>')
+      str << '<c:' << tag_name.to_s << '>'
       if @f
-        str << (+'<c:' << @ref_tag_name.to_s << '>')
-        str << (+'<c:f>' << @f.to_s << '</c:f>')
+        str << '<c:' << @ref_tag_name.to_s << '>'
+        str << '<c:f>' << @f.to_s << '</c:f>'
       end
       @data.to_xml_string str
       if @f
-        str << (+'</c:' << @ref_tag_name.to_s << '>')
+        str << '</c:' << @ref_tag_name.to_s << '>'
       end
-      str << (+'</c:' << tag_name.to_s << '>')
+      str << '</c:' << tag_name.to_s << '>'
     end
   end
 end

--- a/lib/axlsx/drawing/num_val.rb
+++ b/lib/axlsx/drawing/num_val.rb
@@ -26,7 +26,7 @@ module Axlsx
     def to_xml_string(idx, str = +'')
       Axlsx::validate_unsigned_int(idx)
       if !v.to_s.empty?
-        str << (+'<c:pt idx="' << idx.to_s << '" formatCode="' << format_code << '"><c:v>' << v.to_s << '</c:v></c:pt>')
+        str << '<c:pt idx="' << idx.to_s << '" formatCode="' << format_code << '"><c:v>' << v.to_s << '</c:v></c:pt>'
       end
     end
   end

--- a/lib/axlsx/drawing/one_cell_anchor.rb
+++ b/lib/axlsx/drawing/one_cell_anchor.rb
@@ -79,7 +79,7 @@ module Axlsx
       str << '<xdr:from>'
       from.to_xml_string(str)
       str << '</xdr:from>'
-      str << (+'<xdr:ext cx="' << ext[:cx].to_s << '" cy="' << ext[:cy].to_s << '"/>')
+      str << '<xdr:ext cx="' << ext[:cx].to_s << '" cy="' << ext[:cy].to_s << '"/>'
       @object.to_xml_string(str)
       str << '<xdr:clientData/>'
       str << '</xdr:oneCellAnchor>'

--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -192,7 +192,7 @@ module Axlsx
     def to_xml_string(str = +'')
       str << '<xdr:pic>'
       str << '<xdr:nvPicPr>'
-      str << (+'<xdr:cNvPr id="2" name="' << name.to_s << '" descr="' << descr.to_s << '">')
+      str << '<xdr:cNvPr id="2" name="' << name.to_s << '" descr="' << descr.to_s << '">'
       hyperlink.to_xml_string(str) if hyperlink.is_a?(Hyperlink)
       str << '</xdr:cNvPr><xdr:cNvPicPr>'
       picture_locking.to_xml_string(str)

--- a/lib/axlsx/drawing/pie_3D_chart.rb
+++ b/lib/axlsx/drawing/pie_3D_chart.rb
@@ -34,7 +34,7 @@ module Axlsx
     def to_xml_string(str = +'')
       super(str) do
         str << '<c:pie3DChart>'
-        str << (+'<c:varyColors val="' << vary_colors.to_s << '"/>')
+        str << '<c:varyColors val="' << vary_colors.to_s << '"/>'
         @series.each { |ser| ser.to_xml_string(str) }
         d_lbls.to_xml_string(str) if @d_lbls
         str << '</c:pie3DChart>'

--- a/lib/axlsx/drawing/pie_series.rb
+++ b/lib/axlsx/drawing/pie_series.rb
@@ -49,9 +49,9 @@ module Axlsx
         str << '<c:explosion val="' + @explosion.to_s + '"/>' unless @explosion.nil?
         colors.each_with_index do |c, index|
           str << '<c:dPt>'
-          str << (+'<c:idx val="' << index.to_s << '"/>')
+          str << '<c:idx val="' << index.to_s << '"/>'
           str << '<c:spPr><a:solidFill>'
-          str << (+'<a:srgbClr val="' << c << '"/>')
+          str << '<a:srgbClr val="' << c << '"/>'
           str << '</a:solidFill></c:spPr></c:dPt>'
         end
         @labels.to_xml_string str unless @labels.nil?

--- a/lib/axlsx/drawing/scaling.rb
+++ b/lib/axlsx/drawing/scaling.rb
@@ -49,10 +49,10 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       str << '<c:scaling>'
-      str << (+'<c:logBase val="' << @logBase.to_s << '"/>') unless @logBase.nil?
-      str << (+'<c:orientation val="' << @orientation.to_s << '"/>') unless @orientation.nil?
-      str << (+'<c:min val="' << @min.to_s << '"/>') unless @min.nil?
-      str << (+'<c:max val="' << @max.to_s << '"/>') unless @max.nil?
+      str << '<c:logBase val="' << @logBase.to_s << '"/>' unless @logBase.nil?
+      str << '<c:orientation val="' << @orientation.to_s << '"/>' unless @orientation.nil?
+      str << '<c:min val="' << @min.to_s << '"/>' unless @min.nil?
+      str << '<c:max val="' << @max.to_s << '"/>' unless @max.nil?
       str << '</c:scaling>'
     end
   end

--- a/lib/axlsx/drawing/scatter_chart.rb
+++ b/lib/axlsx/drawing/scatter_chart.rb
@@ -52,8 +52,8 @@ module Axlsx
     def to_xml_string(str = +'')
       super(str) do
         str << '<c:scatterChart>'
-        str << (+'<c:scatterStyle val="' << scatter_style.to_s << '"/>')
-        str << (+'<c:varyColors val="' << vary_colors.to_s << '"/>')
+        str << '<c:scatterStyle val="' << scatter_style.to_s << '"/>'
+        str << '<c:varyColors val="' << vary_colors.to_s << '"/>'
         @series.each { |ser| ser.to_xml_string(str) }
         d_lbls.to_xml_string(str) if @d_lbls
         axes.to_xml_string(str, :ids => true)

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -85,17 +85,17 @@ module Axlsx
         # needs to override the super color here to push in ln/and something else!
         if color
           str << '<c:spPr><a:solidFill>'
-          str << (+'<a:srgbClr val="' << color << '"/>')
+          str << '<a:srgbClr val="' << color << '"/>'
           str << '</a:solidFill>'
           str << '<a:ln><a:solidFill>'
-          str << (+'<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
+          str << '<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>'
           str << '</c:spPr>'
           str << '<c:marker>'
           str << '<c:spPr><a:solidFill>'
-          str << (+'<a:srgbClr val="' << color << '"/>')
+          str << '<a:srgbClr val="' << color << '"/>'
           str << '</a:solidFill>'
           str << '<a:ln><a:solidFill>'
-          str << (+'<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
+          str << '<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>'
           str << '</c:spPr>'
           str << marker_symbol_xml
           str << '</c:marker>'
@@ -110,7 +110,7 @@ module Axlsx
         end
         @xData.to_xml_string(str) unless @xData.nil?
         @yData.to_xml_string(str) unless @yData.nil?
-        str << (+'<c:smooth val="' << ((smooth) ? '1' : '0') << '"/>')
+        str << '<c:smooth val="' << ((smooth) ? '1' : '0') << '"/>'
       end
       str
     end

--- a/lib/axlsx/drawing/ser_axis.rb
+++ b/lib/axlsx/drawing/ser_axis.rb
@@ -35,8 +35,8 @@ module Axlsx
     def to_xml_string(str = +'')
       str << '<c:serAx>'
       super(str)
-      str << (+'<c:tickLblSkip val="' << @tick_lbl_skip.to_s << '"/>') unless @tick_lbl_skip.nil?
-      str << (+'<c:tickMarkSkip val="' << @tick_mark_skip.to_s << '"/>') unless @tick_mark_skip.nil?
+      str << '<c:tickLblSkip val="' << @tick_lbl_skip.to_s << '"/>' unless @tick_lbl_skip.nil?
+      str << '<c:tickMarkSkip val="' << @tick_mark_skip.to_s << '"/>' unless @tick_mark_skip.nil?
       str << '</c:serAx>'
     end
   end

--- a/lib/axlsx/drawing/series.rb
+++ b/lib/axlsx/drawing/series.rb
@@ -59,8 +59,8 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       str << '<c:ser>'
-      str << (+'<c:idx val="' << index.to_s << '"/>')
-      str << (+'<c:order val="' << (order || index).to_s << '"/>')
+      str << '<c:idx val="' << index.to_s << '"/>'
+      str << '<c:order val="' << (order || index).to_s << '"/>'
       title.to_xml_string(str) unless title.nil?
       yield if block_given?
       str << '</c:ser>'

--- a/lib/axlsx/drawing/series_title.rb
+++ b/lib/axlsx/drawing/series_title.rb
@@ -11,11 +11,11 @@ module Axlsx
 
       str << '<c:tx>'
       str << '<c:strRef>'
-      str << (+'<c:f>' << Axlsx::cell_range([@cell]) << '</c:f>')
+      str << '<c:f>' << Axlsx::cell_range([@cell]) << '</c:f>'
       str << '<c:strCache>'
       str << '<c:ptCount val="1"/>'
       str << '<c:pt idx="0">'
-      str << (+'<c:v>' << clean_value << '</c:v>')
+      str << '<c:v>' << clean_value << '</c:v>'
       str << '</c:pt>'
       str << '</c:strCache>'
       str << '</c:strRef>'

--- a/lib/axlsx/drawing/str_data.rb
+++ b/lib/axlsx/drawing/str_data.rb
@@ -28,12 +28,12 @@ module Axlsx
 
     # serialize the object
     def to_xml_string(str = +'')
-      str << (+'<c:' << @tag_name.to_s << '>')
-      str << (+'<c:ptCount val="' << @pt.size.to_s << '"/>')
+      str << '<c:' << @tag_name.to_s << '>'
+      str << '<c:ptCount val="' << @pt.size.to_s << '"/>'
       @pt.each_with_index do |value, index|
         value.to_xml_string index, str
       end
-      str << (+'</c:' << @tag_name.to_s << '>')
+      str << '</c:' << @tag_name.to_s << '>'
     end
   end
 end

--- a/lib/axlsx/drawing/str_val.rb
+++ b/lib/axlsx/drawing/str_val.rb
@@ -26,7 +26,7 @@ module Axlsx
     def to_xml_string(idx, str = +'')
       Axlsx::validate_unsigned_int(idx)
       if !v.to_s.empty?
-        str << (+'<c:pt idx="' << idx.to_s << '"><c:v>' << ::CGI.escapeHTML(v.to_s) << '</c:v></c:pt>')
+        str << '<c:pt idx="' << idx.to_s << '"><c:v>' << ::CGI.escapeHTML(v.to_s) << '</c:v></c:pt>'
       end
     end
   end

--- a/lib/axlsx/drawing/title.rb
+++ b/lib/axlsx/drawing/title.rb
@@ -76,11 +76,11 @@ module Axlsx
         str << '<c:tx>'
         if @cell.is_a?(Cell)
           str << '<c:strRef>'
-          str << (+'<c:f>' << Axlsx::cell_range([@cell]) << '</c:f>')
+          str << '<c:f>' << Axlsx::cell_range([@cell]) << '</c:f>'
           str << '<c:strCache>'
           str << '<c:ptCount val="1"/>'
           str << '<c:pt idx="0">'
-          str << (+'<c:v>' << clean_value << '</c:v>')
+          str << '<c:v>' << clean_value << '</c:v>'
           str << '</c:pt>'
           str << '</c:strCache>'
           str << '</c:strRef>'
@@ -90,8 +90,8 @@ module Axlsx
           str << '<a:lstStyle/>'
           str << '<a:p>'
           str << '<a:r>'
-          str << (+'<a:rPr sz="' << @text_size.to_s << '"/>')
-          str << (+'<a:t>' << clean_value << '</a:t>')
+          str << '<a:rPr sz="' << @text_size.to_s << '"/>'
+          str << '<a:t>' << clean_value << '</a:t>'
           str << '</a:r>'
           str << '</a:p>'
           str << '</c:rich>'

--- a/lib/axlsx/drawing/val_axis.rb
+++ b/lib/axlsx/drawing/val_axis.rb
@@ -29,7 +29,7 @@ module Axlsx
     def to_xml_string(str = +'')
       str << '<c:valAx>'
       super(str)
-      str << (+'<c:crossBetween val="' << @cross_between.to_s << '"/>')
+      str << '<c:crossBetween val="' << @cross_between.to_s << '"/>'
       str << '</c:valAx>'
     end
   end

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -111,7 +111,7 @@ module Axlsx
       zip_provider = if zip_command
                        ZipCommand.new(zip_command)
                      else
-                       Zip::OutputStream
+                       BufferedZipOutputStream
                      end
       Relationship.initialize_ids_cache
       zip_provider.open(output) do |zip|
@@ -133,8 +133,9 @@ module Axlsx
       return false unless !confirm_valid || self.validate.empty?
 
       Relationship.initialize_ids_cache
-      zip = write_parts(Zip::OutputStream.new(StringIO.new.binmode, true))
-      stream = zip.close_buffer
+      stream = BufferedZipOutputStream.write_buffer do |zip|
+        write_parts(zip)
+      end
       stream.rewind
       stream
     ensure

--- a/lib/axlsx/rels/relationship.rb
+++ b/lib/axlsx/rels/relationship.rb
@@ -105,7 +105,7 @@ module Axlsx
     def to_xml_string(str = +'')
       h = Axlsx.instance_values_for(self).reject { |k, _| k == "source_obj" }
       str << '<Relationship '
-      str << (h.map { |key, value| +'' << key.to_s << '="' << Axlsx::coder.encode(value.to_s) << '"' }.join(' '))
+      h.each { |key, value| str << key.to_s << '="' << Axlsx::coder.encode(value.to_s) << '" ' }
       str << '/>'
     end
 

--- a/lib/axlsx/rels/relationship.rb
+++ b/lib/axlsx/rels/relationship.rb
@@ -105,7 +105,10 @@ module Axlsx
     def to_xml_string(str = +'')
       h = Axlsx.instance_values_for(self).reject { |k, _| k == "source_obj" }
       str << '<Relationship '
-      h.each { |key, value| str << key.to_s << '="' << Axlsx::coder.encode(value.to_s) << '" ' }
+      h.each_with_index do |key_value, index|
+        str << ' ' unless index.zero?
+        str << key_value.first.to_s << '="' << Axlsx::coder.encode(key_value.last.to_s) << '"'
+      end
       str << '/>'
     end
 

--- a/lib/axlsx/rels/relationships.rb
+++ b/lib/axlsx/rels/relationships.rb
@@ -23,7 +23,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << (+'<Relationships xmlns="' << RELS_R << '">')
+      str << '<Relationships xmlns="' << RELS_R << '">'
       each { |rel| rel.to_xml_string(str) }
       str << '</Relationships>'
     end

--- a/lib/axlsx/stylesheet/border_pr.rb
+++ b/lib/axlsx/stylesheet/border_pr.rb
@@ -63,9 +63,9 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = +'')
-      str << (+'<' << @name.to_s << ' style="' << @style.to_s << '">')
+      str << '<' << @name.to_s << ' style="' << @style.to_s << '">'
       @color.to_xml_string(str) if @color.is_a?(Color)
-      str << (+'</' << @name.to_s << '>')
+      str << '</' << @name.to_s << '>'
     end
   end
 end

--- a/lib/axlsx/stylesheet/font.rb
+++ b/lib/axlsx/stylesheet/font.rb
@@ -151,7 +151,7 @@ module Axlsx
     def to_xml_string(str = +'')
       str << '<font>'
       Axlsx.instance_values_for(self).each do |k, v|
-        v.is_a?(Color) ? v.to_xml_string(str) : (str << (+'<' << k.to_s << ' val="' << Axlsx.booleanize(v).to_s << '"/>'))
+        v.is_a?(Color) ? v.to_xml_string(str) : (str << '<' << k.to_s << ' val="' << Axlsx.booleanize(v).to_s << '"/>')
       end
       str << '</font>'
     end

--- a/lib/axlsx/stylesheet/gradient_stop.rb
+++ b/lib/axlsx/stylesheet/gradient_stop.rb
@@ -30,7 +30,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = +'')
-      str << (+'<stop position="' << position.to_s << '">')
+      str << '<stop position="' << position.to_s << '">'
       self.color.to_xml_string(str)
       str << '</stop>'
     end

--- a/lib/axlsx/stylesheet/pattern_fill.rb
+++ b/lib/axlsx/stylesheet/pattern_fill.rb
@@ -59,7 +59,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = +'')
-      str << (+'<patternFill patternType="' << patternType.to_s << '">')
+      str << '<patternFill patternType="' << patternType.to_s << '">'
       if fgColor.is_a?(Color)
         fgColor.to_xml_string str, "fgColor"
       end

--- a/lib/axlsx/stylesheet/styles.rb
+++ b/lib/axlsx/stylesheet/styles.rb
@@ -486,7 +486,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = +'')
-      str << (+'<styleSheet xmlns="' << XML_NS << '">')
+      str << '<styleSheet xmlns="' << XML_NS << '">'
       instance_vals = Axlsx.instance_values_for(self)
       [:numFmts, :fonts, :fills, :borders, :cellStyleXfs, :cellXfs, :cellStyles, :dxfs, :tableStyles].each do |key|
         instance_vals[key.to_s].to_xml_string(str) unless instance_vals[key.to_s].nil?

--- a/lib/axlsx/util/buffered_zip_output_stream.rb
+++ b/lib/axlsx/util/buffered_zip_output_stream.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Axlsx
+  # The BufferedZipOutputStream buffers the output in order to avoid appending many small strings directly to the
+  # the `Zip::OutputStream`.
+  #
+  # The methods provided here mimic `Zip::OutputStream` so that this class can be used a drop-in replacement.
+  class BufferedZipOutputStream
+    # The 4_096 was chosen somewhat arbitrary, however, it was difficult to see any obvious improvement with larger
+    # buffer sizes.
+    BUFFER_SIZE = 4_096
+
+    def initialize(zos)
+      @zos = zos
+      @buffer = String.new(capacity: BUFFER_SIZE * 2)
+    end
+
+    # Create a temporary directory for writing files to.
+    #
+    # The directory and its contents are removed at the end of the block.
+    def self.open(file_name, encrypter = nil, &block)
+      Zip::OutputStream.open(file_name, encrypter) do |zos|
+        bzos = new(zos)
+        block.call(bzos)
+      ensure
+        bzos.flush if bzos
+      end
+    end
+
+    def self.write_buffer(io = ::StringIO.new, encrypter = nil, &block)
+      Zip::OutputStream.write_buffer(io, encrypter) do |zos|
+        bzos = new(zos)
+        block.call(bzos)
+      ensure
+        bzos.flush if bzos
+      end
+    end
+
+    # Closes the current entry and opens a new for writing.
+    def put_next_entry(entry)
+      flush
+      @zos.put_next_entry(entry)
+    end
+
+    # Write to a buffer that will be written to the current entry
+    def write(content)
+      @buffer << content.to_s
+      flush if @buffer.size > BUFFER_SIZE
+      self
+    end
+    alias << write
+
+    def flush
+      return if @buffer.size == 0
+
+      @zos << @buffer
+      @buffer.clear
+    end
+  end
+end

--- a/lib/axlsx/util/buffered_zip_output_stream.rb
+++ b/lib/axlsx/util/buffered_zip_output_stream.rb
@@ -18,19 +18,19 @@ module Axlsx
     # Create a temporary directory for writing files to.
     #
     # The directory and its contents are removed at the end of the block.
-    def self.open(file_name, encrypter = nil, &block)
+    def self.open(file_name, encrypter = nil)
       Zip::OutputStream.open(file_name, encrypter) do |zos|
         bzos = new(zos)
-        block.call(bzos)
+        yield(bzos)
       ensure
         bzos.flush if bzos
       end
     end
 
-    def self.write_buffer(io = ::StringIO.new, encrypter = nil, &block)
+    def self.write_buffer(io = ::StringIO.new, encrypter = nil)
       Zip::OutputStream.write_buffer(io, encrypter) do |zos|
         bzos = new(zos)
-        block.call(bzos)
+        yield(bzos)
       ensure
         bzos.flush if bzos
       end
@@ -51,7 +51,7 @@ module Axlsx
     alias << write
 
     def flush
-      return if @buffer.size == 0
+      return if @buffer.empty?
 
       @zos << @buffer
       @buffer.clear

--- a/lib/axlsx/util/simple_typed_list.rb
+++ b/lib/axlsx/util/simple_typed_list.rb
@@ -174,9 +174,9 @@ module Axlsx
     def to_xml_string(str = +'')
       classname = @allowed_types[0].name.split('::').last
       el_name = serialize_as.to_s || (classname[0, 1].downcase + classname[1..-1])
-      str << (+'<' << el_name << ' count="' << size.to_s << '">')
+      str << '<' << el_name << ' count="' << size.to_s << '">'
       each { |item| item.to_xml_string(str) }
-      str << (+'</' << el_name << '>')
+      str << '</' << el_name << '>'
     end
   end
 end

--- a/lib/axlsx/util/zip_command.rb
+++ b/lib/axlsx/util/zip_command.rb
@@ -40,23 +40,21 @@ module Axlsx
       @current_file = "#{@dir}/#{entry.name}"
       @files << entry.name
       FileUtils.mkdir_p(File.dirname(@current_file))
+      @io = File.open(@current_file, "wb")
     end
 
     # Write to a buffer that will be written to the current entry
     def write(content)
-      @buffer << content
+      @io << content
     end
     alias << write
 
     private
 
     def write_file
-      if @current_file
-        @buffer.rewind
-        File.open(@current_file, "wb") { |f| f.write @buffer.read }
-      end
+      @io.close if @current_file
       @current_file = nil
-      @buffer = StringIO.new
+      @io = nil
     end
 
     def zip_parts(output)

--- a/lib/axlsx/workbook/defined_name.rb
+++ b/lib/axlsx/workbook/defined_name.rb
@@ -123,9 +123,9 @@ module Axlsx
     def to_xml_string(str = +'')
       raise ArgumentError, 'you must specify the name for this defined name. Please read the documentation for Axlsx::DefinedName for more details' unless name
 
-      str << (+'<definedName ' << 'name="' << name << '" ')
+      str << '<definedName ' << 'name="' << name << '" '
       serialized_attributes str
-      str << (+'>' << @formula << '</definedName>')
+      str << '>' << @formula << '</definedName>'
     end
   end
 end

--- a/lib/axlsx/workbook/shared_strings_table.rb
+++ b/lib/axlsx/workbook/shared_strings_table.rb
@@ -47,9 +47,9 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       Axlsx::sanitize(@shared_xml_string)
-      str << (+'<?xml version="1.0" encoding="UTF-8"?><sst xmlns="' << XML_NS << '"')
-      str << (+' count="' << @count.to_s << '" uniqueCount="' << unique_count.to_s << '"')
-      str << (+' xml:space="' << xml_space.to_s << '">' << @shared_xml_string << '</sst>')
+      str << '<?xml version="1.0" encoding="UTF-8"?><sst xmlns="' << XML_NS << '"'
+      str << ' count="' << @count.to_s << '" uniqueCount="' << unique_count.to_s << '"'
+      str << ' xml:space="' << xml_space.to_s << '">' << @shared_xml_string << '</sst>'
     end
 
     private

--- a/lib/axlsx/workbook/workbook.rb
+++ b/lib/axlsx/workbook/workbook.rb
@@ -408,8 +408,8 @@ module Axlsx
     def to_xml_string(str = +'')
       add_worksheet(name: 'Sheet1') unless worksheets.size > 0
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << (+'<workbook xmlns="' << XML_NS << '" xmlns:r="' << XML_NS_R << '">')
-      str << (+'<workbookPr date1904="' << @@date1904.to_s << '"/>')
+      str << '<workbook xmlns="' << XML_NS << '" xmlns:r="' << XML_NS_R << '">'
+      str << '<workbookPr date1904="' << @@date1904.to_s << '"/>'
       views.to_xml_string(str)
       str << '<sheets>'
       if is_reversed
@@ -422,7 +422,7 @@ module Axlsx
       unless pivot_tables.empty?
         str << '<pivotCaches>'
         pivot_tables.each do |pivot_table|
-          str << (+'<pivotCache cacheId="' << pivot_table.cache_definition.cache_id.to_s << '" r:id="' << pivot_table.cache_definition.rId << '"/>')
+          str << '<pivotCache cacheId="' << pivot_table.cache_definition.cache_id.to_s << '" r:id="' << pivot_table.cache_definition.rId << '"/>'
         end
         str << '</pivotCaches>'
       end

--- a/lib/axlsx/workbook/worksheet/auto_filter/filter_column.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/filter_column.rb
@@ -88,7 +88,9 @@ module Axlsx
 
     # Serialize the object to xml
     def to_xml_string(str = +'')
-      str << "<filterColumn #{serialized_attributes}>"
+      str << '<filterColumn '
+      serialized_attributes(str)
+      str << '>'
       @filter.to_xml_string(str)
       str << "</filterColumn>"
     end

--- a/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
@@ -77,7 +77,9 @@ module Axlsx
 
     # Serialize the object to xml
     def to_xml_string(str = +'')
-      str << "<filters #{serialized_attributes}>"
+      str << '<filters '
+      serialized_attributes(str)
+      str << '>'
       filter_items.each { |filter| filter.to_xml_string(str) }
       date_group_items.each { |date_group_item| date_group_item.to_xml_string(str) }
       str << '</filters>'

--- a/lib/axlsx/workbook/worksheet/cell_serializer.rb
+++ b/lib/axlsx/workbook/worksheet/cell_serializer.rb
@@ -10,7 +10,7 @@ module Axlsx
       # @param [String] str The string to apend serialization to.
       # @return [String]
       def to_xml_string(row_index, column_index, cell, str = +'')
-        str << (+'<c r="' << Axlsx::cell_r(column_index, row_index) << '" s="' << cell.style.to_s << '" ')
+        str << '<c r="' << Axlsx::cell_r(column_index, row_index) << '" s="' << cell.style.to_s << '" '
         return str << '/>' if cell.value.nil?
 
         method = cell.type
@@ -30,7 +30,7 @@ module Axlsx
         elsif cell.contains_rich_text?
           cell.value.to_xml_string(str)
         else
-          str << (+'<t>' << cell.clean_value << '</t>')
+          str << '<t>' << cell.clean_value << '</t>'
         end
         str
       end
@@ -88,8 +88,8 @@ module Axlsx
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
       def formula_serialization(cell, str = +'')
-        str << (+'t="str"><f>' << cell.clean_value.to_s.sub('=', '') << '</f>')
-        str << (+'<v>' << cell.formula_value.to_s << '</v>') unless cell.formula_value.nil?
+        str << 't="str"><f>' << cell.clean_value.to_s.sub('=', '') << '</f>'
+        str << '<v>' << cell.formula_value.to_s << '</v>' unless cell.formula_value.nil?
       end
 
       # Serializes cells that are type array formula
@@ -97,8 +97,8 @@ module Axlsx
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
       def array_formula_serialization(cell, str = +'')
-        str << (+'t="str">' << '<f t="array" ref="' << cell.r << '">' << cell.clean_value.to_s.sub('{=', '').sub(/}$/, '') << '</f>')
-        str << (+'<v>' << cell.formula_value.to_s << '</v>') unless cell.formula_value.nil?
+        str << 't="str">' << '<f t="array" ref="' << cell.r << '">' << cell.clean_value.to_s.sub('{=', '').sub(/}$/, '') << '</f>'
+        str << '<v>' << cell.formula_value.to_s << '</v>' unless cell.formula_value.nil?
       end
 
       # Serializes cells that are type inline_string
@@ -158,8 +158,8 @@ module Axlsx
       end
 
       def value_serialization(serialization_type, serialization_value, str = +'')
-        str << (+'t="' << serialization_type.to_s << '"') if serialization_type
-        str << (+'><v>' << serialization_value.to_s << '</v>')
+        str << 't="' << serialization_type.to_s << '"' if serialization_type
+        str << '><v>' << serialization_value.to_s << '</v>'
       end
     end
   end

--- a/lib/axlsx/workbook/worksheet/col_breaks.rb
+++ b/lib/axlsx/workbook/worksheet/col_breaks.rb
@@ -28,7 +28,7 @@ module Axlsx
     def to_xml_string(str = +'')
       return if empty?
 
-      str << (+'<colBreaks count="' << size.to_s << '" manualBreakCount="' << size.to_s << '">')
+      str << '<colBreaks count="' << size.to_s << '" manualBreakCount="' << size.to_s << '">'
       each { |brk| brk.to_xml_string(str) }
       str << '</colBreaks>'
     end

--- a/lib/axlsx/workbook/worksheet/comment.rb
+++ b/lib/axlsx/workbook/worksheet/comment.rb
@@ -63,15 +63,15 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       author = @comments.authors[author_index]
-      str << (+'<comment ref="' << ref << '" authorId="' << author_index.to_s << '">')
+      str << '<comment ref="' << ref << '" authorId="' << author_index.to_s << '">'
       str << '<text>'
       unless author.to_s == ""
         str << '<r><rPr><b/><color indexed="81"/></rPr>'
-        str << (+"<t>" << ::CGI.escapeHTML(author.to_s) << ":\n</t></r>")
+        str << "<t>" << ::CGI.escapeHTML(author.to_s) << ":\n</t></r>"
       end
       str << '<r>'
       str << '<rPr><color indexed="81"/></rPr>'
-      str << (+'<t>' << ::CGI.escapeHTML(text) << '</t></r></text>')
+      str << '<t>' << ::CGI.escapeHTML(text) << '</t></r></text>'
       str << '</comment>'
     end
 

--- a/lib/axlsx/workbook/worksheet/comments.rb
+++ b/lib/axlsx/workbook/worksheet/comments.rb
@@ -66,9 +66,9 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << (+'<comments xmlns="' << XML_NS << '"><authors>')
+      str << '<comments xmlns="' << XML_NS << '"><authors>'
       authors.each do |author|
-        str << (+'<author>' << author.to_s << '</author>')
+        str << '<author>' << author.to_s << '</author>'
       end
       str << '</authors><commentList>'
       each do |comment|

--- a/lib/axlsx/workbook/worksheet/conditional_formatting.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting.rb
@@ -76,7 +76,10 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       str << '<conditionalFormatting sqref="' << sqref << '">'
-      rules.each { |rule| rule.to_xml_string(str) }
+      rules.each_with_index do |rule, index|
+        str << ' ' unless index.zero?
+        rule.to_xml_string(str)
+      end
       str << '</conditionalFormatting>'
     end
   end

--- a/lib/axlsx/workbook/worksheet/conditional_formatting.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting.rb
@@ -75,8 +75,8 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = +'')
-      str << (+'<conditionalFormatting sqref="' << sqref << '">')
-      str << rules.collect { |rule| rule.to_xml_string }.join(' ')
+      str << '<conditionalFormatting sqref="' << sqref << '">'
+      rules.each { |rule| rule.to_xml_string(str) }
       str << '</conditionalFormatting>'
     end
   end

--- a/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
@@ -208,7 +208,7 @@ module Axlsx
       str << '<cfRule '
       serialized_attributes str
       str << '>'
-      str << (+'<formula>' << [*self.formula].join('</formula><formula>') << '</formula>') if @formula
+      str << '<formula>' << [*self.formula].join('</formula><formula>') << '</formula>' if @formula
       @color_scale.to_xml_string(str) if @color_scale && @type == :colorScale
       @data_bar.to_xml_string(str) if @data_bar && @type == :dataBar
       @icon_set.to_xml_string(str) if @icon_set && @type == :iconSet

--- a/lib/axlsx/workbook/worksheet/data_validation.rb
+++ b/lib/axlsx/workbook/worksheet/data_validation.rb
@@ -237,12 +237,12 @@ module Axlsx
       valid_attributes = get_valid_attributes
 
       str << '<dataValidation '
-      str << Axlsx.instance_values_for(self).map do |key, value|
-        +'' << key << '="' << Axlsx.booleanize(value).to_s << '"' if (valid_attributes.include?(key.to_sym) && !CHILD_ELEMENTS.include?(key.to_sym))
-      end.join(' ')
+      Axlsx.instance_values_for(self).each do |key, value|
+        str << key << '="' << Axlsx.booleanize(value).to_s << '" ' if (valid_attributes.include?(key.to_sym) && !CHILD_ELEMENTS.include?(key.to_sym))
+      end
       str << '>'
-      str << (+'<formula1>' << self.formula1 << '</formula1>') if @formula1 and valid_attributes.include?(:formula1)
-      str << (+'<formula2>' << self.formula2 << '</formula2>') if @formula2 and valid_attributes.include?(:formula2)
+      str << '<formula1>' << self.formula1 << '</formula1>' if @formula1 and valid_attributes.include?(:formula1)
+      str << '<formula2>' << self.formula2 << '</formula2>' if @formula2 and valid_attributes.include?(:formula2)
       str << '</dataValidation>'
     end
 

--- a/lib/axlsx/workbook/worksheet/data_validation.rb
+++ b/lib/axlsx/workbook/worksheet/data_validation.rb
@@ -235,10 +235,12 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       valid_attributes = get_valid_attributes
+      h = Axlsx.instance_values_for(self).select { |key, _| valid_attributes.include?(key.to_sym) && !CHILD_ELEMENTS.include?(key.to_sym) }
 
       str << '<dataValidation '
-      Axlsx.instance_values_for(self).each do |key, value|
-        str << key << '="' << Axlsx.booleanize(value).to_s << '" ' if (valid_attributes.include?(key.to_sym) && !CHILD_ELEMENTS.include?(key.to_sym))
+      h.each_with_index do |key_value, index|
+        str << ' ' unless index.zero?
+        str << key_value.first << '="' << Axlsx.booleanize(key_value.last).to_s << '"'
       end
       str << '>'
       str << '<formula1>' << self.formula1 << '</formula1>' if @formula1 and valid_attributes.include?(:formula1)

--- a/lib/axlsx/workbook/worksheet/outline_pr.rb
+++ b/lib/axlsx/workbook/worksheet/outline_pr.rb
@@ -28,7 +28,9 @@ module Axlsx
     # @param [String] str serialized output will be appended to this object if provided.
     # @return [String]
     def to_xml_string(str = +'')
-      str << "<outlinePr #{serialized_attributes} />"
+      str << '<outlinePr '
+      serialized_attributes(str)
+      str << '/>'
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/page_set_up_pr.rb
+++ b/lib/axlsx/workbook/worksheet/page_set_up_pr.rb
@@ -38,7 +38,9 @@ module Axlsx
 
     # serialize to xml
     def to_xml_string(str = +'')
-      str << (+'<pageSetUpPr ' << serialized_attributes << '/>')
+      str << '<pageSetUpPr '
+      serialized_attributes(str)
+      str << '/>'
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -189,10 +189,10 @@ module Axlsx
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
 
-      str << (+'<pivotTableDefinition xmlns="' << XML_NS << '" name="' << name << '" cacheId="' << cache_definition.cache_id.to_s << '"' << (data.size <= 1 ? ' dataOnRows="1"' : '') << ' applyNumberFormats="0" applyBorderFormats="0" applyFontFormats="0" applyPatternFormats="0" applyAlignmentFormats="0" applyWidthHeightFormats="1" dataCaption="Data" showMultipleLabel="0" showMemberPropertyTips="0" useAutoFormatting="1" indent="0" compact="0" compactData="0" gridDropZones="1" multipleFieldFilters="0">')
+      str << '<pivotTableDefinition xmlns="' << XML_NS << '" name="' << name << '" cacheId="' << cache_definition.cache_id.to_s << '"' << (data.size <= 1 ? ' dataOnRows="1"' : '') << ' applyNumberFormats="0" applyBorderFormats="0" applyFontFormats="0" applyPatternFormats="0" applyAlignmentFormats="0" applyWidthHeightFormats="1" dataCaption="Data" showMultipleLabel="0" showMemberPropertyTips="0" useAutoFormatting="1" indent="0" compact="0" compactData="0" gridDropZones="1" multipleFieldFilters="0">'
 
-      str << (+'<location firstDataCol="1" firstDataRow="1" firstHeaderRow="1" ref="' << ref << '"/>')
-      str << (+'<pivotFields count="' << header_cells_count.to_s << '">')
+      str << '<location firstDataCol="1" firstDataRow="1" firstHeaderRow="1" ref="' << ref << '"/>'
+      str << '<pivotFields count="' << header_cells_count.to_s << '">'
 
       header_cell_values.each do |cell_value|
         subtotal = !no_subtotals_on_headers.include?(cell_value)
@@ -205,12 +205,12 @@ module Axlsx
         str << '<rowFields count="1"><field x="-2"/></rowFields>'
         str << '<rowItems count="2"><i><x/></i> <i i="1"><x v="1"/></i></rowItems>'
       else
-        str << (+'<rowFields count="' << rows.size.to_s << '">')
+        str << '<rowFields count="' << rows.size.to_s << '">'
         rows.each do |row_value|
-          str << (+'<field x="' << header_index_of(row_value).to_s << '"/>')
+          str << '<field x="' << header_index_of(row_value).to_s << '"/>'
         end
         str << '</rowFields>'
-        str << (+'<rowItems count="' << rows.size.to_s << '">')
+        str << '<rowItems count="' << rows.size.to_s << '">'
         rows.size.times do |i|
           str << '<i/>'
         end
@@ -229,16 +229,16 @@ module Axlsx
           str << '<colItems count="1"><i/></colItems>'
         end
       else
-        str << (+'<colFields count="' << columns.size.to_s << '">')
+        str << '<colFields count="' << columns.size.to_s << '">'
         columns.each do |column_value|
-          str << (+'<field x="' << header_index_of(column_value).to_s << '"/>')
+          str << '<field x="' << header_index_of(column_value).to_s << '"/>'
         end
         str << '</colFields>'
       end
       unless pages.empty?
-        str << (+'<pageFields count="' << pages.size.to_s << '">')
+        str << '<pageFields count="' << pages.size.to_s << '">'
         pages.each do |page_value|
-          str << (+'<pageField fld="' << header_index_of(page_value).to_s << '"/>')
+          str << '<pageField fld="' << header_index_of(page_value).to_s << '"/>'
         end
         str << '</pageFields>'
       end

--- a/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
@@ -47,13 +47,13 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << (+'<pivotCacheDefinition xmlns="' << XML_NS << '" xmlns:r="' << XML_NS_R << '" invalid="1" refreshOnLoad="1" recordCount="0">')
+      str << '<pivotCacheDefinition xmlns="' << XML_NS << '" xmlns:r="' << XML_NS_R << '" invalid="1" refreshOnLoad="1" recordCount="0">'
       str << '<cacheSource type="worksheet">'
-      str << (+'<worksheetSource ref="' << pivot_table.range << '" sheet="' << pivot_table.data_sheet.name << '"/>')
+      str << '<worksheetSource ref="' << pivot_table.range << '" sheet="' << pivot_table.data_sheet.name << '"/>'
       str << '</cacheSource>'
-      str << (+'<cacheFields count="' << pivot_table.header_cells_count.to_s << '">')
+      str << '<cacheFields count="' << pivot_table.header_cells_count.to_s << '">'
       pivot_table.header_cells.each do |cell|
-        str << (+'<cacheField name="' << cell.clean_value << '" numFmtId="0">')
+        str << '<cacheField name="' << cell.clean_value << '" numFmtId="0">'
         str <<     '<sharedItems count="0">'
         str <<     '</sharedItems>'
         str << '</cacheField>'

--- a/lib/axlsx/workbook/worksheet/rich_text_run.rb
+++ b/lib/axlsx/workbook/worksheet/rich_text_run.rb
@@ -214,15 +214,15 @@ module Axlsx
       data.keys.each do |key|
         case key
         when :font_name
-          str << (+'<rFont val="' << font_name << '"/>')
+          str << '<rFont val="' << font_name << '"/>'
         when :color
           str << data[key].to_xml_string
         else
-          str << (+'<' << key.to_s << ' val="' << xml_value(data[key]) << '"/>')
+          str << '<' << key.to_s << ' val="' << xml_value(data[key]) << '"/>'
         end
       end
       clean_value = Axlsx::trust_input ? @value.to_s : ::CGI.escapeHTML(Axlsx::sanitize(@value.to_s))
-      str << (+'</rPr><t>' << clean_value << '</t></r>')
+      str << '</rPr><t>' << clean_value << '</t></r>'
     end
 
     private

--- a/lib/axlsx/workbook/worksheet/row.rb
+++ b/lib/axlsx/workbook/worksheet/row.rb
@@ -90,9 +90,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(r_index, str = +'')
       serialized_tag('row', str, :r => r_index + 1) do
-        tmp = +'' # time / memory tradeoff, lots of calls to rubyzip costs more time..
-        each_with_index { |cell, c_index| cell.to_xml_string(r_index, c_index, tmp) }
-        str << tmp
+        each_with_index { |cell, c_index| cell.to_xml_string(r_index, c_index, str) }
       end
     end
 

--- a/lib/axlsx/workbook/worksheet/row_breaks.rb
+++ b/lib/axlsx/workbook/worksheet/row_breaks.rb
@@ -26,7 +26,7 @@ module Axlsx
     def to_xml_string(str = +'')
       return if empty?
 
-      str << (+'<rowBreaks count="' << self.size.to_s << '" manualBreakCount="' << self.size.to_s << '">')
+      str << '<rowBreaks count="' << self.size.to_s << '" manualBreakCount="' << self.size.to_s << '">'
       each { |brk| brk.to_xml_string(str) }
       str << '</rowBreaks>'
     end

--- a/lib/axlsx/workbook/worksheet/sheet_calc_pr.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_calc_pr.rb
@@ -24,7 +24,9 @@ module Axlsx
     # content to.
     # @return [String]
     def to_xml_string(str = +'')
-      str << "<sheetCalcPr #{serialized_attributes}/>"
+      str << '<sheetCalcPr '
+      serialized_attributes(str)
+      str << '/>'
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/sheet_format_pr.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_format_pr.rb
@@ -49,7 +49,9 @@ module Axlsx
     # @param [String] str The string this objects serialization will be appended to
     # @return [String]
     def to_xml_string(str = +'')
-      str << "<sheetFormatPr #{serialized_attributes}/>"
+      str << '<sheetFormatPr '
+      serialized_attributes(str)
+      str << '/>'
     end
 
     private

--- a/lib/axlsx/workbook/worksheet/sheet_pr.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_pr.rb
@@ -52,7 +52,9 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       update_properties
-      str << "<sheetPr #{serialized_attributes}>"
+      str << '<sheetPr '
+      serialized_attributes(str)
+      str << '>'
       tab_color.to_xml_string(str, 'tabColor') if tab_color
       outline_pr.to_xml_string(str) if @outline_pr
       page_setup_pr.to_xml_string(str)

--- a/lib/axlsx/workbook/worksheet/table.rb
+++ b/lib/axlsx/workbook/worksheet/table.rb
@@ -75,12 +75,12 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << (+'<table xmlns="' << XML_NS << '" id="' << (index + 1).to_s << '" name="' << @name << '" displayName="' << @name.gsub(/\s/, '_') << '" ')
-      str << (+'ref="' << @ref << '" totalsRowShown="0">')
-      str << (+'<autoFilter ref="' << @ref << '"/>')
-      str << (+'<tableColumns count="' << header_cells.length.to_s << '">')
+      str << '<table xmlns="' << XML_NS << '" id="' << (index + 1).to_s << '" name="' << @name << '" displayName="' << @name.gsub(/\s/, '_') << '" '
+      str << 'ref="' << @ref << '" totalsRowShown="0">'
+      str << '<autoFilter ref="' << @ref << '"/>'
+      str << '<tableColumns count="' << header_cells.length.to_s << '">'
       header_cells.each_with_index do |cell, index|
-        str << (+'<tableColumn id ="' << (index + 1).to_s << '" name="' << cell.clean_value << '"/>')
+        str << '<tableColumn id ="' << (index + 1).to_s << '" name="' << cell.clean_value << '"/>'
       end
       str << '</tableColumns>'
       table_style_info.to_xml_string(str)

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -632,8 +632,8 @@ module Axlsx
       add_autofilter_defined_name_to_workbook
       str << '<sheet '
       serialized_attributes str
-      str << (+'name="' << name << '" ')
-      str << (+'r:id="' << rId << '"></sheet>')
+      str << 'name="' << name << '" '
+      str << 'r:id="' << rId << '"></sheet>'
     end
 
     # Serializes the worksheet object to an xml string

--- a/test/benchmark.rb
+++ b/test/benchmark.rb
@@ -5,11 +5,14 @@ $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/../lib"
 require 'axlsx'
 require 'csv'
 require 'benchmark'
-Axlsx::trust_input = true
+# Axlsx::trust_input = true
 row = []
-input = (32..126).to_a.pack('U*').chars.to_a
-20.times { row << input.shuffle.join }
+input1 = (32..126).to_a.pack('U*').chars.to_a # these will need to be escaped
+input2 = (65..122).to_a.pack('U*').chars.to_a # these do not need to be escaped
+10.times { row << input1.shuffle.join }
+10.times { row << input2.shuffle.join }
 times = 3000
+
 Benchmark.bmbm(30) do |x|
   x.report('axlsx_noautowidth') do
     p = Axlsx::Package.new
@@ -24,7 +27,7 @@ Benchmark.bmbm(30) do |x|
     p.serialize("example_noautowidth.xlsx")
   end
 
-  x.report('axlsx') do
+  x.report('axlsx_autowidth') do
     p = Axlsx::Package.new
     p.workbook do |wb|
       wb.add_worksheet do |sheet|
@@ -62,6 +65,18 @@ Benchmark.bmbm(30) do |x|
     File.binwrite('example_streamed.xlsx', s.read)
   end
 
+  x.report('axlsx_zip_command') do
+    p = Axlsx::Package.new
+    p.workbook do |wb|
+      wb.add_worksheet do |sheet|
+        times.times do
+          sheet << row
+        end
+      end
+    end
+    p.serialize("example_zip_command.xlsx", zip_command: 'zip')
+  end
+
   x.report('csv') do
     CSV.open("example.csv", "wb") do |csv|
       times.times do
@@ -70,4 +85,4 @@ Benchmark.bmbm(30) do |x|
     end
   end
 end
-File.delete("example.csv", "example_streamed.xlsx", "example_shared.xlsx", "example_autowidth.xlsx", "example_noautowidth.xlsx")
+File.delete("example.csv", "example_streamed.xlsx", "example_shared.xlsx", "example_autowidth.xlsx", "example_noautowidth.xlsx", "example_zip_command.xlsx")

--- a/test/profile_memory.rb
+++ b/test/profile_memory.rb
@@ -3,7 +3,9 @@
 
 $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/../lib"
 require 'axlsx'
-require 'ruby-prof'
+require 'memory_profiler'
+
+# Axlsx.trust_input = true
 
 row = []
 input1 = (32..126).to_a.pack('U*').chars.to_a # these will need to be escaped
@@ -11,15 +13,15 @@ input2 = (65..122).to_a.pack('U*').chars.to_a # these do not need to be escaped
 10.times { row << input1.shuffle.join }
 10.times { row << input2.shuffle.join }
 
-profile = RubyProf.profile do
+report = MemoryProfiler.report do
   p = Axlsx::Package.new
   p.workbook.add_worksheet do |sheet|
     10_000.times do
       sheet << row
     end
   end
-  p.to_stream
+  p.serialize("example_memory.xlsx", zip_command: 'zip')
 end
+report.pretty_print
 
-printer = RubyProf::FlatPrinter.new(profile)
-printer.print($stdout, {})
+File.delete("example_memory.xlsx")


### PR DESCRIPTION
### Description
This PR is a follow-up to https://github.com/caxlsx/caxlsx/pull/213 and includes the commits related to piping directly to output. 

Specifically, we avoid allocating small temporary strings and instead pipe directly to `str`. When using RubyZip, we add BufferedZipOutputStream to avoid invoking RubyZip with lots of small writes. When using ZipCommand, we write directly to file io and avoid buffering the whole output in memory.   

The following are some quick numbers on Ruby 3.1.3 on my MacBook. The main point is that performance is about the same but we see a big memory improvement.

## Before
```
└─▪ test/benchmark.rb
...
                                     user     system      total        real
axlsx_noautowidth                0.867313   0.008313   0.875626 (  0.875865)
axlsx_autowidth                  0.876432   0.007991   0.884423 (  0.884517)
axlsx_shared                     0.894653   0.006771   0.901424 (  0.901884)
axlsx_stream                     0.855583   0.006311   0.861894 (  0.861848)
axlsx_zip_command                0.796771   0.014845   0.861473 (  0.861263)
csv                              0.073763   0.008125   0.081888 (  0.081932)

└─▪ test/profile_memory.rb 
Total allocated: 323260989 bytes (4324555 objects)
```

## After
```
└─▪ test/benchmark.rb
...
                                     user     system      total        real
axlsx_noautowidth                0.865833   0.003750   0.869583 (  0.869780)
axlsx_autowidth                  0.869049   0.003531   0.872580 (  0.872825)
axlsx_shared                     0.892705   0.003378   0.896083 (  0.896287)
axlsx_stream                     0.864130   0.002888   0.867018 (  0.867100)
axlsx_zip_command                0.833567   0.023216   0.906570 (  0.907370)
csv                              0.076694   0.008957   0.085651 (  0.086380)

└─▪ test/profile_memory.rb 
Total allocated: 196992310 bytes (3914412 objects)
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).