### PR TITLE
Fix sheet_by_name for sheets with escaped characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
   - Added frozen string literals
   - Fix `SimpleTypedList#to_a` and `SimpleTypedList#to_ary` returning the internal list instance
   - Remove ability to set `u=` to true in favor of using :single or one of the other underline options
+  - Fix `Workbook#sheet_by_name` not returning sheets with encoded characters in the name
 
 - **April.23.23**: 3.4.1
   - [PR #209](https://github.com/caxlsx/caxlsx/pull/209) - Revert characters other than `=` being considered as formulas.

--- a/lib/axlsx/workbook/workbook.rb
+++ b/lib/axlsx/workbook/workbook.rb
@@ -221,8 +221,8 @@ module Axlsx
     # @param [String] name The name of the sheet you are looking for
     # @return [Worksheet] The sheet found, or nil
     def sheet_by_name(name)
-      index = @worksheets.index { |sheet| sheet.name == name }
-      @worksheets[index] if index
+      encoded_name = Axlsx.coder.encode(name)
+      @worksheets.find { |sheet| sheet.name == encoded_name }
     end
 
     # Creates a new Workbook.

--- a/test/workbook/tc_workbook.rb
+++ b/test/workbook/tc_workbook.rb
@@ -47,8 +47,10 @@ class TestWorkbook < Test::Unit::TestCase
   def test_sheet_by_name_retrieval
     @wb.add_worksheet(:name => 'foo')
     @wb.add_worksheet(:name => 'bar')
+    @wb.add_worksheet(:name => "testin'")
 
     assert_equal('foo', @wb.sheet_by_name('foo').name)
+    assert_equal("testin&apos;", @wb.sheet_by_name("testin'").name)
   end
 
   def test_worksheet_empty_name


### PR DESCRIPTION
### Description
I noticed `Workbook#sheet_by_name` sometimes returns `nil` when trying to find a sheet. After investigation, I realized it's because name is encoded [here](https://github.com/caxlsx/caxlsx/blob/master/lib/axlsx/workbook/worksheet/worksheet.rb#L328-L331), but not in `sheet_by_name`. This encodes the input in `sheet_by_name`, and also makes a minor refactor to just use `find` instead of `index` and lookup separately.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).