### PR TITLE
Fix format string offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -187,18 +187,6 @@ Style/ExpandPathArguments:
     - 'axlsx.gemspec'
 
 # This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: format, sprintf, percent
-Style/FormatString:
-  Exclude:
-    - 'lib/axlsx/drawing/pic.rb'
-    - 'lib/axlsx/drawing/view_3D.rb'
-    - 'lib/axlsx/drawing/vml_drawing.rb'
-    - 'lib/axlsx/util/accessors.rb'
-    - 'lib/axlsx/util/validators.rb'
-    - 'lib/axlsx/workbook/worksheet/worksheet.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: MaxUnannotatedPlaceholdersAllowed, AllowedMethods, AllowedPatterns.
 # SupportedStyles: annotated, template, unannotated
 Style/FormatStringToken:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -323,19 +323,6 @@ Style/RandomWithOffset:
   Exclude:
     - 'lib/axlsx/drawing/vml_shape.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Style/RedundantInterpolation:
-  Exclude:
-    - 'lib/axlsx/drawing/chart.rb'
-    - 'lib/axlsx/drawing/drawing.rb'
-    - 'lib/axlsx/drawing/pic.rb'
-    - 'lib/axlsx/drawing/vml_drawing.rb'
-    - 'lib/axlsx/workbook/worksheet/comments.rb'
-    - 'lib/axlsx/workbook/worksheet/pivot_table.rb'
-    - 'lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb'
-    - 'lib/axlsx/workbook/worksheet/table.rb'
-    - 'lib/axlsx/workbook/worksheet/worksheet.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 Style/RedundantRegexpEscape:
   Exclude:

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -124,7 +124,7 @@ module Axlsx
     # The part name for this chart
     # @return [String]
     def pn
-      CHART_PN % (index + 1)
+      format(CHART_PN, index + 1)
     end
 
     # The title object for the chart.

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -124,7 +124,7 @@ module Axlsx
     # The part name for this chart
     # @return [String]
     def pn
-      "#{CHART_PN % (index + 1)}"
+      CHART_PN % (index + 1)
     end
 
     # The title object for the chart.

--- a/lib/axlsx/drawing/drawing.rb
+++ b/lib/axlsx/drawing/drawing.rb
@@ -128,14 +128,14 @@ module Axlsx
     # The part name for this drawing
     # @return [String]
     def pn
-      "#{DRAWING_PN % (index + 1)}"
+      DRAWING_PN % (index + 1)
     end
 
     # The relational part name for this drawing
     # #NOTE This should be rewritten to return an Axlsx::Relationship object.
     # @return [String]
     def rels_pn
-      "#{DRAWING_RELS_PN % (index + 1)}"
+      DRAWING_RELS_PN % (index + 1)
     end
 
     # A list of objects this drawing holds.

--- a/lib/axlsx/drawing/drawing.rb
+++ b/lib/axlsx/drawing/drawing.rb
@@ -128,14 +128,14 @@ module Axlsx
     # The part name for this drawing
     # @return [String]
     def pn
-      DRAWING_PN % (index + 1)
+      format(DRAWING_PN, index + 1)
     end
 
     # The relational part name for this drawing
     # #NOTE This should be rewritten to return an Axlsx::Relationship object.
     # @return [String]
     def rels_pn
-      DRAWING_RELS_PN % (index + 1)
+      format(DRAWING_RELS_PN, index + 1)
     end
 
     # A list of objects this drawing holds.

--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -131,7 +131,7 @@ module Axlsx
     # @return [Relationship]
     def relationship
       if remote?
-        Relationship.new(self, IMAGE_R, "#{image_src}", target_mode: :External)
+        Relationship.new(self, IMAGE_R, image_src.to_s, target_mode: :External)
       else
         Relationship.new(self, IMAGE_R, "../#{pn}")
       end

--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -124,7 +124,7 @@ module Axlsx
     # The part name for this image used in serialization and relationship building
     # @return [String]
     def pn
-      "#{IMAGE_PN % [(index + 1), extname]}"
+      format(IMAGE_PN, index + 1, extname)
     end
 
     # The relationship object for this pic.

--- a/lib/axlsx/drawing/view_3D.rb
+++ b/lib/axlsx/drawing/view_3D.rb
@@ -111,7 +111,7 @@ module Axlsx
       val = Axlsx.instance_values_for(self)[name]
       return "" if val.nil?
 
