### PR TITLE
Fix safe Style/ColonMethodCall offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -156,10 +156,6 @@ Style/ClassVars:
     - 'lib/axlsx/workbook/workbook.rb'
     - 'lib/axlsx/workbook/worksheet/dimension.rb'
 
-# This cop supports safe autocorrection (--autocorrect).
-Style/ColonMethodCall:
-  Enabled: false
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/ConcatArrayLiterals:
   Exclude:

--- a/lib/axlsx/content_type/abstract_content_type.rb
+++ b/lib/axlsx/content_type/abstract_content_type.rb
@@ -18,7 +18,7 @@ module Axlsx
 
     # The content type.
     # @see Axlsx#validate_content_type
-    def content_type=(v) Axlsx::validate_content_type v; @content_type = v end
+    def content_type=(v) Axlsx.validate_content_type v; @content_type = v end
     alias :ContentType= :content_type=
 
     # Serialize the contenty type to xml
@@ -26,7 +26,7 @@ module Axlsx
       str << '<' << node_name << ' '
       Axlsx.instance_values_for(self).each_with_index do |key_value, index|
         str << ' ' unless index.zero?
-        str << Axlsx::camel(key_value.first) << '="' << key_value.last.to_s << '"'
+        str << Axlsx.camel(key_value.first) << '="' << key_value.last.to_s << '"'
       end
       str << '/>'
     end

--- a/lib/axlsx/content_type/default.rb
+++ b/lib/axlsx/content_type/default.rb
@@ -12,7 +12,7 @@ module Axlsx
     alias :Extension :extension
 
     # Sets the file extension for this content type.
-    def extension=(v) Axlsx::validate_string v; @extension = v end
+    def extension=(v) Axlsx.validate_string v; @extension = v end
     alias :Extension= :extension=
 
     # Serializes this object to xml

--- a/lib/axlsx/content_type/override.rb
+++ b/lib/axlsx/content_type/override.rb
@@ -12,7 +12,7 @@ module Axlsx
     alias :PartName :part_name
 
     # The name and location of the part.
-    def part_name=(v) Axlsx::validate_string v; @part_name = v end
+    def part_name=(v) Axlsx.validate_string v; @part_name = v end
     alias :PartName= :part_name=
 
     # Serializes this object to xml

--- a/lib/axlsx/doc_props/app.rb
+++ b/lib/axlsx/doc_props/app.rb
@@ -132,89 +132,89 @@ module Axlsx
     alias :DocSecurity :doc_security
 
     # Sets the template property of your app.xml file
-    def template=(v) Axlsx::validate_string v; @template = v; end
+    def template=(v) Axlsx.validate_string v; @template = v; end
     alias :Template= :template=
 
     # Sets the manager property of your app.xml file
-    def manager=(v) Axlsx::validate_string v; @manager = v; end
+    def manager=(v) Axlsx.validate_string v; @manager = v; end
     alias :Manager= :manager=
 
     # Sets the company property of your app.xml file
-    def company=(v) Axlsx::validate_string v; @company = v; end
+    def company=(v) Axlsx.validate_string v; @company = v; end
     alias :Company= :company=
     # Sets the pages property of your app.xml file
-    def pages=(v) Axlsx::validate_int v; @pages = v; end
+    def pages=(v) Axlsx.validate_int v; @pages = v; end
 
     # Sets the words property of your app.xml file
-    def words=(v) Axlsx::validate_int v; @words = v; end
+    def words=(v) Axlsx.validate_int v; @words = v; end
     alias :Words= :words=
 
     # Sets the characters property of your app.xml file
-    def characters=(v) Axlsx::validate_int v; @characters = v; end
+    def characters=(v) Axlsx.validate_int v; @characters = v; end
     alias :Characters= :characters=
 
     # Sets the presentation_format property of your app.xml file
-    def presentation_format=(v) Axlsx::validate_string v; @presentation_format = v; end
+    def presentation_format=(v) Axlsx.validate_string v; @presentation_format = v; end
     alias :PresentationFormat= :presentation_format=
 
     # Sets the lines property of your app.xml file
-    def lines=(v) Axlsx::validate_int v; @lines = v; end
+    def lines=(v) Axlsx.validate_int v; @lines = v; end
     alias :Lines= :lines=
 
     # Sets the paragraphs property of your app.xml file
-    def paragraphs=(v) Axlsx::validate_int v; @paragraphs = v; end
+    def paragraphs=(v) Axlsx.validate_int v; @paragraphs = v; end
     alias :Paragraphs= :paragraphs=
 
     # sets the slides property of your app.xml file
-    def slides=(v) Axlsx::validate_int v; @slides = v; end
+    def slides=(v) Axlsx.validate_int v; @slides = v; end
     alias :Slides= :slides=
 
     # sets the notes property of your app.xml file
-    def notes=(v) Axlsx::validate_int v; @notes = v; end
+    def notes=(v) Axlsx.validate_int v; @notes = v; end
     alias :Notes= :notes=
 
     # Sets the total_time property of your app.xml file
-    def total_time=(v) Axlsx::validate_int v; @total_time = v; end
+    def total_time=(v) Axlsx.validate_int v; @total_time = v; end
     alias :TotalTime= :total_time=
 
     # Sets the hidden_slides property of your app.xml file
-    def hidden_slides=(v) Axlsx::validate_int v; @hidden_slides = v; end
+    def hidden_slides=(v) Axlsx.validate_int v; @hidden_slides = v; end
     alias :HiddenSlides= :hidden_slides=
 
     # Sets the m_m_clips property of your app.xml file
-    def m_m_clips=(v) Axlsx::validate_int v; @m_m_clips = v; end
+    def m_m_clips=(v) Axlsx.validate_int v; @m_m_clips = v; end
     alias :MMClips= :m_m_clips=
 
     # Sets the scale_crop property of your app.xml file
-    def scale_crop=(v) Axlsx::validate_boolean v; @scale_crop = v; end
+    def scale_crop=(v) Axlsx.validate_boolean v; @scale_crop = v; end
     alias :ScaleCrop= :scale_crop=
 
     # Sets the links_up_to_date property of your app.xml file
-    def links_up_to_date=(v) Axlsx::validate_boolean v; @links_up_to_date = v; end
+    def links_up_to_date=(v) Axlsx.validate_boolean v; @links_up_to_date = v; end
     alias :LinksUpToDate= :links_up_to_date=
 
     # Sets the characters_with_spaces property of your app.xml file
-    def characters_with_spaces=(v) Axlsx::validate_int v; @characters_with_spaces = v; end
+    def characters_with_spaces=(v) Axlsx.validate_int v; @characters_with_spaces = v; end
     alias :CharactersWithSpaces= :characters_with_spaces=
 
     # Sets the share_doc property of your app.xml file
-    def shared_doc=(v) Axlsx::validate_boolean v; @shared_doc = v; end
+    def shared_doc=(v) Axlsx.validate_boolean v; @shared_doc = v; end
     alias :SharedDoc= :shared_doc=
 
     # Sets the hyperlink_base property of your app.xml file
-    def hyperlink_base=(v) Axlsx::validate_string v; @hyperlink_base = v; end
+    def hyperlink_base=(v) Axlsx.validate_string v; @hyperlink_base = v; end
     alias :HyperlinkBase= :hyperlink_base=
 
     # Sets the HyperLinksChanged property of your app.xml file
-    def hyperlinks_changed=(v) Axlsx::validate_boolean v; @hyperlinks_changed = v; end
+    def hyperlinks_changed=(v) Axlsx.validate_boolean v; @hyperlinks_changed = v; end
     alias :HyperLinksChanged= :hyperlinks_changed=
 
     # Sets the app_version property of your app.xml file
-    def app_version=(v) Axlsx::validate_string v; @app_version = v; end
+    def app_version=(v) Axlsx.validate_string v; @app_version = v; end
     alias :AppVersion= :app_version=
 
     # Sets the doc_security property of your app.xml file
-    def doc_security=(v) Axlsx::validate_int v; @doc_security = v; end
+    def doc_security=(v) Axlsx.validate_int v; @doc_security = v; end
     alias :DocSecurity= :doc_security=
 
     # Serialize the app.xml document

--- a/lib/axlsx/drawing/area_series.rb
+++ b/lib/axlsx/drawing/area_series.rb
@@ -52,19 +52,19 @@ module Axlsx
 
     # @see show_marker
     def show_marker=(v)
-      Axlsx::validate_boolean(v)
+      Axlsx.validate_boolean(v)
       @show_marker = v
     end
 
     # @see marker_symbol
     def marker_symbol=(v)
-      Axlsx::validate_marker_symbol(v)
+      Axlsx.validate_marker_symbol(v)
       @marker_symbol = v
     end
 
     # @see smooth
     def smooth=(v)
-      Axlsx::validate_boolean(v)
+      Axlsx.validate_boolean(v)
       @smooth = v
     end
 

--- a/lib/axlsx/drawing/axis.rb
+++ b/lib/axlsx/drawing/axis.rb
@@ -109,15 +109,15 @@ module Axlsx
 
     # The number format format code for this axis
     # default :General
-    def format_code=(v) Axlsx::validate_string(v); @format_code = v; end
+    def format_code=(v) Axlsx.validate_string(v); @format_code = v; end
 
     # Specify if gridlines should be shown for this axis
     # default true
-    def gridlines=(v) Axlsx::validate_boolean(v); @gridlines = v; end
+    def gridlines=(v) Axlsx.validate_boolean(v); @gridlines = v; end
 
     # Specify if axis should be removed from the chart
     # default false
-    def delete=(v) Axlsx::validate_boolean(v); @delete = v; end
+    def delete=(v) Axlsx.validate_boolean(v); @delete = v; end
 
     # specifies how the perpendicular axis is crossed
     # must be one of [:autoZero, :min, :max]
@@ -126,9 +126,9 @@ module Axlsx
     # Specify the degree of label rotation to apply to labels
     # default true
     def label_rotation=(v)
-      Axlsx::validate_int(v)
+      Axlsx.validate_int(v)
       adjusted = v.to_i * 60000
-      Axlsx::validate_angle(adjusted)
+      Axlsx.validate_angle(adjusted)
       @label_rotation = adjusted
     end
 

--- a/lib/axlsx/drawing/cat_axis.rb
+++ b/lib/axlsx/drawing/cat_axis.rb
@@ -45,15 +45,15 @@ module Axlsx
     LBL_OFFSET_REGEX = /0*(([0-9])|([1-9][0-9])|([1-9][0-9][0-9])|1000)/.freeze
 
     # @see tick_lbl_skip
