### PR TITLE
Use #== and #eql? from BasicObject

### DIFF
--- a/lib/axlsx/util/simple_typed_list.rb
+++ b/lib/axlsx/util/simple_typed_list.rb
@@ -15,6 +15,12 @@ module Axlsx
       undef_method name
     end
 
+    # We often call index(element) on instances of SimpleTypedList. Thus, we do not want to inherit Array
+    # implementation of == / eql? which walks the elements calling == / eql?. Instead we want the fast
+    # and original versions from BasicObject.
+    alias :== :equal?
+    alias :eql? :equal?
+
     # Creats a new typed list
     # @param [Array, Class] type An array of Class objects or a single Class object
     # @param [String] serialize_as The tag name to use in serialization

--- a/test/benchmark.rb
+++ b/test/benchmark.rb
@@ -11,9 +11,22 @@ input1 = (32..126).to_a.pack('U*').chars.to_a # these will need to be escaped
 input2 = (65..122).to_a.pack('U*').chars.to_a # these do not need to be escaped
 10.times { row << input1.shuffle.join }
 10.times { row << input2.shuffle.join }
-times = 3000
+times = 3_000
 
 Benchmark.bmbm(30) do |x|
+  x.report('axlsx_merged_cells') do
+    p = Axlsx::Package.new
+    p.workbook do |wb|
+      wb.add_worksheet do |sheet|
+        times.times do
+          sheet << row
+          sheet.merge_cells(sheet.rows.last.cells)
+        end
+      end
+    end
+    p.serialize("example_axlsx_merged_cells.xlsx")
+  end
+
   x.report('axlsx_noautowidth') do
     p = Axlsx::Package.new
     p.workbook do |wb|
@@ -85,4 +98,4 @@ Benchmark.bmbm(30) do |x|
     end
   end
 end
-File.delete("example.csv", "example_streamed.xlsx", "example_shared.xlsx", "example_autowidth.xlsx", "example_noautowidth.xlsx", "example_zip_command.xlsx")
+File.delete("example_axlsx_merged_cells.xlsx", "example.csv", "example_streamed.xlsx", "example_shared.xlsx", "example_autowidth.xlsx", "example_noautowidth.xlsx", "example_zip_command.xlsx")


### PR DESCRIPTION
### Description
Prior to https://github.com/caxlsx/caxlsx/pull/223, SimpleTypeList was just an object and inheritied #== / #eql? from BasicObject. These versions are fast as they just compare whether two objects sit in the same memory location.

After https://github.com/caxlsx/caxlsx/pull/223, we started to inherit #== / #eql? from Array. These are slow as they crawl all the elements in the Array.

This commit restores the original version of #== / #eql?.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).