### PR TITLE
Serialized attributes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -79,7 +79,6 @@ Lint/UnusedBlockArgument:
 Lint/UnusedMethodArgument:
   Exclude:
     - 'lib/axlsx/package.rb'
-    - 'lib/axlsx/util/serialized_attributes.rb'
     - 'lib/axlsx/util/validators.rb'
 
 Lint/UselessAssignment:
@@ -94,11 +93,6 @@ Lint/Void:
     - 'lib/axlsx/util/storage.rb'
     - 'lib/axlsx/workbook/worksheet/data_bar.rb'
     - 'lib/axlsx/workbook/worksheet/pivot_table.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-Performance/BlockGivenWithExplicitBlock:
-  Exclude:
-    - 'lib/axlsx/util/serialized_attributes.rb'
 
 # Configuration parameters: MinSize.
 Performance/CollectionLiteralInLoop:
@@ -369,7 +363,6 @@ Style/Next:
 Style/NonNilCheck:
   Exclude:
     - 'lib/axlsx/drawing/d_lbls.rb'
-    - 'lib/axlsx/util/serialized_attributes.rb'
     - 'lib/axlsx/workbook/worksheet/col.rb'
     - 'lib/axlsx/workbook/worksheet/page_setup.rb'
 
@@ -398,6 +391,7 @@ Style/OptionalBooleanParameter:
   Exclude:
     - 'lib/axlsx.rb'
     - 'lib/axlsx/package.rb'
+    - 'lib/axlsx/util/serialized_attributes.rb'
     - 'lib/axlsx/util/validators.rb'
     - 'lib/axlsx/workbook/workbook.rb'
     - 'lib/axlsx/workbook/worksheet/cell.rb'

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -171,6 +171,7 @@ module Axlsx
   # @return [Object]
   def self.booleanize(value)
     if value == true || value == false
+      # value ? '1' : '0'
       value ? 1 : 0
     else
       value

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -171,8 +171,7 @@ module Axlsx
   # @return [Object]
   def self.booleanize(value)
     if value == true || value == false
-      # value ? '1' : '0'
-      value ? 1 : 0
+      value ? '1' : '0'
     else
       value
     end

--- a/lib/axlsx/stylesheet/num_fmt.rb
+++ b/lib/axlsx/stylesheet/num_fmt.rb
@@ -75,11 +75,7 @@ module Axlsx
 
     # Override to avoid removing underscores
     def serialized_attributes(str = +'', additional_attributes = {})
-      attributes = declared_attributes.merge! additional_attributes
-      attributes.each do |key, value|
-        str << "#{Axlsx.camel(key, false)}=\"#{Axlsx.booleanize(value)}\" "
-      end
-      str
+      super(str, additional_attributes, false)
     end
   end
 end

--- a/lib/axlsx/util/serialized_attributes.rb
+++ b/lib/axlsx/util/serialized_attributes.rb
@@ -41,7 +41,7 @@ module Axlsx
 
     # creates a XML tag with serialized attributes
     # @see SerializedAttributes#serialized_attributes
-    def serialized_tag(tagname, str, additional_attributes = {}, &block)
+    def serialized_tag(tagname, str, additional_attributes = {})
       str << '<' << tagname << ' '
       serialized_attributes(str, additional_attributes)
       if block_given?
@@ -96,7 +96,7 @@ module Axlsx
     # @param [String] str The string instance to which serialized data is appended
     # @param [Array] additional_attributes An array of additional attribute names.
     # @return [String] The serialized output.
-    def serialized_element_attributes(str = +'', additional_attributes = [], &block)
+    def serialized_element_attributes(str = +'', additional_attributes = [])
       attrs = self.class.xml_element_attributes + additional_attributes
       values = Axlsx.instance_values_for(self)
       attrs.each do |attribute_name|

--- a/lib/axlsx/util/serialized_attributes.rb
+++ b/lib/axlsx/util/serialized_attributes.rb
@@ -15,10 +15,20 @@ module Axlsx
       # which of the instance values are serializable
       def serializable_attributes(*symbols)
         @xml_attributes = symbols
+        @camel_xml_attributes = nil
+        @ivar_xml_attributes = nil
       end
 
       # a reader for those attributes
       attr_reader :xml_attributes
+
+      def camel_xml_attributes
+        @camel_xml_attributes ||= @xml_attributes.map { |attr| Axlsx.camel(attr, false) }
+      end
+
+      def ivar_xml_attributes
+        @ivar_xml_attributes ||= @xml_attributes.map { |attr| :"@#{attr}" }
+      end
 
       # This helper registers the attributes that will be formatted as elements.
       def serializable_element_attributes(*symbols)
@@ -32,12 +42,12 @@ module Axlsx
     # creates a XML tag with serialized attributes
     # @see SerializedAttributes#serialized_attributes
     def serialized_tag(tagname, str, additional_attributes = {}, &block)
