### PR TITLE
Enable Naming/PredicateName cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -103,18 +103,6 @@ Naming/MethodName:
 Naming/MethodParameterName:
   Enabled: false
 
-# Configuration parameters: NamePrefix, ForbiddenPrefixes, AllowedMethods, MethodDefinitionMacros.
-# NamePrefix: is_, has_, have_
-# ForbiddenPrefixes: is_, has_, have_
-# AllowedMethods: is_a?
-# MethodDefinitionMacros: define_method, define_singleton_method
-Naming/PredicateName:
-  Exclude:
-    - 'spec/**/*'
-    - 'lib/axlsx/workbook/worksheet/cell.rb'
-    - 'lib/axlsx/workbook/worksheet/worksheet_comments.rb'
-    - 'lib/axlsx/workbook/worksheet/worksheet_drawing.rb'
-
 # Configuration parameters: EnforcedStyle, AllowedIdentifiers, AllowedPatterns.
 # SupportedStyles: snake_case, camelCase
 Naming/VariableName:

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -167,7 +167,7 @@ module Axlsx
 
     # Indicates that the cell has one or more of the custom cell styles applied.
     # @return [Boolean]
-    def is_text_run?
+    def is_text_run? # rubocop:disable Naming/PredicateName
       defined?(@is_text_run) && @is_text_run && !contains_rich_text?
     end
 
@@ -391,13 +391,13 @@ module Axlsx
       CellSerializer.to_xml_string r_index, c_index, self, str
     end
 
-    def is_formula?
+    def is_formula? # rubocop:disable Naming/PredicateName
       return false if escape_formulas
 
       type == :string && @value.to_s.start_with?(FORMULA_PREFIX)
     end
 
-    def is_array_formula?
+    def is_array_formula? # rubocop:disable Naming/PredicateName
       return false if escape_formulas
 
       type == :string &&

--- a/lib/axlsx/workbook/worksheet/worksheet_comments.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_comments.rb
@@ -37,7 +37,7 @@ module Axlsx
 
     # Helper method to tell us if there are comments in the comments collection
     # @return [Boolean]
-    def has_comments?
+    def has_comments? # rubocop:disable Naming/PredicateName
       !comments.empty?
     end
 

--- a/lib/axlsx/workbook/worksheet/worksheet_drawing.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_drawing.rb
@@ -38,7 +38,7 @@ module Axlsx
 
     # helper method to tell us if the drawing has something in it or not
     # @return [Boolean]
-    def has_drawing?
+    def has_drawing? # rubocop:disable Naming/PredicateName
       @drawing.is_a? Drawing
     end
 


### PR DESCRIPTION
Renaming the existing methods would break the public API, and it is not
worth to alias and/or deprecate existing methods, so this commit
enables Naming/PredicateName and allows the existing methods to preserve
their name

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).