-    def tick_lbl_skip=(v) Axlsx::validate_unsigned_int(v); @tick_lbl_skip = v; end
+    def tick_lbl_skip=(v) Axlsx.validate_unsigned_int(v); @tick_lbl_skip = v; end
     alias :tickLblSkip= :tick_lbl_skip=
 
     # @see tick_mark_skip
-    def tick_mark_skip=(v) Axlsx::validate_unsigned_int(v); @tick_mark_skip = v; end
+    def tick_mark_skip=(v) Axlsx.validate_unsigned_int(v); @tick_mark_skip = v; end
     alias :tickMarkSkip= :tick_mark_skip=
 
     # From the docs: This element specifies that this axis is a date or text axis based on the data that is used for the axis labels, not a specific choice.
-    def auto=(v) Axlsx::validate_boolean(v); @auto = v; end
+    def auto=(v) Axlsx.validate_boolean(v); @auto = v; end
 
     # specifies how the perpendicular axis is crossed
     # must be one of [:ctr, :l, :r]

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -62,7 +62,7 @@ module Axlsx
 
     # Configures the vary_colors options for this chart
     # @param [Boolean] v The value to set
-    def vary_colors=(v) Axlsx::validate_boolean(v); @vary_colors = v; end
+    def vary_colors=(v) Axlsx.validate_boolean(v); @vary_colors = v; end
 
     # The title object for the chart.
     # @return [Title]
@@ -149,13 +149,13 @@ module Axlsx
     # Show the legend in the chart
     # @param [Boolean] v
     # @return [Boolean]
-    def show_legend=(v) Axlsx::validate_boolean(v); @show_legend = v; end
+    def show_legend=(v) Axlsx.validate_boolean(v); @show_legend = v; end
 
     # How to display blank values
     # @see display_blanks_as
     # @param [Symbol] v
     # @return [Symbol]
-    def display_blanks_as=(v) Axlsx::validate_display_blanks_as(v); @display_blanks_as = v; end
+    def display_blanks_as=(v) Axlsx.validate_display_blanks_as(v); @display_blanks_as = v; end
 
     # The style for the chart.
     # see ECMA Part 1 §21.2.2.196
@@ -194,12 +194,12 @@ module Axlsx
     # Whether only data from visible cells should be plotted.
     # @param [Boolean] v
     # @return [Boolean]
-    def plot_visible_only=(v) Axlsx::validate_boolean(v); @plot_visible_only = v; end
+    def plot_visible_only=(v) Axlsx.validate_boolean(v); @plot_visible_only = v; end
 
     # Whether the chart area shall have rounded corners.
     # @param [Boolean] v
     # @return [Boolean]
-    def rounded_corners=(v) Axlsx::validate_boolean(v); @rounded_corners = v; end
+    def rounded_corners=(v) Axlsx.validate_boolean(v); @rounded_corners = v; end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/drawing/d_lbls.rb
+++ b/lib/axlsx/drawing/d_lbls.rb
@@ -78,7 +78,7 @@ module Axlsx
       %w(d_lbl_pos show_legend_key show_val show_cat_name show_ser_name show_percent show_bubble_size show_leader_lines).each do |key|
         next unless instance_vals.key?(key) && !instance_vals[key].nil?
 
-        str << "<c:#{Axlsx::camel(key, false)} val='#{instance_vals[key]}' />"
+        str << "<c:#{Axlsx.camel(key, false)} val='#{instance_vals[key]}' />"
       end
       str << '</c:dLbls>'
     end

--- a/lib/axlsx/drawing/hyperlink.rb
+++ b/lib/axlsx/drawing/hyperlink.rb
@@ -52,7 +52,7 @@ module Axlsx
     # @see endSnd
     # @param [Boolean] v The boolean value indicating the termination of playing sounds on click
     # @return [Boolean]
-    def end_snd=(v) Axlsx::validate_boolean(v); @end_snd = v end
+    def end_snd=(v) Axlsx.validate_boolean(v); @end_snd = v end
     alias :endSnd= :end_snd=
 
     # indicates that the link has already been clicked.
@@ -62,7 +62,7 @@ module Axlsx
 
     # @see highlightClick
     # @param [Boolean] v The value to assign
-    def highlight_click=(v) Axlsx::validate_boolean(v); @highlight_click = v end
+    def highlight_click=(v) Axlsx.validate_boolean(v); @highlight_click = v end
     alias :highlightClick= :highlight_click=
 
     # From the specs: Specifies whether to add this URI to the history when navigating to it. This allows for the viewing of this presentation without the storing of history information on the viewing machine. If this attribute is omitted, then a value of 1 or true is assumed.
@@ -71,7 +71,7 @@ module Axlsx
 
     # @see history
     # param [Boolean] v The value to assing
-    def history=(v) Axlsx::validate_boolean(v); @history = v end
+    def history=(v) Axlsx.validate_boolean(v); @history = v end
 
     # From the specs: Specifies the target frame that is to be used when opening this hyperlink. When the hyperlink is activated this attribute is used to determine if a new window is launched for viewing or if an existing one can be used. If this attribute is omitted, than a new window is opened.
     # @return [String]

--- a/lib/axlsx/drawing/line_series.rb
+++ b/lib/axlsx/drawing/line_series.rb
@@ -52,19 +52,19 @@ module Axlsx
 
     # @see show_marker
     def show_marker=(v)
-      Axlsx::validate_boolean(v)
+      Axlsx.validate_boolean(v)
       @show_marker = v
     end
 
     # @see marker_symbol
     def marker_symbol=(v)
-      Axlsx::validate_marker_symbol(v)
+      Axlsx.validate_marker_symbol(v)
       @marker_symbol = v
     end
 
     # @see smooth
     def smooth=(v)
-      Axlsx::validate_boolean(v)
+      Axlsx.validate_boolean(v)
       @smooth = v
     end
 

--- a/lib/axlsx/drawing/marker.rb
+++ b/lib/axlsx/drawing/marker.rb
@@ -34,13 +34,13 @@ module Axlsx
     attr_reader :rowOff
 
     # @see col
-    def col=(v) Axlsx::validate_unsigned_int v; @col = v end
+    def col=(v) Axlsx.validate_unsigned_int v; @col = v end
     # @see colOff
-    def colOff=(v) Axlsx::validate_int v; @colOff = v end
+    def colOff=(v) Axlsx.validate_int v; @colOff = v end
     # @see row
-    def row=(v) Axlsx::validate_unsigned_int v; @row = v end
+    def row=(v) Axlsx.validate_unsigned_int v; @row = v end
     # @see rowOff
-    def rowOff=(v) Axlsx::validate_int v; @rowOff = v end
+    def rowOff=(v) Axlsx.validate_int v; @rowOff = v end
 
     # shortcut to set the column, row position for this marker
     # @param col the column for the marker, a Cell object or a string reference like "B7"
@@ -68,7 +68,7 @@ module Axlsx
     # @see Chart#start_at
     def parse_coord_args(x, y = 0)
       if x.is_a?(String)
-        x, y = *Axlsx::name_to_indices(x)
+        x, y = *Axlsx.name_to_indices(x)
       end
       if x.is_a?(Cell)
         x, y = *x.pos

--- a/lib/axlsx/drawing/num_data.rb
+++ b/lib/axlsx/drawing/num_data.rb
@@ -31,7 +31,7 @@ module Axlsx
 
     # @see format_code
     def format_code=(v = 'General')
-      Axlsx::validate_string(v)
+      Axlsx.validate_string(v)
       @format_code = v
     end
 

--- a/lib/axlsx/drawing/num_data_source.rb
+++ b/lib/axlsx/drawing/num_data_source.rb
@@ -17,7 +17,7 @@ module Axlsx
       @f = nil
       @data = @data_type.new(options)
       if options[:data] && options[:data].first.is_a?(Cell)
-        @f = Axlsx::cell_range(options[:data])
+        @f = Axlsx.cell_range(options[:data])
       end
       parse_options options
     end

--- a/lib/axlsx/drawing/num_val.rb
+++ b/lib/axlsx/drawing/num_val.rb
@@ -18,13 +18,13 @@ module Axlsx
 
     # @see format_code
     def format_code=(v)
-      Axlsx::validate_string(v)
+      Axlsx.validate_string(v)
       @format_code = v
     end
 
     # serialize the object
     def to_xml_string(idx, str = +'')
-      Axlsx::validate_unsigned_int(idx)
+      Axlsx.validate_unsigned_int(idx)
       unless v.to_s.empty?
         str << '<c:pt idx="' << idx.to_s << '" formatCode="' << format_code << '"><c:v>' << v.to_s << '</c:v></c:pt>'
       end

--- a/lib/axlsx/drawing/one_cell_anchor.rb
+++ b/lib/axlsx/drawing/one_cell_anchor.rb
@@ -60,10 +60,10 @@ module Axlsx
 
     #
     # @see height
-    def height=(v) Axlsx::validate_unsigned_int(v); @height = v; end
+    def height=(v) Axlsx.validate_unsigned_int(v); @height = v; end
 
     # @see width
-    def width=(v) Axlsx::validate_unsigned_int(v); @width = v; end
+    def width=(v) Axlsx.validate_unsigned_int(v); @width = v; end
 
     # The index of this anchor in the drawing
     # @return [Integer]

--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -78,7 +78,7 @@ module Axlsx
     end
 
     def image_src=(v)
