### PR TITLE
Remove redundant `to_s` calls

### DIFF
--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -442,9 +442,10 @@ module Axlsx
       end
     end
 
-    # Returns the sanatized value
-    # TODO find a better way to do this as it accounts for 30% of
+    # Returns the sanitized value
+    # TODO: find a better way to do this as it accounts for 30% of
     # processing time in benchmarking...
+    # @return [String] The sanitized value
     def clean_value
       if (type == :string || type == :text) && !Axlsx::trust_input
         Axlsx::sanitize(::CGI.escapeHTML(@value.to_s))

--- a/lib/axlsx/workbook/worksheet/cell_serializer.rb
+++ b/lib/axlsx/workbook/worksheet/cell_serializer.rb
@@ -90,7 +90,7 @@ module Axlsx
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
       def formula_serialization(cell, str = +'')
-        str << 't="str"><f>' << cell.clean_value.to_s.delete_prefix(FORMULA_PREFIX) << '</f>'
+        str << 't="str"><f>' << cell.clean_value.delete_prefix(FORMULA_PREFIX) << '</f>'
         str << '<v>' << cell.formula_value.to_s << '</v>' unless cell.formula_value.nil?
       end
 
@@ -99,7 +99,7 @@ module Axlsx
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
       def array_formula_serialization(cell, str = +'')
-        str << 't="str">' << '<f t="array" ref="' << cell.r << '">' << cell.clean_value.to_s.delete_prefix(ARRAY_FORMULA_PREFIX).delete_suffix(ARRAY_FORMULA_SUFFIX) << '</f>'
+        str << 't="str">' << '<f t="array" ref="' << cell.r << '">' << cell.clean_value.delete_prefix(ARRAY_FORMULA_PREFIX).delete_suffix(ARRAY_FORMULA_SUFFIX) << '</f>'
         str << '<v>' << cell.formula_value.to_s << '</v>' unless cell.formula_value.nil?
       end
 


### PR DESCRIPTION
`clean_value`'s return value is a `String`. That method will return `@value.to_s`, or it will call `Axlsx.sanitize`, which will return a `String` in both conditions (

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).