### PR TITLE
SimpleTypedList subclass of Array

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -91,7 +91,6 @@ Lint/UselessAssignment:
 Lint/Void:
   Exclude:
     - 'lib/axlsx/drawing/title.rb'
-    - 'lib/axlsx/util/simple_typed_list.rb'
     - 'lib/axlsx/util/storage.rb'
     - 'lib/axlsx/workbook/worksheet/data_bar.rb'
     - 'lib/axlsx/workbook/worksheet/pivot_table.rb'
@@ -215,10 +214,6 @@ Style/ConditionalAssignment:
     - 'lib/axlsx/stylesheet/styles.rb'
     - 'lib/axlsx/workbook/workbook.rb'
     - 'lib/axlsx/workbook/worksheet/data_bar.rb'
-
-Style/DocumentDynamicEvalDefinition:
-  Exclude:
-    - 'lib/axlsx/util/simple_typed_list.rb'
 
 # Configuration parameters: AllowedConstants.
 Style/Documentation:
@@ -350,7 +345,6 @@ Style/MutableConstant:
     - 'lib/axlsx/drawing/pic.rb'
     - 'lib/axlsx/drawing/view_3D.rb'
     - 'lib/axlsx/stylesheet/dxf.rb'
-    - 'lib/axlsx/util/simple_typed_list.rb'
     - 'lib/axlsx/util/storage.rb'
     - 'lib/axlsx/workbook/worksheet/auto_filter/filter_column.rb'
     - 'lib/axlsx/workbook/worksheet/auto_filter/filters.rb'
@@ -395,7 +389,6 @@ Style/NumericPredicate:
     - 'spec/**/*'
     - 'lib/axlsx/package.rb'
     - 'lib/axlsx/stylesheet/font.rb'
-    - 'lib/axlsx/util/simple_typed_list.rb'
     - 'lib/axlsx/util/validators.rb'
     - 'lib/axlsx/workbook/workbook.rb'
     - 'lib/axlsx/workbook/worksheet/cell.rb'
@@ -596,7 +589,6 @@ Style/SlicingWithRange:
     - 'lib/axlsx.rb'
     - 'lib/axlsx/drawing/area_chart.rb'
     - 'lib/axlsx/drawing/line_chart.rb'
-    - 'lib/axlsx/util/simple_typed_list.rb'
     - 'lib/axlsx/workbook/worksheet/pivot_table.rb'
     - 'lib/axlsx/workbook/worksheet/worksheet.rb'
 
@@ -698,7 +690,6 @@ Style/YodaCondition:
 Style/ZeroLengthPredicate:
   Exclude:
     - 'lib/axlsx/package.rb'
-    - 'lib/axlsx/util/simple_typed_list.rb'
     - 'lib/axlsx/workbook/workbook.rb'
     - 'lib/axlsx/workbook/worksheet/sheet_pr.rb'
 
@@ -706,4 +697,4 @@ Style/ZeroLengthPredicate:
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns.
 # URISchemes: http, https
 Layout/LineLength:
-  Max: 574
+  Max: 559

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 - **Unreleased**: 4.0.0
   - Drop support for Ruby versions < 2.6
   - Added frozen string literals