-      Axlsx::validate_string(v)
+      Axlsx.validate_string(v)
       if remote?
         RegexValidator.validate('Pic.image_src', /\A#{URI::DEFAULT_PARSER.make_regexp}\z/, v)
         RestrictionValidator.validate 'Pic.image_src', ALLOWED_MIME_TYPES, MimeTypeUtils.get_mime_type_from_uri(v)
@@ -91,13 +91,13 @@ module Axlsx
     end
 
     # @see name
-    def name=(v) Axlsx::validate_string(v); @name = v; end
+    def name=(v) Axlsx.validate_string(v); @name = v; end
 
     # @see descr
-    def descr=(v) Axlsx::validate_string(v); @descr = v; end
+    def descr=(v) Axlsx.validate_string(v); @descr = v; end
 
     # @see remote
-    def remote=(v) Axlsx::validate_boolean(v); @remote = v; end
+    def remote=(v) Axlsx.validate_boolean(v); @remote = v; end
 
     def remote?
       remote == 1 || remote.to_s == 'true'

--- a/lib/axlsx/drawing/pie_series.rb
+++ b/lib/axlsx/drawing/pie_series.rb
@@ -39,7 +39,7 @@ module Axlsx
     def colors=(v) DataTypeValidator.validate "BarSeries.colors", [Array], v; @colors = v end
 
     # @see explosion
-    def explosion=(v) Axlsx::validate_unsigned_int(v); @explosion = v; end
+    def explosion=(v) Axlsx.validate_unsigned_int(v); @explosion = v; end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -43,7 +43,7 @@ module Axlsx
         @smooth = [:smooth, :smoothMarker].include?(chart.scatter_style)
       else
         # Set smoothing according to the option provided
-        Axlsx::validate_boolean(options[:smooth])
+        Axlsx.validate_boolean(options[:smooth])
         @smooth = options[:smooth]
       end
       @ln_width = options[:ln_width] unless options[:ln_width].nil?
@@ -62,7 +62,7 @@ module Axlsx
 
     # @see smooth
     def smooth=(v)
-      Axlsx::validate_boolean(v)
+      Axlsx.validate_boolean(v)
       @smooth = v
     end
 
@@ -73,7 +73,7 @@ module Axlsx
 
     # @see marker_symbol
     def marker_symbol=(v)
-      Axlsx::validate_marker_symbol(v)
+      Axlsx.validate_marker_symbol(v)
       @marker_symbol = v
     end
 

--- a/lib/axlsx/drawing/ser_axis.rb
+++ b/lib/axlsx/drawing/ser_axis.rb
@@ -22,11 +22,11 @@ module Axlsx
     end
 
     # @see tickLblSkip
-    def tick_lbl_skip=(v) Axlsx::validate_unsigned_int(v); @tick_lbl_skip = v; end
+    def tick_lbl_skip=(v) Axlsx.validate_unsigned_int(v); @tick_lbl_skip = v; end
     alias :tickLblSkip= :tick_lbl_skip=
 
     # @see tickMarkSkip
-    def tick_mark_skip=(v) Axlsx::validate_unsigned_int(v); @tick_mark_skip = v; end
+    def tick_mark_skip=(v) Axlsx.validate_unsigned_int(v); @tick_mark_skip = v; end
     alias :tickMarkSkip= :tick_mark_skip=
 
     # Serializes the object

--- a/lib/axlsx/drawing/series.rb
+++ b/lib/axlsx/drawing/series.rb
@@ -40,7 +40,7 @@ module Axlsx
     end
 
     # @see order
-    def order=(v) Axlsx::validate_unsigned_int(v); @order = v; end
+    def order=(v) Axlsx.validate_unsigned_int(v); @order = v; end
 
     # @see title
     def title=(v)

--- a/lib/axlsx/drawing/series_title.rb
+++ b/lib/axlsx/drawing/series_title.rb
@@ -7,11 +7,11 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = +'')
-      clean_value = Axlsx::trust_input ? @text.to_s : ::CGI.escapeHTML(Axlsx::sanitize(@text.to_s))
+      clean_value = Axlsx.trust_input ? @text.to_s : ::CGI.escapeHTML(Axlsx.sanitize(@text.to_s))
 
       str << '<c:tx>'
       str << '<c:strRef>'
-      str << '<c:f>' << Axlsx::cell_range([@cell]) << '</c:f>'
+      str << '<c:f>' << Axlsx.cell_range([@cell]) << '</c:f>'
       str << '<c:strCache>'
       str << '<c:ptCount val="1"/>'
       str << '<c:pt idx="0">'

--- a/lib/axlsx/drawing/str_val.rb
+++ b/lib/axlsx/drawing/str_val.rb
@@ -24,7 +24,7 @@ module Axlsx
 
     # serialize the object
     def to_xml_string(idx, str = +'')
-      Axlsx::validate_unsigned_int(idx)
+      Axlsx.validate_unsigned_int(idx)
       unless v.to_s.empty?
         str << '<c:pt idx="' << idx.to_s << '"><c:v>' << ::CGI.escapeHTML(v.to_s) << '</c:v></c:pt>'
       end

--- a/lib/axlsx/drawing/title.rb
+++ b/lib/axlsx/drawing/title.rb
@@ -69,11 +69,11 @@ module Axlsx
     def to_xml_string(str = +'')
       str << '<c:title>'
       unless empty?
-        clean_value = Axlsx::trust_input ? @text.to_s : ::CGI.escapeHTML(Axlsx::sanitize(@text.to_s))
+        clean_value = Axlsx.trust_input ? @text.to_s : ::CGI.escapeHTML(Axlsx.sanitize(@text.to_s))
         str << '<c:tx>'
         if @cell.is_a?(Cell)
           str << '<c:strRef>'
-          str << '<c:f>' << Axlsx::cell_range([@cell]) << '</c:f>'
+          str << '<c:f>' << Axlsx.cell_range([@cell]) << '</c:f>'
           str << '<c:strCache>'
           str << '<c:ptCount val="1"/>'
           str << '<c:pt idx="0">'

--- a/lib/axlsx/drawing/view_3D.rb
+++ b/lib/axlsx/drawing/view_3D.rb
@@ -82,7 +82,7 @@ module Axlsx
     alias :depthPercent= :depth_percent=
 
     # @see r_ang_ax
-    def r_ang_ax=(v) Axlsx::validate_boolean(v); @r_ang_ax = v; end
+    def r_ang_ax=(v) Axlsx.validate_boolean(v); @r_ang_ax = v; end
     alias :rAngAx= :r_ang_ax=
 
     # @see perspective
@@ -111,7 +111,7 @@ module Axlsx
       val = Axlsx.instance_values_for(self)[name]
       return "" if val.nil?
 
-      format("<%s:%s val='%s'/>", namespace, Axlsx::camel(name, false), val)
+      format("<%s:%s val='%s'/>", namespace, Axlsx.camel(name, false), val)
     end
   end
 end

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -33,7 +33,7 @@ module Axlsx
     # Shortcut to specify that the workbook should use autowidth
     # @see Workbook#use_autowidth
     def use_autowidth=(v)
-      Axlsx::validate_boolean(v)
+      Axlsx.validate_boolean(v)
       workbook.use_autowidth = v
     end
 
@@ -46,7 +46,7 @@ module Axlsx
     # Shortcut to specify that the workbook should use shared strings
     # @see Workbook#use_shared_strings
     def use_shared_strings=(v)
-      Axlsx::validate_boolean(v)
+      Axlsx.validate_boolean(v)
       workbook.use_shared_strings = v
     end
 

--- a/lib/axlsx/rels/relationship.rb
+++ b/lib/axlsx/rels/relationship.rb
@@ -92,9 +92,9 @@ module Axlsx
     end
 
     # @see Target
-    def Target=(v) Axlsx::validate_string v; @Target = v end
+    def Target=(v) Axlsx.validate_string v; @Target = v end
     # @see Type
-    def Type=(v) Axlsx::validate_relationship_type v; @Type = v end
+    def Type=(v) Axlsx.validate_relationship_type v; @Type = v end
 
     # @see TargetMode
     def TargetMode=(v) RestrictionValidator.validate 'Relationship.TargetMode', [:External, :Internal], v; @TargetMode = v; end
@@ -107,7 +107,7 @@ module Axlsx
       str << '<Relationship '
       h.each_with_index do |key_value, index|
         str << ' ' unless index.zero?
-        str << key_value.first.to_s << '="' << Axlsx::coder.encode(key_value.last.to_s) << '"'
+        str << key_value.first.to_s << '="' << Axlsx.coder.encode(key_value.last.to_s) << '"'
       end
       str << '/>'
     end

--- a/lib/axlsx/stylesheet/border.rb
+++ b/lib/axlsx/stylesheet/border.rb
@@ -43,15 +43,15 @@ module Axlsx
     attr_reader :prs
 
     # @see diagonalUp
-    def diagonal_up=(v) Axlsx::validate_boolean v; @diagonal_up = v end
+    def diagonal_up=(v) Axlsx.validate_boolean v; @diagonal_up = v end
     alias :diagonalUp= :diagonal_up=
 
     # @see diagonalDown
-    def diagonal_down=(v) Axlsx::validate_boolean v; @diagonal_down = v end
+    def diagonal_down=(v) Axlsx.validate_boolean v; @diagonal_down = v end
     alias :diagonalDown= :diagonal_down=
 
     # @see outline
-    def outline=(v) Axlsx::validate_boolean v; @outline = v end
+    def outline=(v) Axlsx.validate_boolean v; @outline = v end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/cell_alignment.rb
+++ b/lib/axlsx/stylesheet/cell_alignment.rb
@@ -86,34 +86,34 @@ module Axlsx
     alias :readingOrder :reading_order
 
     # @see horizontal
-    def horizontal=(v) Axlsx::validate_horizontal_alignment v; @horizontal = v end
+    def horizontal=(v) Axlsx.validate_horizontal_alignment v; @horizontal = v end
     # @see vertical
-    def vertical=(v) Axlsx::validate_vertical_alignment v; @vertical = v end
+    def vertical=(v) Axlsx.validate_vertical_alignment v; @vertical = v end
     # @see textRotation
-    def text_rotation=(v) Axlsx::validate_unsigned_int v; @text_rotation = v end
+    def text_rotation=(v) Axlsx.validate_unsigned_int v; @text_rotation = v end
     alias :textRotation= :text_rotation=
 
     # @see wrapText
-    def wrap_text=(v) Axlsx::validate_boolean v; @wrap_text = v end
+    def wrap_text=(v) Axlsx.validate_boolean v; @wrap_text = v end
     alias :wrapText= :wrap_text=
 
     # @see indent
-    def indent=(v) Axlsx::validate_unsigned_int v; @indent = v end
+    def indent=(v) Axlsx.validate_unsigned_int v; @indent = v end
 
     # @see relativeIndent
-    def relative_indent=(v) Axlsx::validate_int v; @relative_indent = v end
+    def relative_indent=(v) Axlsx.validate_int v; @relative_indent = v end
     alias :relativeIndent= :relative_indent=
 
     # @see justifyLastLine
-    def justify_last_line=(v) Axlsx::validate_boolean v; @justify_last_line = v end
+    def justify_last_line=(v) Axlsx.validate_boolean v; @justify_last_line = v end
     alias :justifyLastLine= :justify_last_line=
 
     # @see shrinkToFit
-    def shrink_to_fit=(v) Axlsx::validate_boolean v; @shrink_to_fit = v end
+    def shrink_to_fit=(v) Axlsx.validate_boolean v; @shrink_to_fit = v end
     alias :shrinkToFit= :shrink_to_fit=
 
     # @see readingOrder