-      "<%s:%s val='%s'/>" % [namespace, Axlsx::camel(name, false), val]
+      format("<%s:%s val='%s'/>", namespace, Axlsx::camel(name, false), val)
     end
   end
 end

--- a/lib/axlsx/drawing/vml_drawing.rb
+++ b/lib/axlsx/drawing/vml_drawing.rb
@@ -14,7 +14,7 @@ module Axlsx
     # The part name for this vml drawing
     # @return [String]
     def pn
-      VML_DRAWING_PN % (@comments.worksheet.index + 1)
+      format(VML_DRAWING_PN, @comments.worksheet.index + 1)
     end
 
     # serialize the vml_drawing to xml.

--- a/lib/axlsx/drawing/vml_drawing.rb
+++ b/lib/axlsx/drawing/vml_drawing.rb
@@ -14,7 +14,7 @@ module Axlsx
     # The part name for this vml drawing
     # @return [String]
     def pn
-      "#{VML_DRAWING_PN}" % (@comments.worksheet.index + 1)
+      VML_DRAWING_PN % (@comments.worksheet.index + 1)
     end
 
     # serialize the vml_drawing to xml.

--- a/lib/axlsx/stylesheet/styles.rb
+++ b/lib/axlsx/stylesheet/styles.rb
@@ -370,7 +370,7 @@ module Axlsx
 
       if options[:border].is_a?(Integer)
         if options[:border] >= borders.size
-          raise ArgumentError, (ERR_INVALID_BORDER_ID % options[:border])
+          raise ArgumentError, format(ERR_INVALID_BORDER_ID, options[:border])
         end
 
         if options[:type] == :dxf
@@ -382,7 +382,7 @@ module Axlsx
 
       validate_border_hash = ->(val) {
         unless val.key?(:style) && val.key?(:color)
-          raise ArgumentError, (ERR_INVALID_BORDER_OPTIONS % options[:border])
+          raise ArgumentError, format(ERR_INVALID_BORDER_OPTIONS, options[:border])
         end
       }
 

--- a/lib/axlsx/util/accessors.rb
+++ b/lib/axlsx/util/accessors.rb
@@ -56,7 +56,7 @@ module Axlsx
         symbols.each do |symbol|
           attr_reader symbol
 
-          module_eval(SETTER % [symbol, validator, symbol], __FILE__, __LINE__)
+          module_eval(format(SETTER, symbol, validator, symbol), __FILE__, __LINE__)
         end
       end
     end

--- a/lib/axlsx/util/validators.rb
+++ b/lib/axlsx/util/validators.rb
@@ -10,7 +10,7 @@ module Axlsx
     # @raise [ArgumentError] Raised if the value provided is not in the list of choices.
     # @return [Boolean] true if validation succeeds.
     def self.validate(name, choices, v)
-      raise ArgumentError, (ERR_RESTRICTION % [v.to_s, name, choices.inspect]) unless choices.include?(v)
+      raise ArgumentError, format(ERR_RESTRICTION, v.to_s, name, choices.inspect) unless choices.include?(v)
 
       true
     end
@@ -31,7 +31,7 @@ module Axlsx
                else
                  min < value && value < max
                end
-      raise ArgumentError, (ERR_RANGE % [value.inspect, min.to_s, max.to_s, inclusive]) unless passes
+      raise ArgumentError, format(ERR_RANGE, value.inspect, min.to_s, max.to_s, inclusive) unless passes
     end
   end
 
@@ -41,7 +41,7 @@ module Axlsx
     # @param [Regexp] regex The regular expression to evaluate
     # @param [Any] v The value to validate.
     def self.validate(name, regex, v)
-      raise ArgumentError, (ERR_REGEX % [v.inspect, regex.to_s]) unless v.respond_to?(:to_s) && regex.match?(v.to_s)
+      raise ArgumentError, format(ERR_REGEX, v.inspect, regex.to_s) unless v.respond_to?(:to_s) && regex.match?(v.to_s)
     end
   end
 
@@ -56,14 +56,14 @@ module Axlsx
     # @see validate_boolean
     def self.validate(name, types, v, other = false)
       if other.is_a?(Proc) && !other.call(v)
