### PR TITLE
Cache `col_ref` and `row_ref`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,6 @@ Layout/FirstHashElementIndentation:
 Layout/HashAlignment:
   Exclude:
     - 'lib/axlsx/workbook/worksheet/border_creator.rb'
-    - 'test/tc_axlsx.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
 Lint/AmbiguousOperatorPrecedence:
@@ -69,7 +68,6 @@ Lint/NonLocalExitFromIterator:
 # Configuration parameters: IgnoreEmptyBlocks, AllowUnusedKeywordArguments.
 Lint/UnusedBlockArgument:
   Exclude:
-    - 'lib/axlsx.rb'
     - 'lib/axlsx/drawing/axes.rb'
     - 'lib/axlsx/workbook/worksheet/pivot_table.rb'
     - 'lib/axlsx/workbook/worksheet/sheet_view.rb'
@@ -119,7 +117,6 @@ Performance/RedundantBlockCall:
 # This cop supports safe autocorrection (--autocorrect).
 Performance/RedundantMatch:
   Exclude:
-    - 'lib/axlsx.rb'
     - 'lib/axlsx/stylesheet/color.rb'
     - 'lib/axlsx/workbook/workbook.rb'
 
@@ -266,7 +263,6 @@ Style/GuardClause:
 # Configuration parameters: AllowSplatArgument.
 Style/HashConversion:
   Exclude:
-    - 'lib/axlsx.rb'
     - 'lib/axlsx/workbook/worksheet/cell_serializer.rb'
     - 'lib/axlsx/workbook/worksheet/rich_text_run.rb'
 
@@ -321,7 +317,6 @@ Style/LineEndConcatenation:
 # Configuration parameters: AllowMethodComparison.
 Style/MultipleComparison:
   Exclude:
-    - 'lib/axlsx.rb'
     - 'lib/axlsx/stylesheet/font.rb'
     - 'lib/axlsx/workbook/worksheet/cell.rb'
     - 'lib/axlsx/workbook/worksheet/rich_text_run.rb'
@@ -449,7 +444,6 @@ Style/PercentLiteralDelimiters:
 # This cop supports safe autocorrection (--autocorrect).
 Style/PerlBackrefs:
   Exclude:
-    - 'lib/axlsx.rb'
     - 'test/workbook/worksheet/tc_sheet_protection.rb'
 
 # This cop supports unsafe autocorrection (--autocorrect-all).
@@ -471,7 +465,6 @@ Style/QuotedSymbols:
 # SupportedStyles: compact, exploded
 Style/RaiseArgs:
   Exclude:
-    - 'lib/axlsx.rb'
     - 'lib/axlsx/package.rb'
     - 'lib/axlsx/util/zip_command.rb'
     - 'lib/axlsx/workbook/worksheet/border_creator.rb'
@@ -490,7 +483,6 @@ Style/RedundantCondition:
 # This cop supports safe autocorrection (--autocorrect).
 Style/RedundantFileExtensionInRequire:
   Exclude:
-    - 'lib/axlsx.rb'
     - 'lib/axlsx/content_type/content_type.rb'
     - 'lib/axlsx/drawing/drawing.rb'
     - 'lib/axlsx/rels/relationships.rb'
@@ -528,7 +520,6 @@ Style/RedundantParentheses:
 # This cop supports safe autocorrection (--autocorrect).
 Style/RedundantRegexpEscape:
   Exclude:
-    - 'lib/axlsx.rb'
     - 'lib/axlsx/workbook/worksheet/pivot_table.rb'
     - 'lib/axlsx/workbook/worksheet/table.rb'
 
@@ -536,7 +527,6 @@ Style/RedundantRegexpEscape:
 # Configuration parameters: AllowMultipleReturnValues.
 Style/RedundantReturn:
   Exclude:
-    - 'lib/axlsx.rb'
     - 'lib/axlsx/package.rb'
     - 'lib/axlsx/stylesheet/styles.rb'
     - 'lib/axlsx/workbook/worksheet/worksheet.rb'
@@ -551,13 +541,6 @@ Style/RedundantSelf:
 Style/RegexpLiteral:
   Exclude:
     - 'lib/axlsx/workbook/worksheet/cell.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: implicit, explicit
-Style/RescueStandardError:
-  Exclude:
-    - 'lib/axlsx.rb'
 
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: ConvertCodeThatCanStartToReturnNil, AllowedMethods, MaxChainLength.
@@ -578,7 +561,6 @@ Style/SingleLineMethods:
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/SlicingWithRange:
   Exclude:
-    - 'lib/axlsx.rb'
     - 'lib/axlsx/drawing/area_chart.rb'
     - 'lib/axlsx/drawing/line_chart.rb'
     - 'lib/axlsx/workbook/worksheet/pivot_table.rb'
@@ -654,11 +636,6 @@ Style/TrivialAccessors:
 Style/UnpackFirst:
   Exclude:
     - 'lib/axlsx/workbook/worksheet/sheet_protection.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-Style/WhileUntilDo:
