### PR TITLE
Optimize cell initialization

### DIFF
--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -41,14 +41,16 @@ module Axlsx
       type = options.delete(:type) || cell_type_from_value(value)
       self.type = type unless type == :string
 
-      val = options.delete(:style)
-      self.style = val unless val.nil? || val.zero?
-      val = options.delete(:formula_value)
-      self.formula_value = val unless val.nil?
-      val = options.delete(:escape_formulas)
-      self.escape_formulas = val unless val.nil?
+      unless options.empty?
+        val = options.delete(:style)
+        self.style = val unless val.nil? || val.zero?
+        val = options.delete(:formula_value)
+        self.formula_value = val unless val.nil?
+        val = options.delete(:escape_formulas)
+        self.escape_formulas = val unless val.nil?
 
-      parse_options(options)
+        parse_options(options)
+      end
 
       self.value = value
       value.cell = self if contains_rich_text?


### PR DESCRIPTION
Optimize cell initialization

This is one of the most used methods in the library. Check for options
presence before assigning attributes and calling `parse_options` will
save some instructions and slightly degrade performance with cells
initialized with options.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).