-        raise ArgumentError, (ERR_TYPE % [v.inspect, name, types.inspect])
+        raise ArgumentError, format(ERR_TYPE, v.inspect, name, types.inspect)
       end
 
       v_class = v.is_a?(Class) ? v : v.class
       Array(types).each do |t|
         return if v_class <= t
       end
-      raise ArgumentError, (ERR_TYPE % [v.inspect, name, types.inspect])
+      raise ArgumentError, format(ERR_TYPE, v.inspect, name, types.inspect)
     end
   end
 

--- a/lib/axlsx/util/validators.rb
+++ b/lib/axlsx/util/validators.rb
@@ -71,7 +71,7 @@ module Axlsx
   # @para, [Any] v the value to validate
   # @raise [ArgumentError] raised if the value cannot be converted to an integer
   def self.validate_integerish(v)
-    raise ArgumentError, (ERR_INTEGERISH % v.inspect) unless v.respond_to?(:to_i) && v.to_i.is_a?(Integer)
+    raise ArgumentError, format(ERR_INTEGERISH, v.inspect) unless v.respond_to?(:to_i) && v.to_i.is_a?(Integer)
   end
 
   # Requires that the value is between -54000000 and 54000000
@@ -79,7 +79,7 @@ module Axlsx
   # @raise [ArgumentError] raised if the value cannot be converted to an integer between the allowed angle values for chart label rotation.
   # @return [Boolean] true if the data is valid
   def self.validate_angle(v)
-    raise ArgumentError, (ERR_ANGLE % v.inspect) unless v.to_i >= -5400000 && v.to_i <= 5400000
+    raise ArgumentError, format(ERR_ANGLE, v.inspect) unless v.to_i >= -5400000 && v.to_i <= 5400000
   end
 
   # Validates an unsigned intger

--- a/lib/axlsx/workbook/workbook.rb
+++ b/lib/axlsx/workbook/workbook.rb
@@ -354,10 +354,10 @@ module Axlsx
     def relationships
       r = Relationships.new
       @worksheets.each do |sheet|
-        r << Relationship.new(sheet, WORKSHEET_R, WORKSHEET_PN % (r.size + 1))
+        r << Relationship.new(sheet, WORKSHEET_R, format(WORKSHEET_PN, r.size + 1))
       end
       pivot_tables.each_with_index do |pivot_table, index|
-        r << Relationship.new(pivot_table.cache_definition, PIVOT_TABLE_CACHE_DEFINITION_R, PIVOT_TABLE_CACHE_DEFINITION_PN % (index + 1))
+        r << Relationship.new(pivot_table.cache_definition, PIVOT_TABLE_CACHE_DEFINITION_R, format(PIVOT_TABLE_CACHE_DEFINITION_PN, index + 1))
       end
       r << Relationship.new(self, STYLES_R, STYLES_PN)
       if use_shared_strings

--- a/lib/axlsx/workbook/worksheet/comments.rb
+++ b/lib/axlsx/workbook/worksheet/comments.rb
@@ -20,7 +20,7 @@ module Axlsx
     # The part name for this object
     # @return [String]
     def pn
-      "#{COMMENT_PN % (index + 1)}"
+      COMMENT_PN % (index + 1)
     end
 
     # Creates a new Comments object

--- a/lib/axlsx/workbook/worksheet/comments.rb
+++ b/lib/axlsx/workbook/worksheet/comments.rb
@@ -20,7 +20,7 @@ module Axlsx
     # The part name for this object
     # @return [String]
     def pn
-      COMMENT_PN % (index + 1)
+      format(COMMENT_PN, index + 1)
     end
 
     # Creates a new Comments object

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -159,13 +159,13 @@ module Axlsx
     # The part name for this table
     # @return [String]
     def pn
-      PIVOT_TABLE_PN % (index + 1)
+      format(PIVOT_TABLE_PN, index + 1)
     end
 
     # The relationship part name of this pivot table
     # @return [String]
     def rels_pn
-      PIVOT_TABLE_RELS_PN % (index + 1)
+      format(PIVOT_TABLE_RELS_PN, index + 1)
     end
 
     # The cache_definition for this pivot table

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -159,13 +159,13 @@ module Axlsx
     # The part name for this table
     # @return [String]
     def pn
