### PR TITLE
Fix safe class comparison offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -77,11 +77,6 @@ Lint/UnusedMethodArgument:
     - 'lib/axlsx/package.rb'
     - 'lib/axlsx/util/validators.rb'
 
-Lint/UselessAssignment:
-  Exclude:
-    - 'lib/axlsx/workbook/worksheet/header_footer.rb'
-    - 'lib/axlsx/workbook/worksheet/sheet_protection.rb'
-
 # Configuration parameters: MinSize.
 Performance/CollectionLiteralInLoop:
   Exclude:
@@ -111,22 +106,6 @@ Style/Alias:
 Style/CaseLikeIf:
   Exclude:
     - 'lib/axlsx/workbook/worksheet/merged_cells.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: is_a?, kind_of?
-Style/ClassCheck:
-  Exclude:
-    - 'lib/axlsx/drawing/axes.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowedMethods, AllowedPatterns.
-# AllowedMethods: ==, equal?, eql?
-Style/ClassEqualityComparison:
-  Exclude:
-    - 'lib/axlsx/workbook/worksheet/pane.rb'
-    - 'lib/axlsx/workbook/worksheet/selection.rb'
-    - 'lib/axlsx/workbook/worksheet/sheet_view.rb'
 
 Style/ClassVars:
   Exclude:

--- a/lib/axlsx/drawing/axes.rb
+++ b/lib/axlsx/drawing/axes.rb
@@ -32,7 +32,7 @@ module Axlsx
     def to_xml_string(str = +'', options = {})
       if options[:ids]
         # CatAxis must come first in the XML (for Microsoft Excel at least)
-        sorted = axes.sort_by { |name, axis| axis.kind_of?(CatAxis) ? 0 : 1 }
+        sorted = axes.sort_by { |name, axis| axis.is_a?(CatAxis) ? 0 : 1 }
         sorted.each { |axis| str << '<c:axId val="' << axis[1].id.to_s << '"/>' }
       else
         axes.each { |axis| axis[1].to_xml_string(str) }

--- a/lib/axlsx/workbook/worksheet/pane.rb
+++ b/lib/axlsx/workbook/worksheet/pane.rb
@@ -108,7 +108,7 @@ module Axlsx
 
     # @see top_left_cell
     def top_left_cell=(v)
-      cell = (v.class == Axlsx::Cell ? v.r_abs : v)
+      cell = (v.instance_of?(Axlsx::Cell) ? v.r_abs : v)
       Axlsx::validate_string(cell)
       @top_left_cell = cell
     end

--- a/lib/axlsx/workbook/worksheet/selection.rb
+++ b/lib/axlsx/workbook/worksheet/selection.rb
@@ -74,7 +74,7 @@ module Axlsx
 
     # @see active_cell
     def active_cell=(v)
-      cell = (v.class == Axlsx::Cell ? v.r_abs : v)
+      cell = (v.instance_of?(Axlsx::Cell) ? v.r_abs : v)
       Axlsx::validate_string(cell)
       @active_cell = cell
     end

--- a/lib/axlsx/workbook/worksheet/sheet_view.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_view.rb
@@ -166,7 +166,7 @@ module Axlsx
 
     # @see top_left_cell
     def top_left_cell=(v)
-      cell = (v.class == Axlsx::Cell ? v.r_abs : v)
+      cell = (v.instance_of?(Axlsx::Cell) ? v.r_abs : v)
       Axlsx::validate_string(cell)
       @top_left_cell = cell
     end


### PR DESCRIPTION
Fixes:
- Style/ClassCheck
- Style/ClassEqualityComparison

While `is_a?` and `kind_of?` are equivalent, there is a 5% gain when switching from class comparison to `intance_of?` 

```
Comparison:
         instance_of: 16902635.9 i/s
    class comparison: 16061288.3 i/s - 1.05x  (± 0.00) slower
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).