-    def reading_order=(v) Axlsx::validate_unsigned_int v; @reading_order = v end
+    def reading_order=(v) Axlsx.validate_unsigned_int v; @reading_order = v end
     alias :readingOrder= :reading_order=
 
     # Serializes the object

--- a/lib/axlsx/stylesheet/cell_protection.rb
+++ b/lib/axlsx/stylesheet/cell_protection.rb
@@ -26,9 +26,9 @@ module Axlsx
     end
 
     # @see hidden
-    def hidden=(v) Axlsx::validate_boolean v; @hidden = v end
+    def hidden=(v) Axlsx.validate_boolean v; @hidden = v end
     # @see locked
-    def locked=(v) Axlsx::validate_boolean v; @locked = v end
+    def locked=(v) Axlsx.validate_boolean v; @locked = v end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/cell_style.rb
+++ b/lib/axlsx/stylesheet/cell_style.rb
@@ -48,17 +48,17 @@ module Axlsx
     attr_reader :customBuiltin
 
     # @see name
-    def name=(v) Axlsx::validate_string v; @name = v end
+    def name=(v) Axlsx.validate_string v; @name = v end
     # @see xfId
-    def xfId=(v) Axlsx::validate_unsigned_int v; @xfId = v end
+    def xfId=(v) Axlsx.validate_unsigned_int v; @xfId = v end
     # @see builtinId
-    def builtinId=(v) Axlsx::validate_unsigned_int v; @builtinId = v end
+    def builtinId=(v) Axlsx.validate_unsigned_int v; @builtinId = v end
     # @see iLivel
-    def iLevel=(v) Axlsx::validate_unsigned_int v; @iLevel = v end
+    def iLevel=(v) Axlsx.validate_unsigned_int v; @iLevel = v end
     # @see hidden
-    def hidden=(v) Axlsx::validate_boolean v; @hidden = v end
+    def hidden=(v) Axlsx.validate_boolean v; @hidden = v end
     # @see customBuiltin
-    def customBuiltin=(v) Axlsx::validate_boolean v; @customBuiltin = v end
+    def customBuiltin=(v) Axlsx.validate_boolean v; @customBuiltin = v end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/color.rb
+++ b/lib/axlsx/stylesheet/color.rb
@@ -47,11 +47,11 @@ module Axlsx
     attr_reader :tint
 
     # @see auto
-    def auto=(v) Axlsx::validate_boolean v; @auto = v end
+    def auto=(v) Axlsx.validate_boolean v; @auto = v end
 
     # @see color
     def rgb=(v)
-      Axlsx::validate_string(v)
+      Axlsx.validate_string(v)
       v = v.upcase
       v *= 3 if v.size == 2
       v = v.rjust(8, 'FF')
@@ -61,7 +61,7 @@ module Axlsx
     end
 
     # @see tint
-    def tint=(v) Axlsx::validate_float v; @tint = v end
+    def tint=(v) Axlsx.validate_float v; @tint = v end
 
     # This version does not support themes
     # def theme=(v) Axlsx::validate_unsigned_integer v; @theme = v end

--- a/lib/axlsx/stylesheet/font.rb
+++ b/lib/axlsx/stylesheet/font.rb
@@ -112,38 +112,38 @@ module Axlsx
     attr_reader :sz
 
     # @see name
-    def name=(v) Axlsx::validate_string v; @name = v end
+    def name=(v) Axlsx.validate_string v; @name = v end
     # @see charset
-    def charset=(v) Axlsx::validate_unsigned_int v; @charset = v end
+    def charset=(v) Axlsx.validate_unsigned_int v; @charset = v end
     # @see family
-    def family=(v) Axlsx::validate_unsigned_int v; @family = v end
+    def family=(v) Axlsx.validate_unsigned_int v; @family = v end
     # @see b
-    def b=(v) Axlsx::validate_boolean v; @b = v end
+    def b=(v) Axlsx.validate_boolean v; @b = v end
     # @see i
-    def i=(v) Axlsx::validate_boolean v; @i = v end
+    def i=(v) Axlsx.validate_boolean v; @i = v end
 
     # @see u
     def u=(v)
       v = :single if v == true || v == 1 || v == :true || v == 'true'
       v = :none if v == false || v == 0 || v == :false || v == 'false'
-      Axlsx::validate_cell_u v
+      Axlsx.validate_cell_u v
       @u = v
     end
 
     # @see strike
-    def strike=(v) Axlsx::validate_boolean v; @strike = v end
+    def strike=(v) Axlsx.validate_boolean v; @strike = v end
     # @see outline
-    def outline=(v) Axlsx::validate_boolean v; @outline = v end
+    def outline=(v) Axlsx.validate_boolean v; @outline = v end
     # @see shadow
-    def shadow=(v) Axlsx::validate_boolean v; @shadow = v end
+    def shadow=(v) Axlsx.validate_boolean v; @shadow = v end
     # @see condense
-    def condense=(v) Axlsx::validate_boolean v; @condense = v end
+    def condense=(v) Axlsx.validate_boolean v; @condense = v end
     # @see extend
-    def extend=(v) Axlsx::validate_boolean v; @extend = v end
+    def extend=(v) Axlsx.validate_boolean v; @extend = v end
     # @see color
     def color=(v) DataTypeValidator.validate "Font.color", Color, v; @color = v end
     # @see sz
-    def sz=(v) Axlsx::validate_unsigned_int v; @sz = v end
+    def sz=(v) Axlsx.validate_unsigned_int v; @sz = v end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/gradient_fill.rb
+++ b/lib/axlsx/stylesheet/gradient_fill.rb
@@ -55,10 +55,10 @@ module Axlsx
     attr_reader :stop
 
     # @see type
-    def type=(v) Axlsx::validate_gradient_type v; @type = v end
+    def type=(v) Axlsx.validate_gradient_type v; @type = v end
 
     # @see degree
-    def degree=(v) Axlsx::validate_float v; @degree = v end
+    def degree=(v) Axlsx.validate_float v; @degree = v end
 
     # @see left
     def left=(v)

--- a/lib/axlsx/stylesheet/num_fmt.rb
+++ b/lib/axlsx/stylesheet/num_fmt.rb
@@ -61,10 +61,10 @@ module Axlsx
     attr_reader :numFmtId
 
     # @see numFmtId
-    def numFmtId=(v) Axlsx::validate_unsigned_int v; @numFmtId = v end
+    def numFmtId=(v) Axlsx.validate_unsigned_int v; @numFmtId = v end
 
     # @see formatCode
-    def formatCode=(v) Axlsx::validate_string v; @formatCode = v end
+    def formatCode=(v) Axlsx.validate_string v; @formatCode = v end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/pattern_fill.rb
+++ b/lib/axlsx/stylesheet/pattern_fill.rb
@@ -53,7 +53,7 @@ module Axlsx
     # @see bgColor
     def bgColor=(v) DataTypeValidator.validate "PatternFill.bgColor", Color, v; @bgColor = v end
     # @see patternType
-    def patternType=(v) Axlsx::validate_pattern_type v; @patternType = v end
+    def patternType=(v) Axlsx.validate_pattern_type v; @patternType = v end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/table_style.rb
+++ b/lib/axlsx/stylesheet/table_style.rb
@@ -33,11 +33,11 @@ module Axlsx
     attr_reader :table
 
     # @see name
-    def name=(v) Axlsx::validate_string v; @name = v end
+    def name=(v) Axlsx.validate_string v; @name = v end
     # @see pivot
-    def pivot=(v) Axlsx::validate_boolean v; @pivot = v end
+    def pivot=(v) Axlsx.validate_boolean v; @pivot = v end
     # @see table
-    def table=(v) Axlsx::validate_boolean v; @table = v end
+    def table=(v) Axlsx.validate_boolean v; @table = v end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/table_style_element.rb
+++ b/lib/axlsx/stylesheet/table_style_element.rb
@@ -58,13 +58,13 @@ module Axlsx
     attr_reader :dxfId
 
     # @see type
-    def type=(v) Axlsx::validate_table_element_type v; @type = v end
+    def type=(v) Axlsx.validate_table_element_type v; @type = v end
 
     # @see size
-    def size=(v) Axlsx::validate_unsigned_int v; @size = v end
+    def size=(v) Axlsx.validate_unsigned_int v; @size = v end
 
     # @see dxfId
-    def dxfId=(v) Axlsx::validate_unsigned_int v; @dxfId = v end
+    def dxfId=(v) Axlsx.validate_unsigned_int v; @dxfId = v end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/table_styles.rb
+++ b/lib/axlsx/stylesheet/table_styles.rb
@@ -26,9 +26,9 @@ module Axlsx
     attr_reader :defaultPivotStyle
 
     # @see defaultTableStyle
-    def defaultTableStyle=(v) Axlsx::validate_string(v); @defaultTableStyle = v; end
+    def defaultTableStyle=(v) Axlsx.validate_string(v); @defaultTableStyle = v; end
     # @see defaultPivotStyle
-    def defaultPivotStyle=(v) Axlsx::validate_string(v); @defaultPivotStyle = v; end
+    def defaultPivotStyle=(v) Axlsx.validate_string(v); @defaultPivotStyle = v; end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/xf.rb
+++ b/lib/axlsx/stylesheet/xf.rb
@@ -101,35 +101,35 @@ module Axlsx
     def protection=(v) DataTypeValidator.validate "Xf.protection", CellProtection, v; @protection = v end
 
     # @see numFmtId
-    def numFmtId=(v) Axlsx::validate_unsigned_int v; @numFmtId = v end
+    def numFmtId=(v) Axlsx.validate_unsigned_int v; @numFmtId = v end
 
     # @see fontId
-    def fontId=(v) Axlsx::validate_unsigned_int v; @fontId = v end
+    def fontId=(v) Axlsx.validate_unsigned_int v; @fontId = v end
     # @see fillId
-    def fillId=(v) Axlsx::validate_unsigned_int v; @fillId = v end
+    def fillId=(v) Axlsx.validate_unsigned_int v; @fillId = v end
     # @see borderId
-    def borderId=(v) Axlsx::validate_unsigned_int v; @borderId = v end
+    def borderId=(v) Axlsx.validate_unsigned_int v; @borderId = v end
     # @see xfId
-    def xfId=(v) Axlsx::validate_unsigned_int v; @xfId = v end
+    def xfId=(v) Axlsx.validate_unsigned_int v; @xfId = v end
     # @see quotePrefix
