### PR TITLE
Improve absolute cell reference method

### DIFF
--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -73,6 +73,9 @@ module Axlsx
     CELL_TYPES = [:date, :time, :float, :integer, :richtext,
                   :string, :boolean, :iso_8601, :text].freeze
 
+    # A regular expression to match the alpha(column)numeric(row) reference of a cell
+    CELL_REFERENCE_REGEX = /([A-Z]+)([0-9]+)/.freeze
+
     # The index of the cellXfs item to be applied to this cell.
     # @return [Integer]
     # @see Axlsx::Styles
@@ -345,11 +348,11 @@ module Axlsx
       Axlsx::cell_r index, @row.row_index
     end
 
-    # @return [String] The absolute alpha(column)numeric(row) reference for this sell.
+    # @return [String] The absolute alpha(column)numeric(row) reference for this cell.
     # @example Absolute Cell Reference
     #   ws.rows.first.cells.first.r #=> "$A$1"
     def r_abs
-      "$#{r.match(/([A-Z]+)([0-9]+)/)[1, 2].join('$')}"
+      "$#{CELL_REFERENCE_REGEX.match(r)[1, 2].join('$')}"
     end
 
     # @return [Integer] The cellXfs item index applied to this cell.


### PR DESCRIPTION
Also inverts `string.match(REGEX)` with `REGEX.match(string)` because
of uniformity and because it has been tested 5% more performant on
Ruby 3.2. Performance on older Rubies is the same

```
 REGEX.match(string):  1234330.7 i/s
 string.match(REGEX):  1172670.1 i/s - 1.05x  (± 0.00) slower
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).