-      "#{PIVOT_TABLE_PN % (index + 1)}"
+      PIVOT_TABLE_PN % (index + 1)
     end
 
     # The relationship part name of this pivot table
     # @return [String]
     def rels_pn
-      "#{PIVOT_TABLE_RELS_PN % (index + 1)}"
+      PIVOT_TABLE_RELS_PN % (index + 1)
     end
 
     # The cache_definition for this pivot table

--- a/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
@@ -26,7 +26,7 @@ module Axlsx
     # The part name for this table
     # @return [String]
     def pn
-      "#{PIVOT_TABLE_CACHE_DEFINITION_PN % (index + 1)}"
+      PIVOT_TABLE_CACHE_DEFINITION_PN % (index + 1)
     end
 
     # The identifier for this cache

--- a/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
@@ -26,7 +26,7 @@ module Axlsx
     # The part name for this table
     # @return [String]
     def pn
-      PIVOT_TABLE_CACHE_DEFINITION_PN % (index + 1)
+      format(PIVOT_TABLE_CACHE_DEFINITION_PN, index + 1)
     end
 
     # The identifier for this cache

--- a/lib/axlsx/workbook/worksheet/table.rb
+++ b/lib/axlsx/workbook/worksheet/table.rb
@@ -44,7 +44,7 @@ module Axlsx
     # The part name for this table
     # @return [String]
     def pn
-      TABLE_PN % (index + 1)
+      format(TABLE_PN, index + 1)
     end
 
     # The relationship id for this table.

--- a/lib/axlsx/workbook/worksheet/table.rb
+++ b/lib/axlsx/workbook/worksheet/table.rb
@@ -44,7 +44,7 @@ module Axlsx
     # The part name for this table
     # @return [String]
     def pn
-      "#{TABLE_PN % (index + 1)}"
+      TABLE_PN % (index + 1)
     end
 
     # The relationship id for this table.

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -675,9 +675,9 @@ module Axlsx
         if parts.size > 2
           raise ArgumentError, (ERR_CELL_REFERENCE_INVALID % cell_def)
         elsif parts.first.nil?
-          raise ArgumentError, (ERR_CELL_REFERENCE_MISSING_CELL % [cell_def.split(":").first, cell_def])
+          raise ArgumentError, format(ERR_CELL_REFERENCE_MISSING_CELL, cell_def.split(":").first, cell_def)
         elsif parts.last.nil?
-          raise ArgumentError, (ERR_CELL_REFERENCE_MISSING_CELL % [cell_def.split(":").last, cell_def])
+          raise ArgumentError, format(ERR_CELL_REFERENCE_MISSING_CELL, cell_def.split(":").last, cell_def)
         end
 
         range(*parts)

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -345,13 +345,13 @@ module Axlsx
     # The part name of this worksheet
     # @return [String]
     def pn
-      "#{WORKSHEET_PN % (index + 1)}"
+      WORKSHEET_PN % (index + 1)
     end
 
     # The relationship part name of this worksheet
     # @return [String]
     def rels_pn
-      "#{WORKSHEET_RELS_PN % (index + 1)}"
+      WORKSHEET_RELS_PN % (index + 1)
     end
 
     # The relationship id of this worksheet.

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -345,13 +345,13 @@ module Axlsx
     # The part name of this worksheet
     # @return [String]
     def pn
-      WORKSHEET_PN % (index + 1)
+      format(WORKSHEET_PN, index + 1)
     end
 
     # The relationship part name of this worksheet
     # @return [String]
     def rels_pn
-      WORKSHEET_RELS_PN % (index + 1)
+      format(WORKSHEET_RELS_PN, index + 1)
     end
 
     # The relationship id of this worksheet.
@@ -673,7 +673,7 @@ module Axlsx
         parts.first
       else
         if parts.size > 2
-          raise ArgumentError, (ERR_CELL_REFERENCE_INVALID % cell_def)
+          raise ArgumentError, format(ERR_CELL_REFERENCE_INVALID, cell_def)
         elsif parts.first.nil?
           raise ArgumentError, format(ERR_CELL_REFERENCE_MISSING_CELL, cell_def.split(":").first, cell_def)
         elsif parts.last.nil?
@@ -756,12 +756,12 @@ module Axlsx
       raise ArgumentError, ERR_SHEET_NAME_EMPTY if name.empty?
 
       character_length = name.encode("utf-16")[1..-1].encode("utf-16").bytesize / 2
