### PR TITLE
Improve escape formulas

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -58,7 +58,6 @@ Lint/DisjunctiveAssignmentInConstructor:
 # Configuration parameters: IgnoreLiteralBranches, IgnoreConstantBranches.
 Lint/DuplicateBranch:
   Exclude:
-    - 'lib/axlsx/workbook/worksheet/cell.rb'
     - 'lib/axlsx/workbook/worksheet/merged_cells.rb'
 
 Lint/NonLocalExitFromIterator:
@@ -133,7 +132,6 @@ Performance/RegexpMatch:
   Exclude:
     - 'lib/axlsx/stylesheet/color.rb'
     - 'lib/axlsx/workbook/workbook.rb'
-    - 'lib/axlsx/workbook/worksheet/cell.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
 Performance/StringIdentifierArgument:
@@ -323,7 +321,6 @@ Style/MultipleComparison:
   Exclude:
     - 'lib/axlsx.rb'
     - 'lib/axlsx/stylesheet/font.rb'
-    - 'lib/axlsx/workbook/worksheet/cell.rb'
     - 'lib/axlsx/workbook/worksheet/rich_text_run.rb'
     - 'test/workbook/tc_workbook_view.rb'
 
@@ -383,7 +380,6 @@ Style/NumericPredicate:
     - 'lib/axlsx/stylesheet/font.rb'
     - 'lib/axlsx/util/validators.rb'
     - 'lib/axlsx/workbook/workbook.rb'
-    - 'lib/axlsx/workbook/worksheet/cell.rb'
     - 'lib/axlsx/workbook/worksheet/sheet_pr.rb'
     - 'lib/axlsx/workbook/worksheet/worksheet.rb'
 
@@ -425,7 +421,6 @@ Style/ParenthesesAroundCondition:
   Exclude:
     - 'lib/axlsx/stylesheet/font.rb'
     - 'lib/axlsx/util/validators.rb'
-    - 'lib/axlsx/workbook/worksheet/cell.rb'
     - 'lib/axlsx/workbook/worksheet/rich_text_run.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
@@ -546,13 +541,6 @@ Style/RedundantSelf:
   Enabled: false
 
 # This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, AllowInnerSlashes.
-# SupportedStyles: slashes, percent_r, mixed
-Style/RegexpLiteral:
-  Exclude:
-    - 'lib/axlsx/workbook/worksheet/cell.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: implicit, explicit
 Style/RescueStandardError:
@@ -620,7 +608,6 @@ Style/SymbolProc:
     - 'lib/axlsx/drawing/drawing.rb'
     - 'lib/axlsx/stylesheet/styles.rb'
     - 'lib/axlsx/workbook/workbook.rb'
-    - 'lib/axlsx/workbook/worksheet/cell.rb'
     - 'lib/axlsx/workbook/worksheet/worksheet.rb'
     - 'lib/axlsx/workbook/worksheet/worksheet_hyperlinks.rb'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
   - Drop support for Ruby versions < 2.6
   - Added frozen string literals
   - Fix `SimpleTypedList#to_a` and `SimpleTypedList#to_ary` returning the internal list instance