-    def quotePrefix=(v) Axlsx::validate_boolean v; @quotePrefix = v end
+    def quotePrefix=(v) Axlsx.validate_boolean v; @quotePrefix = v end
     # @see pivotButton
-    def pivotButton=(v) Axlsx::validate_boolean v; @pivotButton = v end
+    def pivotButton=(v) Axlsx.validate_boolean v; @pivotButton = v end
     # @see applyNumberFormat
-    def applyNumberFormat=(v) Axlsx::validate_boolean v; @applyNumberFormat = v end
+    def applyNumberFormat=(v) Axlsx.validate_boolean v; @applyNumberFormat = v end
     # @see applyFont
-    def applyFont=(v) Axlsx::validate_boolean v; @applyFont = v end
+    def applyFont=(v) Axlsx.validate_boolean v; @applyFont = v end
     # @see applyFill
-    def applyFill=(v) Axlsx::validate_boolean v; @applyFill = v end
+    def applyFill=(v) Axlsx.validate_boolean v; @applyFill = v end
 
     # @see applyBorder
-    def applyBorder=(v) Axlsx::validate_boolean v; @applyBorder = v end
+    def applyBorder=(v) Axlsx.validate_boolean v; @applyBorder = v end
 
     # @see applyAlignment
-    def applyAlignment=(v) Axlsx::validate_boolean v; @applyAlignment = v end
+    def applyAlignment=(v) Axlsx.validate_boolean v; @applyAlignment = v end
 
     # @see applyProtection
-    def applyProtection=(v) Axlsx::validate_boolean v; @applyProtection = v end
+    def applyProtection=(v) Axlsx.validate_boolean v; @applyProtection = v end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/util/storage.rb
+++ b/lib/axlsx/util/storage.rb
@@ -75,7 +75,7 @@ module Axlsx
     # @param [String] v The data for this storages stream
     # @return [Array]
     def data=(v)
-      Axlsx::validate_string(v)
+      Axlsx.validate_string(v)
       self.type = TYPES[:stream] unless @type
       @size = v.size
       @data = v.bytes.to_a

--- a/lib/axlsx/workbook/defined_name.rb
+++ b/lib/axlsx/workbook/defined_name.rb
@@ -109,7 +109,7 @@ module Axlsx
     # The local sheet index (0-based)
     # @param [Integer] value the unsigned integer index of the sheet this defined_name applies to.
     def local_sheet_id=(value)
-      Axlsx::validate_unsigned_int(value)
+      Axlsx.validate_unsigned_int(value)
       @local_sheet_id = value
     end
 

--- a/lib/axlsx/workbook/shared_strings_table.rb
+++ b/lib/axlsx/workbook/shared_strings_table.rb
@@ -46,7 +46,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = +'')
-      Axlsx::sanitize(@shared_xml_string)
+      Axlsx.sanitize(@shared_xml_string)
       str << '<?xml version="1.0" encoding="UTF-8"?><sst xmlns="' << XML_NS << '"'
       str << ' count="' << @count.to_s << '" uniqueCount="' << unique_count.to_s << '"'
       str << ' xml:space="' << xml_space.to_s << '">' << @shared_xml_string << '</sst>'

--- a/lib/axlsx/workbook/workbook.rb
+++ b/lib/axlsx/workbook/workbook.rb
@@ -95,7 +95,7 @@ module Axlsx
 
     # @see use_shared_strings
     def use_shared_strings=(v)
-      Axlsx::validate_boolean(v)
+      Axlsx.validate_boolean(v)
       @use_shared_strings = v
     end
 
@@ -104,7 +104,7 @@ module Axlsx
     attr_reader :is_reversed
 
     def is_reversed=(v)
-      Axlsx::validate_boolean(v)
+      Axlsx.validate_boolean(v)
       @is_reversed = v
     end
 
@@ -252,11 +252,11 @@ module Axlsx
     def date1904() @@date1904; end
 
     # see @date1904
-    def date1904=(v) Axlsx::validate_boolean v; @@date1904 = v; end
+    def date1904=(v) Axlsx.validate_boolean v; @@date1904 = v; end
 
     # Sets the date1904 attribute to the provided boolean
     # @return [Boolean]
-    def self.date1904=(v) Axlsx::validate_boolean v; @@date1904 = v; end
+    def self.date1904=(v) Axlsx.validate_boolean v; @@date1904 = v; end
 
     # retrieves the date1904 attribute
     # @return [Boolean]
@@ -283,7 +283,7 @@ module Axlsx
     def use_autowidth() @use_autowidth; end
 
     # see @use_autowidth
-    def use_autowidth=(v = true) Axlsx::validate_boolean v; @use_autowidth = v; end
+    def use_autowidth=(v = true) Axlsx.validate_boolean v; @use_autowidth = v; end
 
     # Font size of bold fonts is multiplied with this
     # Used for automatic calculation of cell widths with bold text
@@ -291,7 +291,7 @@ module Axlsx
     attr_reader :bold_font_multiplier
 
     def bold_font_multiplier=(v)
-      Axlsx::validate_float v
+      Axlsx.validate_float v
       @bold_font_multiplier = v
     end
 
@@ -301,7 +301,7 @@ module Axlsx
     attr_reader :font_scale_divisor
 
     def font_scale_divisor=(v)
-      Axlsx::validate_float v
+      Axlsx.validate_float v
       @font_scale_divisor = v
     end
 

--- a/lib/axlsx/workbook/worksheet/auto_filter/auto_filter.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/auto_filter.rb
@@ -52,8 +52,8 @@ module Axlsx
     # match the filter.
     def apply
       first_cell, last_cell = range.split(':')
-      start_point = Axlsx::name_to_indices(first_cell)
-      end_point = Axlsx::name_to_indices(last_cell)
+      start_point = Axlsx.name_to_indices(first_cell)
+      end_point = Axlsx.name_to_indices(last_cell)
       # The +1 is so we skip the header row with the filter drop downs
       rows = worksheet.rows[(start_point.last + 1)..end_point.last] || []
 

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -345,7 +345,7 @@ module Axlsx
     # @example Relative Cell Reference
     #   ws.rows.first.cells.first.r #=> "A1"
     def r
-      Axlsx::cell_r index, @row.row_index
+      Axlsx.cell_r index, @row.row_index
     end
 
     # @return [String] The absolute alpha(column)numeric(row) reference for this cell.
@@ -358,7 +358,7 @@ module Axlsx
     # @return [Integer] The cellXfs item index applied to this cell.
     # @raise [ArgumentError] Invalid cellXfs id if the value provided is not within cellXfs items range.
     def style=(v)
-      Axlsx::validate_unsigned_int(v)
+      Axlsx.validate_unsigned_int(v)
       count = styles.cellXfs.size
       raise ArgumentError, "Invalid cellXfs id" unless v < count
 
@@ -446,8 +446,8 @@ module Axlsx
     # TODO find a better way to do this as it accounts for 30% of
     # processing time in benchmarking...
     def clean_value
-      if (type == :string || type == :text) && !Axlsx::trust_input
-        Axlsx::sanitize(::CGI.escapeHTML(@value.to_s))
+      if (type == :string || type == :text) && !Axlsx.trust_input
+        Axlsx.sanitize(::CGI.escapeHTML(@value.to_s))
       else
         @value.to_s
       end
@@ -488,7 +488,7 @@ module Axlsx
 
     # @see ssti
     def ssti=(v)
-      Axlsx::validate_unsigned_int(v)
+      Axlsx.validate_unsigned_int(v)
       @ssti = v
     end
 

--- a/lib/axlsx/workbook/worksheet/cell_serializer.rb
+++ b/lib/axlsx/workbook/worksheet/cell_serializer.rb
@@ -11,7 +11,7 @@ module Axlsx
       # @return [String]
       def to_xml_string(row_index, column_index, cell, str = +'')
         str << '<c r="'
-        str << Axlsx::col_ref(column_index) << Axlsx::row_ref(row_index)
+        str << Axlsx.col_ref(column_index) << Axlsx.row_ref(row_index)
         str << '" s="' << cell.style_str << '" '
         return str << '/>' if cell.value.nil?
 
@@ -50,7 +50,7 @@ module Axlsx
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
       def date(cell, str = +'')
-        value_serialization false, DateTimeConverter::date_to_serial(cell.value).to_s, str
+        value_serialization false, DateTimeConverter.date_to_serial(cell.value).to_s, str
       end
 
       # Serializes cells that are type time
@@ -58,7 +58,7 @@ module Axlsx
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
       def time(cell, str = +'')
-        value_serialization false, DateTimeConverter::time_to_serial(cell.value).to_s, str
+        value_serialization false, DateTimeConverter.time_to_serial(cell.value).to_s, str
       end
 
       # Serializes cells that are type boolean

--- a/lib/axlsx/workbook/worksheet/cfvo.rb
+++ b/lib/axlsx/workbook/worksheet/cfvo.rb
@@ -40,10 +40,10 @@ module Axlsx
     attr_reader :val
 
     # @see type
-    def type=(v); Axlsx::validate_conditional_formatting_value_object_type(v); @type = v end
+    def type=(v); Axlsx.validate_conditional_formatting_value_object_type(v); @type = v end
 
     # @see gte
-    def gte=(v); Axlsx::validate_boolean(v); @gte = v end
+    def gte=(v); Axlsx.validate_boolean(v); @gte = v end
 
     # @see val
     def val=(v)

--- a/lib/axlsx/workbook/worksheet/comment.rb
+++ b/lib/axlsx/workbook/worksheet/comment.rb
@@ -80,7 +80,7 @@ module Axlsx
     # initialize the vml shape based on this comment's ref/position in the worksheet.
     # by default, all columns are 5 columns wide and 5 rows high
     def initialize_vml_shape
-      pos = Axlsx::name_to_indices(ref)
+      pos = Axlsx.name_to_indices(ref)
       @vml_shape = VmlShape.new(row: pos[1], column: pos[0], visible: @visible) do |vml|
         vml.left_column = vml.column
         vml.right_column = vml.column + 2

--- a/lib/axlsx/workbook/worksheet/conditional_formatting.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting.rb
@@ -63,7 +63,7 @@ module Axlsx
     # @see rules
     def rules=(v); @rules = v end
     # @see sqref
-    def sqref=(v); Axlsx::validate_string(v); @sqref = v end
+    def sqref=(v); Axlsx.validate_string(v); @sqref = v end
 
     # Serializes the conditional formatting element
     # @example Conditional Formatting XML looks like:

--- a/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
@@ -155,33 +155,33 @@ module Axlsx
     end
 
     # @see type
-    def type=(v); Axlsx::validate_conditional_formatting_type(v); @type = v end
+    def type=(v); Axlsx.validate_conditional_formatting_type(v); @type = v end
     # @see aboveAverage
-    def aboveAverage=(v); Axlsx::validate_boolean(v); @aboveAverage = v end
+    def aboveAverage=(v); Axlsx.validate_boolean(v); @aboveAverage = v end
     # @see bottom
-    def bottom=(v); Axlsx::validate_boolean(v); @bottom = v end
+    def bottom=(v); Axlsx.validate_boolean(v); @bottom = v end
     # @see dxfId
-    def dxfId=(v); Axlsx::validate_unsigned_numeric(v); @dxfId = v end
+    def dxfId=(v); Axlsx.validate_unsigned_numeric(v); @dxfId = v end
     # @see equalAverage
-    def equalAverage=(v); Axlsx::validate_boolean(v); @equalAverage = v end
+    def equalAverage=(v); Axlsx.validate_boolean(v); @equalAverage = v end
     # @see priority
-    def priority=(v); Axlsx::validate_unsigned_numeric(v); @priority = v end
+    def priority=(v); Axlsx.validate_unsigned_numeric(v); @priority = v end
     # @see operator
-    def operator=(v); Axlsx::validate_conditional_formatting_operator(v); @operator = v end
+    def operator=(v); Axlsx.validate_conditional_formatting_operator(v); @operator = v end
     # @see text
-    def text=(v); Axlsx::validate_string(v); @text = v end
+    def text=(v); Axlsx.validate_string(v); @text = v end
     # @see percent
-    def percent=(v); Axlsx::validate_boolean(v); @percent = v end
+    def percent=(v); Axlsx.validate_boolean(v); @percent = v end
     # @see rank
-    def rank=(v); Axlsx::validate_unsigned_numeric(v); @rank = v end
+    def rank=(v); Axlsx.validate_unsigned_numeric(v); @rank = v end
     # @see stdDev
-    def stdDev=(v); Axlsx::validate_unsigned_numeric(v); @stdDev = v end
+    def stdDev=(v); Axlsx.validate_unsigned_numeric(v); @stdDev = v end
     # @see stopIfTrue
-    def stopIfTrue=(v); Axlsx::validate_boolean(v); @stopIfTrue = v end
+    def stopIfTrue=(v); Axlsx.validate_boolean(v); @stopIfTrue = v end
     # @see timePeriod
-    def timePeriod=(v); Axlsx::validate_time_period_type(v); @timePeriod = v end
+    def timePeriod=(v); Axlsx.validate_time_period_type(v); @timePeriod = v end
     # @see formula
-    def formula=(v); [*v].each { |x| Axlsx::validate_string(x) }; @formula = [*v].map { |form| ::CGI.escapeHTML(form) } end
+    def formula=(v); [*v].each { |x| Axlsx.validate_string(x) }; @formula = [*v].map { |form| ::CGI.escapeHTML(form) } end
 
     # @see color_scale
     def color_scale=(v)

--- a/lib/axlsx/workbook/worksheet/data_validation.rb
+++ b/lib/axlsx/workbook/worksheet/data_validation.rb
@@ -178,57 +178,57 @@ module Axlsx
     attr_reader :type
 
     # @see formula1
-    def formula1=(v); Axlsx::validate_string(v); @formula1 = v end
+    def formula1=(v); Axlsx.validate_string(v); @formula1 = v end
 
     # @see formula2
-    def formula2=(v); Axlsx::validate_string(v); @formula2 = v end
+    def formula2=(v); Axlsx.validate_string(v); @formula2 = v end
 
     # @see allowBlank
-    def allowBlank=(v); Axlsx::validate_boolean(v); @allowBlank = v end
+    def allowBlank=(v); Axlsx.validate_boolean(v); @allowBlank = v end
 
     # @see error
-    def error=(v); Axlsx::validate_string(v); @error = v end
+    def error=(v); Axlsx.validate_string(v); @error = v end
 
     # @see errorStyle
-    def errorStyle=(v); Axlsx::validate_data_validation_error_style(v); @errorStyle = v end
+    def errorStyle=(v); Axlsx.validate_data_validation_error_style(v); @errorStyle = v end
 
     # @see errorTitle
-    def errorTitle=(v); Axlsx::validate_string(v); @errorTitle = v end
+    def errorTitle=(v); Axlsx.validate_string(v); @errorTitle = v end
 
     # @see operator
-    def operator=(v); Axlsx::validate_data_validation_operator(v); @operator = v end
+    def operator=(v); Axlsx.validate_data_validation_operator(v); @operator = v end
 
     # @see prompt
-    def prompt=(v); Axlsx::validate_string(v); @prompt = v end
+    def prompt=(v); Axlsx.validate_string(v); @prompt = v end
 
     # @see promptTitle
-    def promptTitle=(v); Axlsx::validate_string(v); @promptTitle = v end
+    def promptTitle=(v); Axlsx.validate_string(v); @promptTitle = v end
 
     # @see showDropDown
     def showDropDown=(v)
       warn 'The `showDropDown` has an inverted logic, false shows the dropdown list! You should use `hideDropDown` instead.'
-      Axlsx::validate_boolean(v)
+      Axlsx.validate_boolean(v)
       @showDropDown = v
     end
 
     # @see hideDropDown
     def hideDropDown=(v)
-      Axlsx::validate_boolean(v)
+      Axlsx.validate_boolean(v)
       # It's just an alias for the showDropDown attribute, hideDropDown should set the value of the original showDropDown.
       @showDropDown = v
     end
 
     # @see showErrorMessage
-    def showErrorMessage=(v); Axlsx::validate_boolean(v); @showErrorMessage = v end
+    def showErrorMessage=(v); Axlsx.validate_boolean(v); @showErrorMessage = v end
 
     # @see showInputMessage
-    def showInputMessage=(v); Axlsx::validate_boolean(v); @showInputMessage = v end
+    def showInputMessage=(v); Axlsx.validate_boolean(v); @showInputMessage = v end
 
     # @see sqref
-    def sqref=(v); Axlsx::validate_string(v); @sqref = v end
+    def sqref=(v); Axlsx.validate_string(v); @sqref = v end
 
     # @see type
-    def type=(v); Axlsx::validate_data_validation_type(v); @type = v end
+    def type=(v); Axlsx.validate_data_validation_type(v); @type = v end
 
     # Serializes the data validation
     # @param [String] str

--- a/lib/axlsx/workbook/worksheet/date_time_converter.rb
+++ b/lib/axlsx/workbook/worksheet/date_time_converter.rb
@@ -9,7 +9,7 @@ module Axlsx
     # @param [Date] date the date to be serialized
     # @return [Numeric]
     def self.date_to_serial(date)
-      epoch = Axlsx::Workbook::date1904 ? Date.new(1904) : Date.new(1899, 12, 30)
+      epoch = Axlsx::Workbook.date1904 ? Date.new(1904) : Date.new(1899, 12, 30)
       offset_date = date.respond_to?(:utc_offset) ? date + date.utc_offset.seconds : date
       (offset_date - epoch).to_f
     end
@@ -23,7 +23,7 @@ module Axlsx
       epoch1900 = -2209161600.0 # Time.utc(1899, 12, 30).to_i
       epoch1904 = -2082844800.0 # Time.utc(1904, 1, 1).to_i
       seconds_per_day = 86400.0 # 60*60*24
-      epoch = Axlsx::Workbook::date1904 ? epoch1904 : epoch1900
+      epoch = Axlsx::Workbook.date1904 ? epoch1904 : epoch1900
       (time.utc_offset + time.to_f - epoch) / seconds_per_day
     end
   end

--- a/lib/axlsx/workbook/worksheet/icon_set.rb
+++ b/lib/axlsx/workbook/worksheet/icon_set.rb
@@ -49,7 +49,7 @@ module Axlsx
     attr_reader :showValue
 
     # @see iconSet
-    def iconSet=(v); Axlsx::validate_icon_set(v); @iconSet = v end
+    def iconSet=(v); Axlsx.validate_icon_set(v); @iconSet = v end
 
     # @see showValue
     def showValue=(v); Axlsx.validate_boolean(v); @showValue = v end

--- a/lib/axlsx/workbook/worksheet/merged_cells.rb
+++ b/lib/axlsx/workbook/worksheet/merged_cells.rb
@@ -19,7 +19,7 @@ module Axlsx
       self << if cells.is_a?(String)
                 cells
               elsif cells.is_a?(Array)
-                Axlsx::cell_range(cells, false)
+                Axlsx.cell_range(cells, false)
               end
     end
 

--- a/lib/axlsx/workbook/worksheet/page_margins.rb
+++ b/lib/axlsx/workbook/worksheet/page_margins.rb
@@ -78,17 +78,17 @@ module Axlsx
     end
 
     # @see left
-    def left=(v); Axlsx::validate_unsigned_numeric(v); @left = v end
+    def left=(v); Axlsx.validate_unsigned_numeric(v); @left = v end
     # @see right
-    def right=(v); Axlsx::validate_unsigned_numeric(v); @right = v end
+    def right=(v); Axlsx.validate_unsigned_numeric(v); @right = v end
     # @see top
-    def top=(v); Axlsx::validate_unsigned_numeric(v); @top = v end
+    def top=(v); Axlsx.validate_unsigned_numeric(v); @top = v end
     # @see bottom
-    def bottom=(v); Axlsx::validate_unsigned_numeric(v); @bottom = v end
+    def bottom=(v); Axlsx.validate_unsigned_numeric(v); @bottom = v end
     # @see header
-    def header=(v); Axlsx::validate_unsigned_numeric(v); @header = v end
+    def header=(v); Axlsx.validate_unsigned_numeric(v); @header = v end
     # @see footer
-    def footer=(v); Axlsx::validate_unsigned_numeric(v); @footer = v end
+    def footer=(v); Axlsx.validate_unsigned_numeric(v); @footer = v end
 
     # Serializes the page margins element
     # @param [String] str

--- a/lib/axlsx/workbook/worksheet/page_setup.rb
+++ b/lib/axlsx/workbook/worksheet/page_setup.rb
@@ -198,17 +198,17 @@ module Axlsx
     end
 
     # @see fit_to_height
-    def fit_to_height=(v); Axlsx::validate_unsigned_int(v); @fit_to_height = v; end
+    def fit_to_height=(v); Axlsx.validate_unsigned_int(v); @fit_to_height = v; end
     # @see fit_to_width
