### PR TITLE
Fix Style/AndOr offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -115,13 +115,6 @@ Style/Alias:
   Enabled: false
 
 # This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: always, conditionals
-Style/AndOr:
-  Exclude:
-    - 'lib/axlsx/workbook/worksheet/data_validation.rb'
-
-# This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: MinBranchesCount.
 Style/CaseLikeIf:
   Exclude:

--- a/lib/axlsx/workbook/worksheet/data_validation.rb
+++ b/lib/axlsx/workbook/worksheet/data_validation.rb
@@ -243,8 +243,8 @@ module Axlsx
         str << key_value.first << '="' << Axlsx.booleanize(key_value.last).to_s << '"'
       end
       str << '>'
-      str << '<formula1>' << self.formula1 << '</formula1>' if @formula1 and valid_attributes.include?(:formula1)
-      str << '<formula2>' << self.formula2 << '</formula2>' if @formula2 and valid_attributes.include?(:formula2)
+      str << '<formula1>' << formula1 << '</formula1>' if formula1 && valid_attributes.include?(:formula1)
+      str << '<formula2>' << formula2 << '</formula2>' if formula2 && valid_attributes.include?(:formula2)
       str << '</dataValidation>'
     end
 


### PR DESCRIPTION
From Ruby Style Guide:

> Do not use `and` and `or` in boolean context - and and or are control
flow operators and should be used as such. They have very low precedence, and can be used as a short form of specifying flow sequences like "evaluate expression 1, and only if it is not successful (returned `nil`), evaluate expression 2". This is especially useful for raising errors or early return without breaking the reading flow.

Also:

- Remove redundant use of self
- Use attribute reader instead of accessing instance variable

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).