### PR TITLE
Enable Security cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,9 @@ Minitest:
 Performance:
   Enabled: true
 
+Security:
+  Enabled: true
+
 Style:
   Enabled: true
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -77,11 +77,6 @@ Lint/UnusedMethodArgument:
     - 'lib/axlsx/package.rb'
     - 'lib/axlsx/util/validators.rb'
 
-Lint/UselessAssignment:
-  Exclude:
-    - 'lib/axlsx/workbook/worksheet/header_footer.rb'
-    - 'lib/axlsx/workbook/worksheet/sheet_protection.rb'
-
 # Configuration parameters: MinSize.
 Performance/CollectionLiteralInLoop:
   Exclude:

--- a/lib/axlsx/util/mime_type_utils.rb
+++ b/lib/axlsx/util/mime_type_utils.rb
@@ -16,7 +16,7 @@ module Axlsx
     # @param [String] v URI
     # @return [String] File mime type
     def self.get_mime_type_from_uri(v)
-      Marcel::MimeType.for(URI.open(v))
+      Marcel::MimeType.for(URI.parse(v).open)
     end
   end
 end

--- a/test/util/tc_mime_type_utils.rb
+++ b/test/util/tc_mime_type_utils.rb
@@ -17,4 +17,8 @@ class TestMimeTypeUtils < Test::Unit::TestCase
     assert_equal('image/jpeg', Axlsx::MimeTypeUtils::get_mime_type(@test_img))
     assert_equal('image/png', Axlsx::MimeTypeUtils::get_mime_type_from_uri(@test_img_url))
   end
+
+  def test_escape_uri
+    assert_raise(URI::InvalidURIError) { Axlsx::MimeTypeUtils::get_mime_type_from_uri('| ls') }
+  end
 end


### PR DESCRIPTION
Also fixes a Security/Open offense that couldn't be exploited, because
the only invocation of `get_mime_type_from_uri` was validating the
input with a `URI::DEFAULT_PARSER` regexp

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).