### PR TITLE
Add `Cell#style_str` so that we can directly return '0'

### DIFF
--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -80,6 +80,11 @@ module Axlsx
       defined?(@style) ? @style : 0
     end
 
+    # Internal
+    def style_str
+      defined?(@style) ? @style.to_s : '0'
+    end
+
     attr_accessor :raw_style
 
     # The index of the cellXfs item to be applied to this cell.

--- a/lib/axlsx/workbook/worksheet/cell_serializer.rb
+++ b/lib/axlsx/workbook/worksheet/cell_serializer.rb
@@ -12,7 +12,7 @@ module Axlsx
       def to_xml_string(row_index, column_index, cell, str = +'')
         str << '<c r="'
         str << Axlsx::col_ref(column_index) << Axlsx::row_ref(row_index)
-        str << '" s="' << cell.style.to_s << '" '
+        str << '" s="' << cell.style_str << '" '
         return str << '/>' if cell.value.nil?
 
         method = cell.type


### PR DESCRIPTION
# Description 
In our benchmarks, as I suspect in real world, it is common for cells to use the 
default style of 0. Currently, the CellSerializer asks the cell for its style and
then converts it to a string. We can optimize by adding an "private" method to 
cell to return the style as a string and avoid the conversion of 0 to '0'.

# Benchmarks

Using Ruby 3.2.1 for the following benchmarks. It appears to be a bit faster, but 
it should be taken with a grain of salt as the perf numbers are not consistent at
these scales.

However, we do avoid allocating 15%! of the memory.

## Before

```
└─▪ test/benchmark.rb 
...
                                     user     system      total        real
axlsx_noautowidth                0.545710   0.002926   0.548636 (  0.549055)
axlsx_autowidth                  0.576632   0.002091   0.578723 (  0.579273)
axlsx_shared                     0.564917   0.001680   0.566597 (  0.566864)
axlsx_stream                     0.548316   0.002168   0.550484 (  0.551103)
axlsx_zip_command                0.519887   0.020335   0.595864 (  0.597973)
csv                              0.069698   0.005153   0.074851 (  0.075006)

└─▪ test/profile_memory.rb 
Total allocated: 56018687 bytes (703469 objects)
```

## After
```
└─▪ test/benchmark.rb 
...
                                     user     system      total        real
axlsx_noautowidth                0.554961   0.002813   0.557774 (  0.558036)
axlsx_autowidth                  0.567947   0.003041   0.570988 (  0.571424)
axlsx_shared                     0.570797   0.002169   0.572966 (  0.573320)
axlsx_stream                     0.537936   0.001583   0.539519 (  0.539721)
axlsx_zip_command                0.497389   0.019624   0.568752 (  0.569667)
csv                              0.067539   0.004547   0.072086 (  0.072156)

└─▪ test/profile_memory.rb 
Total allocated: 48018687 bytes (503469 objects)
```