-      str << "<#{tagname} "
+      str << '<' << tagname << ' '
       serialized_attributes(str, additional_attributes)
       if block_given?
         str << '>'
         yield
-        str << "</#{tagname}>"
+        str << '</' << tagname << '>'
       else
         str << '/>'
       end
@@ -49,21 +59,34 @@ module Axlsx
     # serialization to.
     # @param [Hash] additional_attributes An option key value hash for
     # defining values that are not serializable attributes list.
-    def serialized_attributes(str = +'', additional_attributes = {})
-      attributes = declared_attributes.merge! additional_attributes
-      attributes.each do |key, value|
-        str << "#{Axlsx.camel(key, false)}=\"#{Axlsx.camel(Axlsx.booleanize(value), false)}\" "
-      end
-      str
-    end
+    # @param [Boolean] camelize_value Should the attribute values be camelized
+    def serialized_attributes(str = +'', additional_attributes = {}, camelize_value = true)
+      camel_xml_attributes = self.class.camel_xml_attributes
+      ivar_xml_attributes = self.class.ivar_xml_attributes
 
-    # A hash of instance variables that have been declared with
-    # seraialized_attributes and are not nil.
-    # This requires ruby 1.9.3 or higher
-    def declared_attributes
-      Axlsx.instance_values_for(self).select do |key, value|
-        value != nil && self.class.xml_attributes.include?(key.to_sym)
+      self.class.xml_attributes.each_with_index do |attr, index|
+        next if additional_attributes.key?(attr)
+        next unless instance_variable_defined?(ivar_xml_attributes[index])
+
+        value = instance_variable_get(ivar_xml_attributes[index])
+        next if value.nil?
+
+        value = Axlsx.booleanize(value)
+        value = Axlsx.camel(value, false) if camelize_value
+
+        str << camel_xml_attributes[index] << '="' << value.to_s << '" '
       end
+
+      additional_attributes.each do |attr, value|
+        next if value.nil?
+
+        value = Axlsx.booleanize(value)
+        value = Axlsx.camel(value, false) if camelize_value
+
+        str << Axlsx.camel(attr, false) << '="' << value.to_s << '" '
+      end
+
+      str
     end
 
     # serialized instance values at text nodes on a camelized element of the
@@ -82,7 +105,7 @@ module Axlsx
 
         value = yield value if block_given?
         element_name = Axlsx.camel(attribute_name, false)
-        str << "<#{element_name}>#{value}</#{element_name}>"
+        str << '<' << element_name << '>' << value << '</' << element_name << '>'
       end
       str
     end


### PR DESCRIPTION
# Description
Serialized attributes are usually declared in snake case as is the convention in Ruby. However, they need to be written in xml in camel case. So the `serialized_attributes` converts each serialied attribute into camel case on each invocation. We can avoid the time / memory for this conversion by caching the conversion the first time and re-using it each subsequent time.

We also avoid using `instance_values_for` to grab all instance variables only to reject ones with nil values and ones that are not serialied attributes. Instead, we can grab only the instance variables that correspond to defined serialied attributes. 

Finally, `Axlsx#booleanize` is commonly used to convert `true` / `false` into `1` / `0` when outputting values to the xml string. However, instead of returning `1` / `0` we can return `'1'` / `'0'` and avoid the `to_s` from needing to do anything.

# Benchmarks
All benchmarks used Ruby 3.2.1 on my macbook pro.

The performance benchmarks varied enough that it is difficult to tell how much of a speed boost we get. I did feel most of the time the new code was a bit faster, but there were instances where the new code was slightly slower. 

Either way, we definitely see a drop in allocated memory.

## Before
```
└─▪ test/benchmark.rb 
...
                                     user     system      total        real
axlsx_noautowidth                0.694793   0.002791   0.697584 (  0.697599)
axlsx_autowidth                  0.678625   0.002049   0.680674 (  0.680835)
axlsx_shared                     0.734707   0.002182   0.736889 (  0.736920)
axlsx_stream                     0.682153   0.001656   0.683809 (  0.683833)
axlsx_zip_command                0.641514   0.020684   0.713513 (  0.714249)
csv                              0.075997   0.005555   0.081552 (  0.081607)

└─▪ test/profile_memory.rb 
Total allocated: 103045567 bytes (1634154 objects)
```

## After
```
└─▪ test/benchmark.rb 
...
                                     user     system      total        real
axlsx_noautowidth                0.709162   0.003540   0.712702 (  0.712935)
axlsx_autowidth                  0.710035   0.002539   0.712574 (  0.712763)
axlsx_shared                     0.721251   0.001731   0.722982 (  0.723049)
axlsx_stream                     0.668538   0.001325   0.669863 (  0.669898)
axlsx_zip_command                0.639397   0.020657   0.712318 (  0.712707)
csv                              0.068726   0.004731   0.073457 (  0.073459)

└─▪ test/profile_memory.rb
Total allocated: 95239839 bytes (1503455 objects)
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).