-  Exclude:
-    - 'lib/axlsx.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
 Style/WhileUntilModifier:

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -1,29 +1,29 @@
 # frozen_string_literal: true
 
 require 'htmlentities'
-require 'axlsx/version.rb'
+require 'axlsx/version'
 require 'marcel'
 
-require 'axlsx/util/simple_typed_list.rb'
-require 'axlsx/util/constants.rb'
-require 'axlsx/util/validators.rb'
-require 'axlsx/util/accessors.rb'
+require 'axlsx/util/simple_typed_list'
+require 'axlsx/util/constants'
+require 'axlsx/util/validators'
+require 'axlsx/util/accessors'
 require 'axlsx/util/serialized_attributes'
 require 'axlsx/util/options_parser'
 require 'axlsx/util/mime_type_utils'
 require 'axlsx/util/buffered_zip_output_stream'
 require 'axlsx/util/zip_command'
 
-require 'axlsx/stylesheet/styles.rb'
+require 'axlsx/stylesheet/styles'
 
-require 'axlsx/doc_props/app.rb'
-require 'axlsx/doc_props/core.rb'
-require 'axlsx/content_type/content_type.rb'
-require 'axlsx/rels/relationships.rb'
+require 'axlsx/doc_props/app'
+require 'axlsx/doc_props/core'
+require 'axlsx/content_type/content_type'
+require 'axlsx/rels/relationships'
 
-require 'axlsx/drawing/drawing.rb'
-require 'axlsx/workbook/workbook.rb'
-require 'axlsx/package.rb'
+require 'axlsx/drawing/drawing'
+require 'axlsx/workbook/workbook'
+require 'axlsx/package'
 # required gems
 require 'nokogiri'
 require 'zip'
@@ -35,9 +35,9 @@ require 'time'
 
 begin
   if Gem.loaded_specs.has_key?("axlsx_styler")
-    raise StandardError.new("Please remove `axlsx_styler` from your Gemfile, the associated functionality is now built-in to `caxlsx` directly.")
+    raise StandardError, "Please remove `axlsx_styler` from your Gemfile, the associated functionality is now built-in to `caxlsx` directly."
   end
-rescue
+rescue StandardError
   # Do nothing
 end
 
@@ -53,7 +53,7 @@ module Axlsx
   #
   # Defining as a class method on Axlsx to refrain from monkeypatching Object for all users of this gem.
   def self.instance_values_for(object)
-    Hash[object.instance_variables.map { |name| [name.to_s[1..-1], object.instance_variable_get(name)] }]
+    object.instance_variables.to_h { |name| [name.to_s[1..], object.instance_variable_get(name)] }
   end
 
   # determines the cell range for the items provided
@@ -105,7 +105,7 @@ module Axlsx
 
     row_index = (numbers_str.to_i - 1)
 
-    return [col_index, row_index]
+    [col_index, row_index]
   end
 
   # converts the column index into alphabetical values.
@@ -147,9 +147,9 @@ module Axlsx
   # @param [String] range A cell range, for example A1:D5
   # @return [Array]
   def self.range_to_a(range)
-    range.match(/^(\w+?\d+)\:(\w+?\d+)$/)
-    start_col, start_row = name_to_indices($1)
-    end_col,   end_row   = name_to_indices($2)
+    range =~ /^(\w+?\d+):(\w+?\d+)$/
+    start_col, start_row = name_to_indices(::Regexp.last_match(1))
+    end_col,   end_row   = name_to_indices(::Regexp.last_match(2))
     (start_row..end_row).to_a.map do |row_num|
       (start_col..end_col).to_a.map do |col_num|
         cell_r(col_num, row_num)
@@ -163,7 +163,7 @@ module Axlsx
   def self.camel(s = "", all_caps = true)
     s = s.to_s
     s = s.capitalize if all_caps
-    s.gsub(/_(.)/) { $1.upcase }
+    s.gsub(/_(.)/) { ::Regexp.last_match(1).upcase }
   end
 
   # returns the provided string with all invalid control charaters
@@ -184,7 +184,7 @@ module Axlsx
   # @param [Object] value The value to process
   # @return [Object]
   def self.booleanize(value)
-    if value == true || value == false
+    if BOOLEAN_VALUES.include?(value)
       value ? 1 : 0
     else
       value
@@ -195,7 +195,7 @@ module Axlsx
   # @param [Hash] Hash to merge into
   # @param [Hash] Hash to be added
   def self.hash_deep_merge(first_hash, second_hash)
-    first_hash.merge(second_hash) do |key, this_val, other_val|
+    first_hash.merge(second_hash) do |_key, this_val, other_val|
       if this_val.is_a?(Hash) && other_val.is_a?(Hash)
         Axlsx.hash_deep_merge(this_val, other_val)
       else

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -125,7 +125,6 @@ module Axlsx
       end
       chars.prepend((i + 65).chr)
       chars.freeze
-      chars
     end
   end
 
