### PR TITLE
Fix Performance/StringIdentifierArgument offense

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -136,11 +136,6 @@ Performance/RegexpMatch:
     - 'lib/axlsx/workbook/worksheet/cell.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
-Performance/StringIdentifierArgument:
-  Exclude:
-    - 'lib/axlsx/drawing/pic.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: separated, grouped
 Style/AccessorGrouping:

--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -239,7 +239,7 @@ module Axlsx
     def swap_anchor(new_anchor)
       new_anchor.drawing.anchors.delete(new_anchor)
       @anchor.drawing.anchors[@anchor.drawing.anchors.index(@anchor)] = new_anchor
-      new_anchor.instance_variable_set "@object", @anchor.object
+      new_anchor.instance_variable_set :@object, @anchor.object
       @anchor = new_anchor
     end
   end


### PR DESCRIPTION
Very minor (safe) fix, because I was curious of the difference

```
Warming up --------------------------------------
          ivs_string   852.934k i/100ms
          ivs_symbol     1.323M i/100ms
Calculating -------------------------------------
          ivs_string      8.502M (± 0.2%) i/s -     42.647M in   5.016094s
          ivs_symbol     13.287M (± 0.3%) i/s -     67.461M in   5.077418s

Comparison:
          ivs_symbol: 13286595.1 i/s
          ivs_string:  8502017.1 i/s - 1.56x  (± 0.00) slower
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).