### PR TITLE
Use `include?` and `find` for performance

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -106,11 +106,6 @@ Performance/CollectionLiteralInLoop:
     - 'lib/axlsx/package.rb'
     - 'lib/axlsx/workbook/worksheet/page_margins.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Performance/Detect:
-  Exclude:
-    - 'lib/axlsx/workbook/workbook.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 Performance/RedundantBlockCall:
   Exclude:
@@ -121,7 +116,6 @@ Performance/RedundantMatch:
   Exclude:
     - 'lib/axlsx.rb'
     - 'lib/axlsx/stylesheet/color.rb'
-    - 'lib/axlsx/workbook/workbook.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
 Performance/RedundantSplitRegexpArgument:
@@ -132,7 +126,6 @@ Performance/RedundantSplitRegexpArgument:
 Performance/RegexpMatch:
   Exclude:
     - 'lib/axlsx/stylesheet/color.rb'
-    - 'lib/axlsx/workbook/workbook.rb'
     - 'lib/axlsx/workbook/worksheet/cell.rb'
 
 # This cop supports safe autocorrection (--autocorrect).

--- a/lib/axlsx/workbook/workbook.rb
+++ b/lib/axlsx/workbook/workbook.rb
@@ -395,8 +395,8 @@ module Axlsx
     # retrieve the cells from. e.g. range('Sheet1!A1:B2') will return an array of four cells [A1, A2, B1, B2] while range('Sheet1!A1') will return a single Cell.
     # @return [Cell, Array]
     def [](cell_def)
-      sheet_name = cell_def.split('!')[0] if cell_def.match('!')
-      worksheet =  self.worksheets.select { |s| s.name == sheet_name }.first
+      sheet_name = cell_def.split('!')[0] if cell_def.include?('!')
+      worksheet =  self.worksheets.find { |s| s.name == sheet_name }
       raise ArgumentError, 'Unknown Sheet' unless sheet_name && worksheet.is_a?(Worksheet)
 
       worksheet[cell_def.gsub(/.+!/, "")]


### PR DESCRIPTION
Fix a couple of performance RuboCop offenses in workbook

```
Warming up --------------------------------------
    match_and_select    59.143k i/100ms
    include_and_find   123.780k i/100ms
Calculating -------------------------------------
    match_and_select    591.904k (± 1.0%) i/s -      3.016M in   5.096401s
    include_and_find      1.238M (± 0.8%) i/s -      6.313M in   5.098961s

Comparison:
    include_and_find:  1238131.2 i/s
    match_and_select:   591904.2 i/s - 2.09x  (± 0.00) slower

Calculating -------------------------------------
    match_and_select   947.000  memsize (   499.000  retained)
                         9.000  objects (     1.000  retained)
                         3.000  strings (     0.000  retained)
    include_and_find   160.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)

Comparison:
    include_and_find:        160 allocated
    match_and_select:        947 allocated - 5.92x more
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).