@@ -133,7 +132,8 @@ module Axlsx
   # @note The spreadsheet rows are 1-based and the passed in index is 0-based, so we add 1.
   # @return [String]
   def self.row_ref(index)
-    (index + 1).to_s
+    @row_ref ||= {}
+    @row_ref[index] ||= (index + 1).to_s.freeze
   end
 
   # @return [String] The alpha(column)numeric(row) reference for this sell.

--- a/lib/axlsx/util/constants.rb
+++ b/lib/axlsx/util/constants.rb
@@ -413,4 +413,6 @@ module Axlsx
 
   # Numeric recognition
   NUMERIC_REGEX = /\A[+-]?\d+?\Z/.freeze
+
+  BOOLEAN_VALUES = [true, false].freeze
 end

--- a/lib/axlsx/workbook/worksheet/cell_serializer.rb
+++ b/lib/axlsx/workbook/worksheet/cell_serializer.rb
@@ -10,7 +10,9 @@ module Axlsx
       # @param [String] str The string to apend serialization to.
       # @return [String]
       def to_xml_string(row_index, column_index, cell, str = +'')
-        str << '<c r="' << Axlsx::cell_r(column_index, row_index) << '" s="' << cell.style.to_s << '" '
+        str << '<c r="'
+        str << Axlsx::col_ref(column_index) << Axlsx::row_ref(row_index)
+        str << '" s="' << cell.style.to_s << '" '
         return str << '/>' if cell.value.nil?
 
         method = cell.type

--- a/lib/axlsx/workbook/worksheet/row.rb
+++ b/lib/axlsx/workbook/worksheet/row.rb
@@ -89,7 +89,7 @@ module Axlsx
     # @param [String] str The string this rows xml will be appended to.
     # @return [String]
     def to_xml_string(r_index, str = +'')
-      serialized_tag('row', str, :r => r_index + 1) do
+      serialized_tag('row', str, :r => Axlsx.row_ref(r_index)) do
         each_with_index { |cell, c_index| cell.to_xml_string(r_index, c_index, str) }
       end
     end

--- a/test/tc_axlsx.rb
+++ b/test/tc_axlsx.rb
@@ -83,8 +83,14 @@ class TestAxlsx < Test::Unit::TestCase
     end
   end
 
+  def test_row_ref
+    assert_equal('1', Axlsx.row_ref(0))
+    assert_equal('100', Axlsx.row_ref(99))
+  end
+
   def test_cell_r
-    # todo
+    assert_equal('A1', Axlsx.cell_r(0, 0))
+    assert_equal('Z26', Axlsx.cell_r(25, 25))
   end
 
   def test_range_to_a

--- a/test/tc_axlsx.rb
+++ b/test/tc_axlsx.rb
@@ -3,6 +3,7 @@
 require 'tc_helper'
 
 class TestAxlsx < Test::Unit::TestCase
+  # rubocop:disable Layout/HashAlignment
   def setup_wide
     @wide_test_points = {
       "A3"    =>                              0,
@@ -15,6 +16,7 @@ class TestAxlsx < Test::Unit::TestCase
       "BZU3"  => (2 * (26**2)) + (26 * 26) + 20
     }
   end
+  # rubocop:enable Layout/HashAlignment
 
   def test_cell_range_empty_if_no_cell
     assert_equal("", Axlsx.cell_range([]))


### PR DESCRIPTION
## Description
The column references are computed in `#col_ref`, but for any 
spreadsheet, the column references in each rows will be the 
same. So we can cache those and avoid small string allocations.

We can also modify `CellSerializer` to directly use `#col_ref` 
and `#row_ref`. 

Overall, we gain a perf improvement and reduction in allocated 
memory. 

# Benchmarks

The following are on Ruby 3.2.1 on my macbook.

## Before
```
└─▪ test/benchmark.rb
...
                                     user     system      total        real
axlsx_noautowidth                0.781451   0.003570   0.785021 (  0.785643)
axlsx_autowidth                  0.777843   0.003068   0.780911 (  0.781048)
axlsx_shared                     0.807382   0.003307   0.810689 (  0.811241)
axlsx_stream                     0.793688   0.003162   0.796850 (  0.797375)
axlsx_zip_command                0.700329   0.018630   0.773423 (  0.773902)
csv                              0.070879   0.005509   0.076388 (  0.076479)

└─▪ test/profile_memory.rb 
Total allocated: 171215847 bytes (3314397 objects)
```

## After
```
└─▪ test/benchmark.rb
...
                                     user     system      total        real
axlsx_noautowidth                0.736204   0.003416   0.739620 (  0.739657)
axlsx_autowidth                  0.734824   0.002832   0.737656 (  0.737725)
axlsx_shared                     0.722133   0.001917   0.724050 (  0.724042)
axlsx_stream                     0.703980   0.001778   0.705758 (  0.705631)
axlsx_zip_command                0.674138   0.021385   0.747201 (  0.748139)
csv                              0.076111   0.005816   0.081927 (  0.083902)

└─▪ test/profile_memory.rb 
Total allocated: 154813359 bytes (2904376 objects)
```
### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).