### PR TITLE
Fix Lint/NonLocalExitFromIterator offense

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -56,10 +56,6 @@ Lint/DisjunctiveAssignmentInConstructor:
   Exclude:
     - 'lib/axlsx/drawing/num_data_source.rb'
 
-Lint/NonLocalExitFromIterator:
-  Exclude:
-    - 'lib/axlsx/util/validators.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: IgnoreEmptyBlocks, AllowUnusedKeywordArguments.
 Lint/UnusedBlockArgument:

--- a/lib/axlsx/util/validators.rb
+++ b/lib/axlsx/util/validators.rb
@@ -60,9 +60,8 @@ module Axlsx
       end
 
       v_class = v.is_a?(Class) ? v : v.class
-      Array(types).each do |t|
-        return if v_class <= t
-      end
+      return if Array(types).any? { |t| v_class <= t }
+
       raise ArgumentError, format(ERR_TYPE, v.inspect, name, types.inspect)
     end
   end


### PR DESCRIPTION
Uses `Array#any?` instead of `Array#each`.

According to benchmarks, `any?` is slightly faster when validation fails (3%) and noticeably faster when validation passes (up to 60%)

---

I'm consistently getting better results in benchmark after this change, can you please take a look?

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).