### PR TITLE
Fix Lint/Void offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -82,14 +82,6 @@ Lint/UselessAssignment:
     - 'lib/axlsx/workbook/worksheet/header_footer.rb'
     - 'lib/axlsx/workbook/worksheet/sheet_protection.rb'
 
-# Configuration parameters: CheckForMethodsWithNoSideEffects.
-Lint/Void:
-  Exclude:
-    - 'lib/axlsx/drawing/title.rb'
-    - 'lib/axlsx/util/storage.rb'
-    - 'lib/axlsx/workbook/worksheet/data_bar.rb'
-    - 'lib/axlsx/workbook/worksheet/pivot_table.rb'
-
 # Configuration parameters: MinSize.
 Performance/CollectionLiteralInLoop:
   Exclude:

--- a/lib/axlsx/drawing/title.rb
+++ b/lib/axlsx/drawing/title.rb
@@ -32,7 +32,6 @@ module Axlsx
       DataTypeValidator.validate 'Title.text', String, v
       @text = v
       @cell = nil
-      v
     end
 
     # @see text_size
@@ -40,7 +39,6 @@ module Axlsx
       DataTypeValidator.validate 'Title.text_size', String, v
       @text_size = v
       @cell = nil
-      v
     end
 
     # @see cell
@@ -48,7 +46,6 @@ module Axlsx
       DataTypeValidator.validate 'Title.text', Cell, v
       @cell = v
       @text = v.value.to_s
-      v
     end
 
     # Check if the title is empty.

--- a/lib/axlsx/util/storage.rb
+++ b/lib/axlsx/util/storage.rb
@@ -63,7 +63,6 @@ module Axlsx
     def name=(v)
       @name = v.bytes.to_a << 0
       @name_size = @name.size * 2
-      @name
     end
 
     # The size of the stream

--- a/lib/axlsx/workbook/worksheet/data_bar.rb
+++ b/lib/axlsx/workbook/worksheet/data_bar.rb
@@ -101,7 +101,6 @@ module Axlsx
     def color=(v)
       @color = v if v.is_a? Color
       self.color.rgb = v if v.is_a? String
-      @color
     end
 
     # Serialize this object to an xml string

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -135,7 +135,6 @@ module Axlsx
         end
         @data << data_field
       end
-      @data
     end
 
     # The pages


### PR DESCRIPTION
Setter methods return the assigned value. Given:

```rb
class MyClass
  def foo=(v)
    v = 10
    42
  end
end
```

`my_object.foo = 5` will always return `5`

This methods removes code that does not have effect

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).