-      raise ArgumentError, (ERR_SHEET_NAME_TOO_LONG % name) if character_length > WORKSHEET_MAX_NAME_LENGTH
-      raise ArgumentError, (ERR_SHEET_NAME_CHARACTER_FORBIDDEN % name) if WORKSHEET_NAME_FORBIDDEN_CHARS.any? { |char| name.include? char }
+      raise ArgumentError, format(ERR_SHEET_NAME_TOO_LONG, name) if character_length > WORKSHEET_MAX_NAME_LENGTH
+      raise ArgumentError, format(ERR_SHEET_NAME_CHARACTER_FORBIDDEN, name) if WORKSHEET_NAME_FORBIDDEN_CHARS.any? { |char| name.include? char }
 
       name = Axlsx::coder.encode(name)
       sheet_names = @workbook.worksheets.reject { |s| s == self }.map(&:name)
-      raise ArgumentError, (ERR_DUPLICATE_SHEET_NAME % name) if sheet_names.include?(name)
+      raise ArgumentError, format(ERR_DUPLICATE_SHEET_NAME, name) if sheet_names.include?(name)
     end
 
     def serializable_parts

--- a/test/content_type/tc_content_type.rb
+++ b/test/content_type/tc_content_type.rb
@@ -21,30 +21,30 @@ class TestContentType < Test::Unit::TestCase
     # default
     assert_equal(2, @doc.xpath("//xmlns:Default").size, "There should be 2 default types")
 
-    node = @doc.xpath(d_path % Axlsx::XML_CT).first
+    node = @doc.xpath(format(d_path, Axlsx::XML_CT)).first
 
     assert_equal(node["Extension"], Axlsx::XML_EX.to_s, "xml content type invalid")
 
-    node = @doc.xpath(d_path % Axlsx::RELS_CT).first
+    node = @doc.xpath(format(d_path, Axlsx::RELS_CT)).first
 
     assert_equal(node["Extension"], Axlsx::RELS_EX.to_s, "relationships content type invalid")
 
     # overrride
     assert_equal(4, @doc.xpath("//xmlns:Override").size, "There should be 4 Override types")
 
-    node = @doc.xpath(o_path % Axlsx::APP_CT).first
+    node = @doc.xpath(format(o_path, Axlsx::APP_CT)).first
 
     assert_equal(node["PartName"], "/#{Axlsx::APP_PN}", "App part name invalid")
 
-    node = @doc.xpath(o_path % Axlsx::CORE_CT).first
+    node = @doc.xpath(format(o_path, Axlsx::CORE_CT)).first
 
     assert_equal(node["PartName"], "/#{Axlsx::CORE_PN}", "Core part name invalid")
 
-    node = @doc.xpath(o_path % Axlsx::STYLES_CT).first
+    node = @doc.xpath(format(o_path, Axlsx::STYLES_CT)).first
 
     assert_equal(node["PartName"], "/xl/#{Axlsx::STYLES_PN}", "Styles part name invalid")
 
-    node = @doc.xpath(o_path % Axlsx::WORKBOOK_CT).first
+    node = @doc.xpath(format(o_path, Axlsx::WORKBOOK_CT)).first
 
     assert_equal(node["PartName"], "/#{Axlsx::WORKBOOK_PN}", "Workbook part invalid")
   end
@@ -56,13 +56,13 @@ class TestContentType < Test::Unit::TestCase
     doc = Nokogiri::XML(@package.send(:content_types).to_xml_string)
 
     assert_equal(5, doc.xpath("//xmlns:Override").size, "adding a worksheet should add another type")
-    assert_equal(doc.xpath(o_path % Axlsx::WORKSHEET_CT).last["PartName"], "/xl/#{ws.pn}", "Worksheet part invalid")
+    assert_equal(doc.xpath(format(o_path, Axlsx::WORKSHEET_CT)).last["PartName"], "/xl/#{ws.pn}", "Worksheet part invalid")
 
     ws = @package.workbook.add_worksheet
     doc = Nokogiri::XML(@package.send(:content_types).to_xml_string)
 
     assert_equal(6, doc.xpath("//xmlns:Override").size, "adding workship should add another type")