+  - Remove ability to set `u=` to true in favor of using :single or one of the other underline options
 
 - **April.23.23**: 3.4.1
   - [PR #209](https://github.com/caxlsx/caxlsx/pull/209) - Revert characters other than `=` being considered as formulas.

--- a/lib/axlsx/util/validators.rb
+++ b/lib/axlsx/util/validators.rb
@@ -106,8 +106,10 @@ module Axlsx
     DataTypeValidator.validate :signed_int, Integer, v
   end
 
-  VALID_BOOLEAN_CLASSES = [String, Integer, Symbol, TrueClass, FalseClass].freeze
-  VALID_BOOLEAN_VALUES = [0, 1, 'true', 'false', :true, :false, true, false, '0', '1'].freeze
+  VALID_BOOLEAN_CLASSES = [TrueClass, FalseClass, Integer, String, Symbol].freeze
+  VALID_BOOLEAN_TRUE_VALUES = [true, 1, '1', 'true', :true].freeze
+  VALID_BOOLEAN_FALSE_VALUES = [false, 0, '0', 'false', :false].freeze
+  VALID_BOOLEAN_VALUES = VALID_BOOLEAN_TRUE_VALUES.zip(VALID_BOOLEAN_FALSE_VALUES).flatten.freeze
   BOOLEAN_VALIDATOR = lambda { |arg| VALID_BOOLEAN_VALUES.include?(arg) }
 
   # Requires that the value is a form that can be evaluated as a boolean in an xml document.

--- a/lib/axlsx/util/validators.rb
+++ b/lib/axlsx/util/validators.rb
@@ -107,9 +107,7 @@ module Axlsx
   end
 
   VALID_BOOLEAN_CLASSES = [TrueClass, FalseClass, Integer, String, Symbol].freeze
-  VALID_BOOLEAN_TRUE_VALUES = [true, 1, '1', 'true', :true].freeze
-  VALID_BOOLEAN_FALSE_VALUES = [false, 0, '0', 'false', :false].freeze
-  VALID_BOOLEAN_VALUES = VALID_BOOLEAN_TRUE_VALUES.zip(VALID_BOOLEAN_FALSE_VALUES).flatten.freeze
+  VALID_BOOLEAN_VALUES = [true, false, 1, 0, '1', '0', 'true', 'false', :true, :false].freeze
   BOOLEAN_VALIDATOR = lambda { |arg| VALID_BOOLEAN_VALUES.include?(arg) }
 
   # Requires that the value is a form that can be evaluated as a boolean in an xml document.

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -511,7 +511,7 @@ module Axlsx
         :boolean
       elsif v.respond_to?(:to_i) && v.to_s =~ Axlsx::NUMERIC_REGEX
         :integer
-      elsif v.respond_to?(:to_f) && (v.to_s =~ Axlsx::SAFE_FLOAT_REGEX || ((matchdata = v.to_s.match(MAYBE_FLOAT_REGEX)) && (Float::MIN_10_EXP..Float::MAX_10_EXP).cover?(matchdata[:exp].to_i)))
+      elsif v.respond_to?(:to_f) && (v.to_s =~ Axlsx::SAFE_FLOAT_REGEX || ((matchdata = v.to_s.match(MAYBE_FLOAT_REGEX)) && matchdata[:exp].to_i.between?(Float::MIN_10_EXP, Float::MAX_10_EXP)))
         :float
       elsif Axlsx::ISO_8601_REGEX.match?(v.to_s)
         :iso_8601

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -285,15 +285,13 @@ module Axlsx
     def extend=(v) set_run_style :validate_boolean, :extend, v; end
 
     # The inline underline property for the cell.
-    # It must be one of :none, :single, :double, :singleAccounting, :doubleAccounting, true
+    # It must be one of :none, :single, :double, :singleAccounting, :doubleAccounting
     # @return [Boolean]
     # @return [String]
-    # @note true is for backwards compatability and is reassigned to :single
     attr_reader :u
 
     # @see u
     def u=(v)
-      v = :single if VALID_BOOLEAN_TRUE_VALUES.include?(v)
       set_run_style :validate_cell_u, :u, v
     end
 

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -45,9 +45,10 @@ module Axlsx
       self.style = val unless val.nil? || val == 0
       val = options.delete(:formula_value)
       self.formula_value = val unless val.nil?
+      val = options.delete(:escape_formulas)
+      self.escape_formulas = val.nil? ? row.worksheet.escape_formulas : val
 
       parse_options(options)
-      self.escape_formulas = row.worksheet.escape_formulas if escape_formulas.nil?
 
       self.value = value
       value.cell = self if contains_rich_text?

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -46,7 +46,7 @@ module Axlsx
       val = options.delete(:formula_value)
       self.formula_value = val unless val.nil?
       val = options.delete(:escape_formulas)
-      self.escape_formulas = val.nil? ? row.worksheet.escape_formulas : val
+      self.escape_formulas = val unless val.nil?
 
       parse_options(options)
 
@@ -146,7 +146,9 @@ module Axlsx
     # Allowing user-generated data to be interpreted as formulas is a security risk.
     # See https://www.owasp.org/index.php/CSV_Injection for details.
     # @return [Boolean]
-    attr_reader :escape_formulas
+    def escape_formulas
+      defined?(@escape_formulas) ? @escape_formulas : row.worksheet.escape_formulas
+    end
 
     # Sets whether to treat values starting with an equals sign as formulas or as literal strings.
     # @param [Boolean] value The value to set.

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -42,7 +42,7 @@ module Axlsx
       self.type = type unless type == :string
 
       val = options.delete(:style)
-      self.style = val unless val.nil? || val == 0
+      self.style = val unless val.nil? || val.zero?
       val = options.delete(:formula_value)
       self.formula_value = val unless val.nil?
       val = options.delete(:escape_formulas)
@@ -291,7 +291,7 @@ module Axlsx
 
     # @see u
     def u=(v)
-      v = :single if (v == true || v == 1 || v == :true || v == 'true')
+      v = :single if [true, 1, :true, 'true'].include?(v)
       set_run_style :validate_cell_u, :u, v
     end
 
@@ -354,7 +354,7 @@ module Axlsx
     # @example Absolute Cell Reference
     #   ws.rows.first.cells.first.r #=> "$A$1"
     def r_abs
-      "$#{r.match(%r{([A-Z]+)([0-9]+)})[1, 2].join('$')}"
+      "$#{r.match(/([A-Z]+)([0-9]+)/)[1, 2].join('$')}"
     end
 
     # @return [Integer] The cellXfs item index applied to this cell.
@@ -379,7 +379,7 @@ module Axlsx
       start, stop = if target.is_a?(String)
                       [self.r, target]
                     elsif target.is_a?(Cell)
-                      Axlsx.sort_cells([self, target]).map { |c| c.r }
+                      Axlsx.sort_cells([self, target]).map(&:r)
                     end
       self.row.worksheet.merge_cells "#{start}:#{stop}" unless stop.nil?
     end
@@ -509,13 +509,11 @@ module Axlsx
         :time
       elsif v.is_a?(TrueClass) || v.is_a?(FalseClass)
         :boolean
-      elsif v.to_s =~ Axlsx::NUMERIC_REGEX && v.respond_to?(:to_i)
+      elsif v.respond_to?(:to_i) && v.to_s =~ Axlsx::NUMERIC_REGEX
         :integer
-      elsif v.to_s =~ Axlsx::SAFE_FLOAT_REGEX && v.respond_to?(:to_f)
+      elsif v.respond_to?(:to_f) && (v.to_s =~ Axlsx::SAFE_FLOAT_REGEX || ((matchdata = v.to_s.match(MAYBE_FLOAT_REGEX)) && (Float::MIN_10_EXP..Float::MAX_10_EXP).cover?(matchdata[:exp].to_i)))
         :float
-      elsif (matchdata = v.to_s.match(MAYBE_FLOAT_REGEX)) && (Float::MIN_10_EXP..Float::MAX_10_EXP).cover?(matchdata[:exp].to_i) && v.respond_to?(:to_f)
-        :float
-      elsif v.to_s =~ Axlsx::ISO_8601_REGEX
+      elsif Axlsx::ISO_8601_REGEX.match?(v.to_s)
         :iso_8601
       elsif v.is_a? RichText
         :richtext
@@ -533,14 +531,14 @@ module Axlsx
 
       case type
       when :date
-        self.style = STYLE_DATE if self.style == 0
+        self.style = STYLE_DATE if self.style.zero?
         if !v.is_a?(Date) && v.respond_to?(:to_date)
           v.to_date
         else
           v
         end
       when :time
-        self.style = STYLE_DATE if self.style == 0
+        self.style = STYLE_DATE if self.style.zero?
         if !v.is_a?(Time) && v.respond_to?(:to_time)
           v.to_time
         else

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -291,7 +291,7 @@ module Axlsx
 
     # @see u
     def u=(v)
-      v = :single if [true, 1, :true, 'true'].include?(v)
+      v = :single if VALID_BOOLEAN_TRUE_VALUES.include?(v)
       set_run_style :validate_cell_u, :u, v
     end
 

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -429,7 +429,6 @@ module Axlsx
     #    Allowing user generated data to be interpreted as formulas can be dangerous
     #   (see https://www.owasp.org/index.php/CSV_Injection for details).
     def add_row(values = [], options = {})
-      options[:escape_formulas] = escape_formulas if options[:escape_formulas].nil?
       row = Row.new(self, values, options)
       update_column_info row, options.delete(:widths)
       yield row if block_given?

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -567,7 +567,7 @@ class TestCell < Test::Unit::TestCase
   def test_to_xml
     # TODO: This could use some much more stringent testing related to the xml content generated!
     @ws.add_row [Time.now, Date.today, true, 1, 1.0, "text", "=sum(A1:A2)", "2013-01-13T13:31:25.123"]
-    @ws.rows.last.cells[5].u = true
+    @ws.rows.last.cells[5].u = :single
 
     schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
     doc = Nokogiri::XML(@ws.to_xml_string)


### PR DESCRIPTION
# Description
Treat escape_formulas similar to type, style, formula_value in Axlsx::Cell. This avoid parse_options doing anything and setting `escape_formulas` in the common case  which can be expensive f it happens for each cell.

Also took the opportunity to fix rubocop offenses in cell.rb.    

# Benchmarks

Here are some quick benchmarks on Ruby 3.1.3 on my macbook. Notice the perf improvements and memory reduction.

## Before
```
└─▪ test/benchmark.rb 
...
                                     user     system      total        real
axlsx_noautowidth                0.926718   0.003697   0.930415 (  0.930809)
axlsx_autowidth                  0.895991   0.003213   0.899204 (  0.899484)
axlsx_shared                     0.843739   0.002358   0.846097 (  0.846468)
axlsx_stream                     0.848358   0.002555   0.850913 (  0.850882)
axlsx_zip_command                0.769339   0.021957   0.840977 (  0.842261)
csv                              0.072973   0.008301   0.081274 (  0.081322)

└─▪ test/profile_memory.rb 
Total allocated: 156983678 bytes (3314372 objects)
```
# After
```
└─▪ test/benchmark.rb 
...
                                     user     system      total        real
axlsx_noautowidth                0.829864   0.003496   0.833360 (  0.833703)
axlsx_autowidth                  0.770486   0.002469   0.772955 (  0.773007)
axlsx_shared                     0.795521   0.002633   0.798154 (  0.798300)
axlsx_stream                     0.798489   0.002096   0.800585 (  0.800483)
axlsx_zip_command                0.713900   0.021538   0.785212 (  0.786637)
csv                              0.070823   0.007912   0.078735 (  0.078735)

└─▪ test/profile_memory.rb 
Total allocated: 148984014 bytes (3114372 objects)
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).