### PR TITLE
Avoid unnecessary calls to `parse_options`

### DIFF
--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -48,7 +48,7 @@ module Axlsx
       val = options.delete(:escape_formulas)
       self.escape_formulas = val unless val.nil?
 
-      parse_options(options)
+      parse_options(options) unless options.empty?
 
       self.value = value
       value.cell = self if contains_rich_text?


### PR DESCRIPTION
`Cell#initialize` is one of the most used methods in the library, so a small improvement here will make a lot of difference on the overall performance.

The impact of this change is negligible when `options` has elements but is substantial when it is empty.

```
Comparison (empty options):
        parse unless: 11636650.6 i/s
               parse:  8109825.4 i/s - 1.43x  (± 0.00) slower

Comparison (1 option):
               parse:  3548037.5 i/s
        parse unless:  3459029.7 i/s - same-ish: difference falls within error
```

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).