-    assert_equal(doc.xpath(o_path % Axlsx::WORKSHEET_CT).last["PartName"], "/xl/#{ws.pn}", "Worksheet part invalid")
+    assert_equal(doc.xpath(format(o_path, Axlsx::WORKSHEET_CT)).last["PartName"], "/xl/#{ws.pn}", "Worksheet part invalid")
   end
 
   def test_drawings_and_charts_need_content_types
@@ -73,13 +73,13 @@ class TestContentType < Test::Unit::TestCase
     doc = Nokogiri::XML(@package.send(:content_types).to_xml_string)
 
     assert_equal(7, doc.xpath("//xmlns:Override").size, "expected 7 types got #{doc.css('Types Override').size}")
-    assert_equal(doc.xpath(o_path % Axlsx::DRAWING_CT).first["PartName"], "/xl/#{ws.drawing.pn}", "Drawing part name invlid")
-    assert_equal(doc.xpath(o_path % Axlsx::CHART_CT).last["PartName"], "/xl/#{c.pn}", "Chart part name invlid")
+    assert_equal(doc.xpath(format(o_path, Axlsx::DRAWING_CT)).first["PartName"], "/xl/#{ws.drawing.pn}", "Drawing part name invlid")
+    assert_equal(doc.xpath(format(o_path, Axlsx::CHART_CT)).last["PartName"], "/xl/#{c.pn}", "Chart part name invlid")
 
     c = ws.add_chart Axlsx::Pie3DChart
     doc = Nokogiri::XML(@package.send(:content_types).to_xml_string)
 
     assert_equal(8, doc.xpath("//xmlns:Override").size, "expected 7 types got #{doc.css('Types Override').size}")
-    assert_equal(doc.xpath(o_path % Axlsx::CHART_CT).last["PartName"], "/xl/#{c.pn}", "Chart part name invlid")
+    assert_equal(doc.xpath(format(o_path, Axlsx::CHART_CT)).last["PartName"], "/xl/#{c.pn}", "Chart part name invlid")
   end
 end

--- a/test/drawing/tc_vml_drawing.rb
+++ b/test/drawing/tc_vml_drawing.rb
@@ -16,6 +16,12 @@ class TestVmlDrawing < Test::Unit::TestCase
     assert_raise(ArgumentError) { Axlsx::VmlDrawing.new }
   end
 
+  def test_pn
+    str = @vml_drawing.pn
+
+    assert_equal("drawings/vmlDrawing1.vml", str)
+  end
+
   def test_to_xml_string
     str = @vml_drawing.to_xml_string
     doc = Nokogiri::XML(str)

--- a/test/workbook/worksheet/tc_comments.rb
+++ b/test/workbook/worksheet/tc_comments.rb
@@ -37,7 +37,7 @@ class TestComments < Test::Unit::TestCase
   end
 
   def test_pn
-    assert_equal(@ws.comments.pn, Axlsx::COMMENT_PN % (@ws.index + 1).to_s)
+    assert_equal(@ws.comments.pn, format(Axlsx::COMMENT_PN, @ws.index + 1))
   end
 
   def test_index

--- a/test/workbook/worksheet/tc_pivot_table.rb
+++ b/test/workbook/worksheet/tc_pivot_table.rb
@@ -144,6 +144,12 @@ class TestPivotTable < Test::Unit::TestCase
     assert_equal(2, @ws.relationships.size, "adding a pivot table adds a relationship")
   end
 
+  def test_rels_pn
+    @ws.add_pivot_table('G5:G6', 'A1:D5')
+
+    assert_equal("pivotTables/_rels/pivotTable1.xml.rels", @ws.pivot_tables.first.rels_pn)
+  end
+
   def test_to_xml_string
     pivot_table = @ws.add_pivot_table('G5:G6', 'A1:E5', { no_subtotals_on_headers: ['Year'] }) do |pt|
       pt.rows = ['Year', 'Month']


### PR DESCRIPTION
`Kernel.format` is faster and will avoid to allocate an array compared
to `String#%`.


```
IPS:
       kernel_format:  3877614.2 i/s
      string_percent:  3531475.0 i/s - 1.10x  (± 0.00) slower

Memory (in case of array parameters):
       kernel_format:        160 allocated
      string_percent:        200 allocated - 1.25x more
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).