-    def fit_to_width=(v); Axlsx::validate_unsigned_int(v); @fit_to_width = v; end
+    def fit_to_width=(v); Axlsx.validate_unsigned_int(v); @fit_to_width = v; end
     # @see orientation
-    def orientation=(v); Axlsx::validate_page_orientation(v); @orientation = v; end
+    def orientation=(v); Axlsx.validate_page_orientation(v); @orientation = v; end
     # @see paper_height
-    def paper_height=(v); Axlsx::validate_number_with_unit(v); @paper_height = v; end
+    def paper_height=(v); Axlsx.validate_number_with_unit(v); @paper_height = v; end
     # @see paper_width
-    def paper_width=(v); Axlsx::validate_number_with_unit(v); @paper_width = v; end
+    def paper_width=(v); Axlsx.validate_number_with_unit(v); @paper_width = v; end
     # @see scale
-    def scale=(v); Axlsx::validate_scale_10_400(v); @scale = v; end
+    def scale=(v); Axlsx.validate_scale_10_400(v); @scale = v; end
 
     # convenience method to achieve sanity when setting fit_to_width and fit_to_height
     # as they both default to 1 if only their counterpart is specified.

--- a/lib/axlsx/workbook/worksheet/pane.rb
+++ b/lib/axlsx/workbook/worksheet/pane.rb
@@ -96,28 +96,28 @@ module Axlsx
 
     # @see active_pane
     def active_pane=(v)
-      Axlsx::validate_pane_type(v)
-      @active_pane = Axlsx::camel(v.to_s, false)
+      Axlsx.validate_pane_type(v)
+      @active_pane = Axlsx.camel(v.to_s, false)
     end
 
     # @see state
     def state=(v)
-      Axlsx::validate_split_state_type(v)
-      @state = Axlsx::camel(v.to_s, false)
+      Axlsx.validate_split_state_type(v)
+      @state = Axlsx.camel(v.to_s, false)
     end
 
     # @see top_left_cell
     def top_left_cell=(v)
       cell = (v.instance_of?(Axlsx::Cell) ? v.r_abs : v)
-      Axlsx::validate_string(cell)
+      Axlsx.validate_string(cell)
       @top_left_cell = cell
     end
 
     # @see x_split
-    def x_split=(v); Axlsx::validate_unsigned_int(v); @x_split = v end
+    def x_split=(v); Axlsx.validate_unsigned_int(v); @x_split = v end
 
     # @see y_split
-    def y_split=(v); Axlsx::validate_unsigned_int(v); @y_split = v end
+    def y_split=(v); Axlsx.validate_unsigned_int(v); @y_split = v end
 
     # Serializes the data validation
     # @param [String] str

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -266,7 +266,7 @@ module Axlsx
     # References for header cells
     # @return [Array]
     def header_cell_refs
-      Axlsx::range_to_a(header_range).first
+      Axlsx.range_to_a(header_range).first
     end
 
     # The header cells for the pivot table

--- a/lib/axlsx/workbook/worksheet/protected_ranges.rb
+++ b/lib/axlsx/workbook/worksheet/protected_ranges.rb
@@ -19,7 +19,7 @@ module Axlsx
       sqref = if cells.is_a?(String)
                 cells
               elsif cells.is_a?(SimpleTypedList) || cells.is_a?(Array)
-                Axlsx::cell_range(cells, false)
+                Axlsx.cell_range(cells, false)
               end
       self << ProtectedRange.new(sqref: sqref, name: "Range#{size}")
       last

--- a/lib/axlsx/workbook/worksheet/rich_text_run.rb
+++ b/lib/axlsx/workbook/worksheet/rich_text_run.rb
@@ -221,7 +221,7 @@ module Axlsx
           str << '<' << key.to_s << ' val="' << xml_value(val) << '"/>'
         end
       end
-      clean_value = Axlsx::trust_input ? @value.to_s : ::CGI.escapeHTML(Axlsx::sanitize(@value.to_s))
+      clean_value = Axlsx.trust_input ? @value.to_s : ::CGI.escapeHTML(Axlsx.sanitize(@value.to_s))
       str << '</rPr><t>' << clean_value << '</t></r>'
     end
 

--- a/lib/axlsx/workbook/worksheet/row.rb
+++ b/lib/axlsx/workbook/worksheet/row.rb
@@ -129,7 +129,7 @@ module Axlsx
     # @see height
     def height=(v)
       unless v.nil?
-        Axlsx::validate_unsigned_numeric(v)
+        Axlsx.validate_unsigned_numeric(v)
         @custom_height = true
         @ht = v
       end

--- a/lib/axlsx/workbook/worksheet/selection.rb
+++ b/lib/axlsx/workbook/worksheet/selection.rb
@@ -75,21 +75,21 @@ module Axlsx
     # @see active_cell
     def active_cell=(v)
       cell = (v.instance_of?(Axlsx::Cell) ? v.r_abs : v)
-      Axlsx::validate_string(cell)
+      Axlsx.validate_string(cell)
       @active_cell = cell
     end
 
     # @see active_cell_id
-    def active_cell_id=(v); Axlsx::validate_unsigned_int(v); @active_cell_id = v end
+    def active_cell_id=(v); Axlsx.validate_unsigned_int(v); @active_cell_id = v end
 
     # @see pane
     def pane=(v)
-      Axlsx::validate_pane_type(v)
-      @pane = Axlsx::camel(v, false)
+      Axlsx.validate_pane_type(v)
+      @pane = Axlsx.camel(v, false)
     end
 
     # @see sqref
-    def sqref=(v); Axlsx::validate_string(v); @sqref = v end
+    def sqref=(v); Axlsx.validate_string(v); @sqref = v end
 
     # Serializes the data validation
     # @param [String] str

--- a/lib/axlsx/workbook/worksheet/sheet_view.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_view.rb
@@ -162,32 +162,32 @@ module Axlsx
     end
 
     # @see color_id
-    def color_id=(v); Axlsx::validate_unsigned_int(v); @color_id = v end
+    def color_id=(v); Axlsx.validate_unsigned_int(v); @color_id = v end
 
     # @see top_left_cell
     def top_left_cell=(v)
       cell = (v.instance_of?(Axlsx::Cell) ? v.r_abs : v)
-      Axlsx::validate_string(cell)
+      Axlsx.validate_string(cell)
       @top_left_cell = cell
     end
 
     # @see view
-    def view=(v); Axlsx::validate_sheet_view_type(v); @view = v end
+    def view=(v); Axlsx.validate_sheet_view_type(v); @view = v end
 
     # @see workbook_view_id
-    def workbook_view_id=(v); Axlsx::validate_unsigned_int(v); @workbook_view_id = v end
+    def workbook_view_id=(v); Axlsx.validate_unsigned_int(v); @workbook_view_id = v end
 
     # @see zoom_scale
-    def zoom_scale=(v); Axlsx::validate_scale_0_10_400(v); @zoom_scale = v end
+    def zoom_scale=(v); Axlsx.validate_scale_0_10_400(v); @zoom_scale = v end
 
     # @see zoom_scale_normal
-    def zoom_scale_normal=(v); Axlsx::validate_scale_0_10_400(v); @zoom_scale_normal = v end
+    def zoom_scale_normal=(v); Axlsx.validate_scale_0_10_400(v); @zoom_scale_normal = v end
 
     # @see zoom_scale_page_layout_view
-    def zoom_scale_page_layout_view=(v); Axlsx::validate_scale_0_10_400(v); @zoom_scale_page_layout_view = v end
+    def zoom_scale_page_layout_view=(v); Axlsx.validate_scale_0_10_400(v); @zoom_scale_page_layout_view = v end
 
     # @see zoom_scale_sheet_layout_view
-    def zoom_scale_sheet_layout_view=(v); Axlsx::validate_scale_0_10_400(v); @zoom_scale_sheet_layout_view = v end
+    def zoom_scale_sheet_layout_view=(v); Axlsx.validate_scale_0_10_400(v); @zoom_scale_sheet_layout_view = v end
 
     # Serializes the data validation
     # @param [String] str

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -327,7 +327,7 @@ module Axlsx
     # @param [String] name
     def name=(name)
       validate_sheet_name name
-      @name = Axlsx::coder.encode(name)
+      @name = Axlsx.coder.encode(name)
     end
 
     # The auto filter range for the worksheet
@@ -547,7 +547,7 @@ module Axlsx
       widths.each_with_index do |value, index|
         next if value.nil?
 
-        Axlsx::validate_unsigned_numeric(value) unless value.nil?
+        Axlsx.validate_unsigned_numeric(value) unless value.nil?
         find_or_create_column_info(index).width = value
       end
     end
@@ -688,7 +688,7 @@ module Axlsx
     # @param [String] name The cell or cell range to return. "A1" will return the first cell of the first row.
     # @return [Cell]
     def name_to_cell(name)
-      col_index, row_index = *Axlsx::name_to_indices(name)
+      col_index, row_index = *Axlsx.name_to_indices(name)
 
       r = rows[row_index]
 
@@ -759,7 +759,7 @@ module Axlsx
       raise ArgumentError, format(ERR_SHEET_NAME_TOO_LONG, name) if character_length > WORKSHEET_MAX_NAME_LENGTH
       raise ArgumentError, format(ERR_SHEET_NAME_CHARACTER_FORBIDDEN, name) if WORKSHEET_NAME_FORBIDDEN_CHARS.any? { |char| name.include? char }
 
-      name = Axlsx::coder.encode(name)
+      name = Axlsx.coder.encode(name)
       sheet_names = @workbook.worksheets.reject { |s| s == self }.map(&:name)
       raise ArgumentError, format(ERR_DUPLICATE_SHEET_NAME, name) if sheet_names.include?(name)
     end

--- a/lib/axlsx/workbook/worksheet/worksheet_hyperlink.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_hyperlink.rb
@@ -41,7 +41,7 @@ module Axlsx
     # @param [String|Cell] cell_reference The string reference or cell that defines where this hyperlink shows in the worksheet.
     def ref=(cell_reference)
       cell_reference = cell_reference.r if cell_reference.is_a?(Cell)
-      Axlsx::validate_string cell_reference
+      Axlsx.validate_string cell_reference
       @ref = cell_reference
     end
 
@@ -69,7 +69,7 @@ module Axlsx
     # r:id should only be specified for external targets.
     # @return [Hash]
     def location_or_id
