### PR TITLE
Replace `sub` with `delete_prefix`/`delete_suffix`

### DIFF
--- a/lib/axlsx/util/constants.rb
+++ b/lib/axlsx/util/constants.rb
@@ -413,4 +413,14 @@ module Axlsx
 
   # Numeric recognition
   NUMERIC_REGEX = /\A[+-]?\d+?\Z/.freeze
+
+  # Leading characters that indicate a formula.
+  # See: https://owasp.org/www-community/attacks/CSV_Injection
+  FORMULA_PREFIX = '='
+
+  # Leading characters that indicate an array formula.
+  ARRAY_FORMULA_PREFIX = '{='
+
+  # Trailing character that indicates an array formula.
+  ARRAY_FORMULA_SUFFIX = '}'
 end

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -72,16 +72,6 @@ module Axlsx
     CELL_TYPES = [:date, :time, :float, :integer, :richtext,
                   :string, :boolean, :iso_8601, :text].freeze
 
-    # Leading characters that indicate a formula.
-    # See: https://owasp.org/www-community/attacks/CSV_Injection
-    FORMULA_PREFIXES = ['='].freeze
-
-    # Leading characters that indicate an array formula.
-    ARRAY_FORMULA_PREFIXES = ['{='].freeze
-
-    # Trailing character that indicates an array formula.
-    ARRAY_FORMULA_SUFFIX = '}'
-
     # The index of the cellXfs item to be applied to this cell.
     # @return [Integer]
     # @see Axlsx::Styles
@@ -395,14 +385,14 @@ module Axlsx
     def is_formula?
       return false if escape_formulas
 
-      type == :string && @value.to_s.start_with?(*FORMULA_PREFIXES)
+      type == :string && @value.to_s.start_with?(FORMULA_PREFIX)
     end
 
     def is_array_formula?
       return false if escape_formulas
 
       type == :string &&
-        @value.to_s.start_with?(*ARRAY_FORMULA_PREFIXES) &&
+        @value.to_s.start_with?(ARRAY_FORMULA_PREFIX) &&
         @value.to_s.end_with?(ARRAY_FORMULA_SUFFIX)
     end
 

--- a/lib/axlsx/workbook/worksheet/cell_serializer.rb
+++ b/lib/axlsx/workbook/worksheet/cell_serializer.rb
@@ -88,7 +88,7 @@ module Axlsx
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
       def formula_serialization(cell, str = +'')
-        str << 't="str"><f>' << cell.clean_value.to_s.sub('=', '') << '</f>'
+        str << 't="str"><f>' << cell.clean_value.to_s.delete_prefix(FORMULA_PREFIX) << '</f>'
         str << '<v>' << cell.formula_value.to_s << '</v>' unless cell.formula_value.nil?
       end
 
@@ -97,7 +97,7 @@ module Axlsx
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
       def array_formula_serialization(cell, str = +'')
-        str << 't="str">' << '<f t="array" ref="' << cell.r << '">' << cell.clean_value.to_s.sub('{=', '').sub(/}$/, '') << '</f>'
+        str << 't="str">' << '<f t="array" ref="' << cell.r << '">' << cell.clean_value.to_s.delete_prefix(ARRAY_FORMULA_PREFIX).delete_suffix(ARRAY_FORMULA_SUFFIX) << '</f>'
         str << '<v>' << cell.formula_value.to_s << '</v>' unless cell.formula_value.nil?
       end
 


### PR DESCRIPTION
Ruby 2.5 introduced `delete_prefix` and `delete_suffix`.

Those methods are helpful when serializing formula and array formula values, that are supposed to start and end with given prefixes

Also moves formula prefix to constants so they can be used by both `Cell` and `CellSerializer` classes

Formula:
```
Ruby version: 3.2.2
Comparison:
       delete_prefix:  8759353.5 i/s
                 sub:  2607022.4 i/s - 3.36x  (± 0.00) slower

Comparison:
       delete_prefix:         40 allocated
                 sub:        160 allocated - 4.00x more

```

Array Formula:
```
Ruby version: 3.2.2
Comparison:
     delete_prefixes:  4798837.8 i/s
             sub_sub:   937072.1 i/s - 5.12x  (± 0.00) slower

Comparison:
     delete_prefixes:        120 allocated
             sub_sub:        488 allocated - 4.07x more
```

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).