### PR TITLE
Fix profiler deprecations

### DIFF
--- a/test/profile.rb
+++ b/test/profile.rb
@@ -11,7 +11,7 @@ input2 = (65..122).to_a.pack('U*').chars.to_a # these do not need to be escaped
 10.times { row << input1.shuffle.join }
 10.times { row << input2.shuffle.join }
 
-profile = RubyProf.profile do
+result = RubyProf::Profile.profile do
   p = Axlsx::Package.new
   p.workbook.add_worksheet do |sheet|
     10_000.times do
@@ -21,5 +21,5 @@ profile = RubyProf.profile do
   p.to_stream
 end
 
-printer = RubyProf::FlatPrinter.new(profile)
+printer = RubyProf::FlatPrinter.new(result)
 printer.print($stdout, {})


### PR DESCRIPTION
```
NOTE: RubyProf.profile is deprecated; use Profile.profile instead. It will be removed on or after 2023-06.
RubyProf.profile called from ./test/profile.rb:14.
NOTE: RubyProf.running? is deprecated; use Profile#running? instead. It will be removed on or after 2023-06.
NOTE: RubyProf.measure_mode is deprecated; use Profile#measure_mode instead. It will be removed on or after 2023-06.
NOTE: RubyProf.exclude_threads is deprecated; use Profile#exclude_threads instead. It will be removed on or after 2023-06.
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).