### PR TITLE
Add optional interpolation points to icon sets

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -125,11 +125,6 @@ Style/ClassVars:
     - 'lib/axlsx/workbook/workbook.rb'
     - 'lib/axlsx/workbook/worksheet/dimension.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Style/ConcatArrayLiterals:
-  Exclude:
-    - 'lib/axlsx/workbook/worksheet/icon_set.rb'
-
 # Configuration parameters: AllowedConstants.
 Style/Documentation:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
   - Raise exception if `axlsx_styler` gem is present as its code was merged directly into `caxlsx` in v3.3.0
   - Add 'SortState' and 'SortCondition' classes to the 'AutoFilter' class to add sorting to the generated file.
   - [PR #189](https://github.com/caxlsx/caxlsx/pull/189) - Make `Axlsx::escape_formulas` true by default to mitigate [Formula Injection](https://www.owasp.org/index.php/CSV_Injection) vulnerabilities.
+  - [PR #269](https://github.com/caxlsx/caxlsx/pull/269) - Add optional interpolation points to icon sets
 
 - **April.23.23**: 3.4.1
   - [PR #209](https://github.com/caxlsx/caxlsx/pull/209) - Revert characters other than `=` being considered as formulas.

--- a/lib/axlsx/workbook/worksheet/icon_set.rb
+++ b/lib/axlsx/workbook/worksheet/icon_set.rb
@@ -20,8 +20,10 @@ module Axlsx
       @percent = @showValue = true
       @reverse = false
       @iconSet = "3TrafficLights1"
-      initialize_value_objects
+      @interpolationPoints = [0, 33, 67]
+
       parse_options options
+
       yield self if block_given?
     end
 
@@ -34,7 +36,7 @@ module Axlsx
     attr_reader :iconSet
 
     # Indicates whether the thresholds indicate percentile values, instead of number values.
-    # The default falue is true
+    # The default value is true
     # @return [Boolean]
     attr_reader :percent
 
@@ -48,8 +50,20 @@ module Axlsx
     # @return [Boolean]
     attr_reader :showValue
 
+    # Sets the values of the interpolation points in the scale.
+    # The default value is [0, 33, 67]
+    # @return [Integer]
+    attr_reader :interpolationPoints
+
     # @see iconSet
     def iconSet=(v); Axlsx.validate_icon_set(v); @iconSet = v end
+
+    # @see interpolationPoints
+    def interpolationPoints=(v)
+      v.each { |point| Axlsx.validate_int(point) }
+      @value_objects = nil
+      @interpolationPoints = v
+    end
 
     # @see showValue
     def showValue=(v); Axlsx.validate_boolean(v); @showValue = v end
@@ -64,6 +78,8 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = +'')
+      initialize_value_objects if @value_objects.nil?
+
       serialized_tag('iconSet', str) do
         @value_objects.each { |cfvo| cfvo.to_xml_string(str) }
       end
@@ -72,10 +88,9 @@ module Axlsx
     private
 
     # Initalize the simple typed list of value objects
-    # I am keeping this private for now as I am not sure what impact changes to the required two cfvo objects will do.
     def initialize_value_objects
       @value_objects = SimpleTypedList.new Cfvo
-      @value_objects.concat [Cfvo.new(type: :percent, val: 0), Cfvo.new(type: :percent, val: 33), Cfvo.new(type: :percent, val: 67)]
+      @interpolationPoints.each { |point| @value_objects << Cfvo.new(type: :percent, val: point) }
       @value_objects.lock
     end
   end

--- a/test/workbook/worksheet/tc_icon_set.rb
+++ b/test/workbook/worksheet/tc_icon_set.rb
@@ -12,12 +12,19 @@ class TestIconSet < Test::Unit::TestCase
     assert(@icon_set.percent)
     refute(@icon_set.reverse)
     assert(@icon_set.showValue)
+    assert_equal([0, 33, 67], @icon_set.interpolationPoints)
   end
 
   def test_icon_set
     assert_raise(ArgumentError) { @icon_set.iconSet = "invalid_value" }
     assert_nothing_raised { @icon_set.iconSet = "5Rating" }
     assert_equal("5Rating", @icon_set.iconSet)
+  end
+
+  def test_interpolation_points
+    assert_raise(ArgumentError) { @icon_set.interpolationPoints = ["invalid_value"] }
+    assert_nothing_raised { @icon_set.interpolationPoints = [0, 60, 80] }
+    assert_equal([0, 60, 80], @icon_set.interpolationPoints)
   end
 
   def test_percent
@@ -43,5 +50,14 @@ class TestIconSet < Test::Unit::TestCase
 
     assert_equal(1, doc.xpath(".//iconSet[@iconSet='3TrafficLights1'][@percent=1][@reverse=0][@showValue=1]").size)
     assert_equal(3, doc.xpath(".//iconSet//cfvo").size)
+  end
+
+  def test_to_xml_string_with_interpolation_points
+    @icon_set.iconSet = '5Arrows'
+    @icon_set.interpolationPoints = [0, 20, 40, 60, 80]
+    doc = Nokogiri::XML.parse(@icon_set.to_xml_string)
+
+    assert_equal(1, doc.xpath(".//iconSet[@iconSet='5Arrows'][@percent=1][@reverse=0][@showValue=1]").size)
+    assert_equal(5, doc.xpath(".//iconSet//cfvo").size)
   end
 end


### PR DESCRIPTION
### Description

Closes #221 

I turned the code snippet from #221 into a PR.

I renamed the new attribute to `interpolationPoints` as the `Cfvo` class refers to them as interpolation points in the comments (then as `val` in the code).

I also had to move the call for `initialize_value_objects` into the `to_xml_string` method as we can override the interpolation points any time before the actual serialization. I'm not sure if we really need to store it in memory, it could be handy only if we call `to_xml_string` multiple times on the same iconSet.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).