+  - Fix `SimpleTypedList#to_a` and `SimpleTypedList#to_ary` returning the internal list instance
 
 - **April.23.23**: 3.4.1
   - [PR #209](https://github.com/caxlsx/caxlsx/pull/209) - Revert characters other than `=` being considered as formulas.

--- a/lib/axlsx/util/simple_typed_list.rb
+++ b/lib/axlsx/util/simple_typed_list.rb
@@ -3,12 +3,25 @@
 module Axlsx
   # A SimpleTypedList is a type restrictive collection that allows some of the methods from Array and supports basic xml serialization.
   # @private
-  class SimpleTypedList
+  class SimpleTypedList < Array
+    DESTRUCTIVE = [
+      'replace', 'insert', 'collect!', 'map!', 'pop', 'delete_if',
+      'reverse!', 'shift', 'shuffle!', 'slice!', 'sort!', 'uniq!',
+      'unshift', 'zip', 'flatten!', 'fill', 'drop', 'drop_while',
+      'clear'
+    ].freeze
+
+    DESTRUCTIVE.each do |name|
+      undef_method name
+    end
+
     # Creats a new typed list
     # @param [Array, Class] type An array of Class objects or a single Class object
     # @param [String] serialize_as The tag name to use in serialization
     # @raise [ArgumentError] if all members of type are not Class objects
     def initialize(type, serialize_as = nil, start_size = 0)
+      super(start_size)
+
       if type.is_a? Array
         type.each { |item| raise ArgumentError, "All members of type must be Class objects" unless item.is_a? Class }
         @allowed_types = type
@@ -18,7 +31,6 @@ module Axlsx
         @allowed_types = [type]
       end
       @serialize_as = serialize_as unless serialize_as.nil?
-      @list = Array.new(start_size)
     end
 
     # The class constants of allowed types
@@ -39,16 +51,16 @@ module Axlsx
     # Transposes the list (without blowing up like ruby does)
     # any non populated cell in the matrix will be a nil value
     def transpose
-      return @list.clone if @list.size == 0
+      return clone if size.zero?
 
-      row_count = @list.size
-      max_column_count = @list.map { |row| row.cells.size }.max
+      row_count = size
+      max_column_count = map { |row| row.cells.size }.max
       result = Array.new(max_column_count) { Array.new(row_count) }
       # yes, I know it is silly, but that warning is really annoying
       row_count.times do |row_index|
         max_column_count.times do |column_index|
-          datum = if @list[row_index].cells.size >= max_column_count
-                    @list[row_index].cells[column_index]
+          datum = if self[row_index].cells.size >= max_column_count
+                    self[row_index].cells[column_index]
                   elsif block_given?
                     yield(column_index, row_index)
                   end
@@ -61,7 +73,7 @@ module Axlsx
     # Lock this list at the current size
     # @return [self]
     def lock
-      @locked_at = @list.size
+      @locked_at = size
       self
     end
 
@@ -85,9 +97,9 @@ module Axlsx
     # @return [SimpleTypedList]
     def +(v)
       v.each do |item|
-        DataTypeValidator.validate :SimpleTypedList_plus, @allowed_types, item
-        @list << item
+        self << item
       end
+      super
     end
 
     # Concat operator
@@ -96,8 +108,8 @@ module Axlsx
     # @return [Integer] returns the index of the item added.
     def <<(v)
       DataTypeValidator.validate :SimpleTypedList_push, @allowed_types, v
-      @list << v
-      @list.size - 1
+      super
+      size - 1
     end
 
     alias :push :<<
@@ -110,17 +122,16 @@ module Axlsx
       return unless include? v
       raise ArgumentError, "Item is protected and cannot be deleted" if protected? index(v)
 
-      @list.delete v
+      super
     end
 
     # delete the item from the list at the index position provided
     # @raise [ArgumentError] if the index is protected by locking
     # @return [Any] The item deleted
     def delete_at(index)
-      @list[index]
       raise ArgumentError, "Item is protected and cannot be deleted" if protected? index
 
-      @list.delete_at index
+      super
     end
 
     # positional assignment. Adds the item at the index specified
@@ -128,12 +139,12 @@ module Axlsx
     # @param [Any] v
     # @raise [ArgumentError] if the index is protected by locking
     # @raise [ArgumentError] if the item is not one of the allowed types
+    # @return [Any] The item added
     def []=(index, v)
       DataTypeValidator.validate :SimpleTypedList_insert, @allowed_types, v
       raise ArgumentError, "Item is protected and cannot be changed" if protected? index
 
-      @list[index] = v
-      v
+      super
     end
 
     # inserts an item at the index specfied
@@ -141,11 +152,12 @@ module Axlsx
     # @param [Any] v
     # @raise [ArgumentError] if the index is protected by locking
     # @raise [ArgumentError] if the index is not one of the allowed types
+    # @return [Any] The item inserted
     def insert(index, v)
       DataTypeValidator.validate :SimpleTypedList_insert, @allowed_types, v
       raise ArgumentError, "Item is protected and cannot be changed" if protected? index
 
-      @list.insert(index, v)
+      super
       v
     end
 
@@ -157,23 +169,9 @@ module Axlsx
       index < locked_at
     end
 
-    DESTRUCTIVE = ['replace', 'insert', 'collect!', 'map!', 'pop', 'delete_if',
-                   'reverse!', 'shift', 'shuffle!', 'slice!', 'sort!', 'uniq!',
-                   'unshift', 'zip', 'flatten!', 'fill', 'drop', 'drop_while',
-                   'delete_if', 'clear']
-    DELEGATES = Array.instance_methods - self.instance_methods - DESTRUCTIVE
-
-    DELEGATES.each do |method|
-      class_eval %{
-        def #{method}(*args, &block)
-          @list.send(:#{method}, *args, &block)
-        end
-      }, __FILE__, __LINE__ - 4
-    end
-
     def to_xml_string(str = +'')
       classname = @allowed_types[0].name.split('::').last
-      el_name = serialize_as.to_s || (classname[0, 1].downcase + classname[1..-1])
+      el_name = serialize_as.to_s || (classname[0, 1].downcase + classname[1..])
       str << '<' << el_name << ' count="' << size.to_s << '">'
       each { |item| item.to_xml_string(str) }
       str << '</' << el_name << '>'

--- a/lib/axlsx/util/simple_typed_list.rb
+++ b/lib/axlsx/util/simple_typed_list.rb
@@ -84,12 +84,6 @@ module Axlsx
       self
     end
 
-    def to_ary
-      @list
-    end
-
-    alias :to_a :to_ary
-
     # join operator
     # @param [Array] v the array to join
     # @raise [ArgumentError] if any of the values being joined are not

--- a/test/util/tc_simple_typed_list.rb
+++ b/test/util/tc_simple_typed_list.rb
@@ -58,6 +58,9 @@ class TestSimpleTypedList < Test::Unit::TestCase
     assert_raise(ArgumentError) { @list.delete 1  }
     assert_raise(ArgumentError) { @list.delete_at 1 }
     assert_raise(ArgumentError) { @list.delete_at 2 }
+    assert_raise(ArgumentError) { @list.insert(1, 3) }
+    assert_raise(ArgumentError) { @list[1] = 3 }
+
     @list.push 4
     assert_nothing_raised { @list.delete_at 3 }
     @list.unlock
@@ -80,5 +83,25 @@ class TestSimpleTypedList < Test::Unit::TestCase
     @list.push 2
 
     assert_equal([1, 2], @list.to_ary)
+  end
+
+  def test_insert
+    assert_raise(ArgumentError) { @list << nil }
+
+    assert_equal(1, @list.insert(0, 1))
+    assert_equal(2, @list.insert(1, 2))
+    assert_equal(3, @list.insert(0, 3))
+
+    assert_equal([3, 1, 2], @list)
+  end
+
+  def test_setter
+    assert_raise(ArgumentError) { @list[0] = nil }
+
+    assert_equal(1, @list[0] = 1)
+    assert_equal(2, @list[1] = 2)
+    assert_equal(3, @list[0] = 3)
+
+    assert_equal([3, 2], @list)
   end
 end

--- a/test/util/tc_simple_typed_list.rb
+++ b/test/util/tc_simple_typed_list.rb
@@ -82,7 +82,16 @@ class TestSimpleTypedList < Test::Unit::TestCase
     @list.push 1
     @list.push 2
 
-    assert_equal([1, 2], @list.to_ary)
+    assert_equal([1, 2], @list)
+  end
+
+  def test_to_a
+    refute_equal(@list.object_id, @list.to_a.object_id)
+    assert_instance_of(Array, @list.to_a)
+  end
+
+  def test_to_ary
+    assert_equal(@list.object_id, @list.to_ary.object_id)
   end
 
   def test_insert


### PR DESCRIPTION
### Description
This PR is a follow-up to https://github.com/caxlsx/caxlsx/pull/213 and includes the commits related to having SimpleTypedList subclass Array.

The following are some quick numbers on Ruby 3.1.3 on my MacBook. The main point is that performance is bit faster and memory is quite a bit less. I do not fully understand why the previous approach of class_eval and delegating was so much more memory intensive.

Used the benchmark / memory profiler from https://github.com/caxlsx/caxlsx/pull/220/commits/1c355c83a9603f835dfe59ef4473df2b8cc3534c.

## Before
```
└─▪ test/benchmark.rb
...
                                     user     system      total        real
axlsx_noautowidth                0.896363   0.007475   0.903838 (  0.904204)
axlsx_autowidth                  0.939241   0.008933   0.948174 (  0.948764)
axlsx_shared                     0.880671   0.006855   0.887526 (  0.887798)
axlsx_stream                     0.899906   0.007002   0.906908 (  0.906970)
axlsx_zip_command                0.798402   0.016269   0.869353 (  0.869569)
csv                              0.076229   0.007790   0.084019 (  0.086200)

└─▪ test/profile_memory.rb
Total allocated: 323260989 bytes (4324555 objects)
```

## After

```
└─▪ test/benchmark.rb
...
                                     user     system      total        real
axlsx_noautowidth                0.845286   0.008978   0.854264 (  0.854391)
axlsx_autowidth                  0.880355   0.007838   0.888193 (  0.888505)
axlsx_shared                     0.871679   0.007646   0.879325 (  0.879488)
axlsx_stream                     0.860668   0.006819   0.867487 (  0.867364)
axlsx_zip_command                0.764416   0.016046   0.828939 (  0.829377)
csv                              0.078395   0.008152   0.086547 (  0.087438)

└─▪ test/profile_memory.rb
Total allocated: 256291309 bytes (2644313 objects)
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).