-      @target == :external ? { "r:id": relationship.Id } : { location: Axlsx::coder.encode(location) }
+      @target == :external ? { "r:id": relationship.Id } : { location: Axlsx.coder.encode(location) }
     end
   end
 end

--- a/test/drawing/tc_d_lbls.rb
+++ b/test/drawing/tc_d_lbls.rb
@@ -53,7 +53,7 @@ class TestDLbls < Test::Unit::TestCase
     doc = Nokogiri::XML(str)
 
     Axlsx.instance_values_for(@d_lbls).each do |name, value|
-      assert(doc.xpath("//c:#{Axlsx::camel(name, false)}[@val='#{value}']"), "#{name} is properly serialized")
+      assert(doc.xpath("//c:#{Axlsx.camel(name, false)}[@val='#{value}']"), "#{name} is properly serialized")
     end
   end
 end

--- a/test/tc_axlsx.rb
+++ b/test/tc_axlsx.rb
@@ -96,9 +96,9 @@ class TestAxlsx < Test::Unit::TestCase
   end
 
   def test_range_to_a
-    assert_equal([['A1', 'B1', 'C1']],                         Axlsx::range_to_a('A1:C1'))
-    assert_equal([['A1', 'B1', 'C1'], ['A2', 'B2', 'C2']],     Axlsx::range_to_a('A1:C2'))
-    assert_equal([['Z5', 'AA5', 'AB5'], ['Z6', 'AA6', 'AB6']], Axlsx::range_to_a('Z5:AB6'))
+    assert_equal([['A1', 'B1', 'C1']],                         Axlsx.range_to_a('A1:C1'))
+    assert_equal([['A1', 'B1', 'C1'], ['A2', 'B2', 'C2']],     Axlsx.range_to_a('A1:C2'))
+    assert_equal([['Z5', 'AA5', 'AB5'], ['Z6', 'AA6', 'AB6']], Axlsx.range_to_a('Z5:AB6'))
   end
 
   def test_sanitize_frozen_control_strippped
@@ -165,15 +165,15 @@ class TestAxlsx < Test::Unit::TestCase
   def test_escape_formulas
     Axlsx.instance_variable_set(:@escape_formulas, nil)
 
-    refute Axlsx::escape_formulas
+    refute Axlsx.escape_formulas
 
-    Axlsx::escape_formulas = true
+    Axlsx.escape_formulas = true
 
-    assert Axlsx::escape_formulas
+    assert Axlsx.escape_formulas
 
-    Axlsx::escape_formulas = false
+    Axlsx.escape_formulas = false
 
-    refute Axlsx::escape_formulas
+    refute Axlsx.escape_formulas
   ensure
     Axlsx.instance_variable_set(:@escape_formulas, nil)
   end

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -319,8 +319,8 @@ class TestPackage < Test::Unit::TestCase
   end
 
   def test_name_to_indices
-    assert_equal([0, 0], Axlsx::name_to_indices('A1'))
-    assert_equal([0, 99], Axlsx::name_to_indices('A100'), 'needs to axcept rows that contain 0')
+    assert_equal([0, 0], Axlsx.name_to_indices('A1'))
+    assert_equal([0, 99], Axlsx.name_to_indices('A100'), 'needs to axcept rows that contain 0')
   end
 
   def test_to_stream

--- a/test/util/tc_mime_type_utils.rb
+++ b/test/util/tc_mime_type_utils.rb
@@ -14,11 +14,11 @@ class TestMimeTypeUtils < Test::Unit::TestCase
   def teardown; end
 
   def test_mime_type_utils
-    assert_equal('image/jpeg', Axlsx::MimeTypeUtils::get_mime_type(@test_img))
-    assert_equal('image/png', Axlsx::MimeTypeUtils::get_mime_type_from_uri(@test_img_url))
+    assert_equal('image/jpeg', Axlsx::MimeTypeUtils.get_mime_type(@test_img))
+    assert_equal('image/png', Axlsx::MimeTypeUtils.get_mime_type_from_uri(@test_img_url))
   end
 
   def test_escape_uri
-    assert_raise(URI::InvalidURIError) { Axlsx::MimeTypeUtils::get_mime_type_from_uri('| ls') }
+    assert_raise(URI::InvalidURIError) { Axlsx::MimeTypeUtils.get_mime_type_from_uri('| ls') }
   end
 end

--- a/test/workbook/tc_workbook.rb
+++ b/test/workbook/tc_workbook.rb
@@ -185,7 +185,7 @@ class TestWorkbook < Test::Unit::TestCase
   end
 
   def test_escape_formulas
-    Axlsx::escape_formulas = false
+    Axlsx.escape_formulas = false
     p = Axlsx::Package.new
     @wb = p.workbook
 
@@ -194,7 +194,7 @@ class TestWorkbook < Test::Unit::TestCase
     assert_false @wb.add_worksheet(escape_formulas: false).escape_formulas
     assert @wb.add_worksheet(escape_formulas: true).escape_formulas
 
-    Axlsx::escape_formulas = true
+    Axlsx.escape_formulas = true
     p = Axlsx::Package.new
     @wb = p.workbook
 

--- a/test/workbook/worksheet/tc_comment.rb
+++ b/test/workbook/worksheet/tc_comment.rb
@@ -41,7 +41,7 @@ class TestComment < Test::Unit::TestCase
   end
 
   def test_vml_shape
-    pos = Axlsx::name_to_indices(@c1.ref)
+    pos = Axlsx.name_to_indices(@c1.ref)
 
     assert(@c1.vml_shape.is_a?(Axlsx::VmlShape))
     assert_equal(@c1.vml_shape.column, pos[0])

--- a/test/workbook/worksheet/tc_date_time_converter.rb
+++ b/test/workbook/worksheet/tc_date_time_converter.rb
@@ -16,7 +16,7 @@ class TestDateTimeConverter < Test::Unit::TestCase
       "2006-02-01" => 38_749.0,
       "9999-12-31" => 2_958_465.0
     }.each do |date_string, expected|
-      serial = Axlsx::DateTimeConverter::date_to_serial Date.parse(date_string)
+      serial = Axlsx::DateTimeConverter.date_to_serial Date.parse(date_string)
 
       assert_equal expected, serial
     end
@@ -31,7 +31,7 @@ class TestDateTimeConverter < Test::Unit::TestCase
       "2006-02-01" => 37_287.0,
       "9999-12-31" => 2_957_003.0
     }.each do |date_string, expected|
-      serial = Axlsx::DateTimeConverter::date_to_serial Date.parse(date_string)
+      serial = Axlsx::DateTimeConverter.date_to_serial Date.parse(date_string)
 
       assert_equal expected, serial
     end
@@ -46,7 +46,7 @@ class TestDateTimeConverter < Test::Unit::TestCase
       "1900-01-01T12:00:00Z" => 2.5, # wrongly indicated as 1.5 in the spec!
       "9999-12-31T23:59:59Z" => 2_958_465.9999884
     }.each do |time_string, expected|
-      serial = Axlsx::DateTimeConverter::time_to_serial Time.parse(time_string)
+      serial = Axlsx::DateTimeConverter.time_to_serial Time.parse(time_string)
 
       assert_in_delta expected, serial, @margin_of_error
     end
@@ -61,7 +61,7 @@ class TestDateTimeConverter < Test::Unit::TestCase
       "1904-01-01T12:00:00Z" => 0.5000000,
       "9999-12-31T23:59:59Z" => 2_957_003.9999884
     }.each do |time_string, expected|
-      serial = Axlsx::DateTimeConverter::time_to_serial Time.parse(time_string)
+      serial = Axlsx::DateTimeConverter.time_to_serial Time.parse(time_string)
 
       assert_in_delta expected, serial, @margin_of_error
     end
@@ -72,9 +72,9 @@ class TestDateTimeConverter < Test::Unit::TestCase
     local = Time.parse "2012-01-01 09:00:00 +0900"
 
     assert_equal local, utc
-    assert_equal Axlsx::DateTimeConverter::time_to_serial(local) - (local.utc_offset.to_f / 86_400), Axlsx::DateTimeConverter::time_to_serial(utc)
+    assert_equal Axlsx::DateTimeConverter.time_to_serial(local) - (local.utc_offset.to_f / 86_400), Axlsx::DateTimeConverter.time_to_serial(utc)
     Axlsx::Workbook.date1904 = true
 
-    assert_equal Axlsx::DateTimeConverter::time_to_serial(local) - (local.utc_offset.to_f / 86_400), Axlsx::DateTimeConverter::time_to_serial(utc)
+    assert_equal Axlsx::DateTimeConverter.time_to_serial(local) - (local.utc_offset.to_f / 86_400), Axlsx::DateTimeConverter.time_to_serial(utc)
   end
 end

--- a/test/workbook/worksheet/tc_table_style_info.rb
+++ b/test/workbook/worksheet/tc_table_style_info.rb
@@ -9,7 +9,7 @@ class TestTableStyleInfo < Test::Unit::TestCase
     40.times do
       @ws.add_row %w(aa bb cc dd ee ff gg hh ii jj kk)
     end
-    @table = @ws.add_table(Axlsx::cell_range([@ws.rows.first.cells.first, @ws.rows.last.cells.last], false), name: 'foo')
+    @table = @ws.add_table(Axlsx.cell_range([@ws.rows.first.cells.first, @ws.rows.last.cells.last], false), name: 'foo')
     @options =  { show_first_column: 1,
                   show_last_column: 1,
                   show_row_stripes: 1,

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -456,14 +456,14 @@ class TestWorksheet < Test::Unit::TestCase
   end
 
   def test_to_xml_string_with_illegal_chars
-    old = Axlsx::trust_input
-    Axlsx::trust_input = false
+    old = Axlsx.trust_input
+    Axlsx.trust_input = false
     nasties = "\v\u2028\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u001f"
     @ws.add_row [nasties]
 
     assert_equal(0, @ws.rows.last.cells.last.value.index("\v"))
     assert_nil(@ws.to_xml_string.index("\v"))
-    Axlsx::trust_input = old
+    Axlsx.trust_input = old
   end
 
   def test_to_xml_string_with_newlines


### PR DESCRIPTION
Caxlsx is using both `.` and `::`, 220 occurrences vs 280 to invoke
methods on `Axlsx` module.

This commit standardizes the approach towards `.`, which will also allow
shorter lines.

Performance is not affected

```
Comparison:
      Axlsx.validate:  8515252.3 i/s
     Axlsx::validate:  8512863.7 i/s - same-ish: difference falls within error 
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).