### PR TITLE
Fix Style/HashEachMethods offense

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -183,13 +183,6 @@ Style/GuardClause:
     - 'lib/axlsx/workbook/worksheet/table.rb'
     - 'lib/axlsx/workbook/worksheet/worksheet.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: AllowedReceivers.
-# AllowedReceivers: Thread.current
-Style/HashEachMethods:
-  Exclude:
-    - 'lib/axlsx/workbook/worksheet/rich_text_run.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowIfModifier.
 Style/IfInsideElse:

--- a/lib/axlsx/workbook/worksheet/rich_text_run.rb
+++ b/lib/axlsx/workbook/worksheet/rich_text_run.rb
@@ -211,14 +211,14 @@ module Axlsx
       data = data.select { |key, value| valid.include?(key) && !value.nil? }
 
       str << '<r><rPr>'
-      data.keys.each do |key|
+      data.each do |key, val|
         case key
         when :font_name
           str << '<rFont val="' << font_name << '"/>'
         when :color
-          str << data[key].to_xml_string
+          str << val.to_xml_string
         else
-          str << '<' << key.to_s << ' val="' << xml_value(data[key]) << '"/>'
+          str << '<' << key.to_s << ' val="' << xml_value(val) << '"/>'
         end
       end
       clean_value = Axlsx::trust_input ? @value.to_s : ::CGI.escapeHTML(Axlsx::sanitize(@value.to_s))


### PR DESCRIPTION
Replace `keys.each` with hash iteration

```rb
MY_HASH = {
  first: '1',
  second: '2',
  third: '3'
}

%i[ips memory].each do |benchmark|
  Benchmark.send(benchmark) do |x|
    x.report("each_key") { MY_HASH.each_key { |k| MY_HASH[k] } }
    x.report("keys.each") { MY_HASH.keys.each { |k| MY_HASH[k] } }
    x.report("each") { MY_HASH.each { |k, v| v } }
    x.compare!
  end
end
```

```
IPS Comparison:
                each:  4283031.6 i/s
            each_key:  3683407.4 i/s - 1.16x  (± 0.00) slower
           keys.each:  3387425.1 i/s - 1.26x  (± 0.00) slower

Memory Comparison:
            each_key:          0 allocated
                each:          0 allocated - same
           keys.each:         40 allocated - Infx more
```


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).