### PR TITLE
Require 'cgi' at module level

### DIFF
--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -30,6 +30,7 @@ require 'zip'
 
 # core dependencies
 require 'bigdecimal'
+require 'cgi'
 require 'set'
 require 'time'
 

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'cgi'
 module Axlsx
   # A cell in a worksheet.
   # Cell stores inforamation requried to serialize a single worksheet cell to xml. You must provde the Row that the cell belongs to and the cells value. The data type will automatically be determed if you do not specify the :type option. The default style will be applied if you do not supply the :style option. Changing the cell's type will recast the value to the type specified. Altering the cell's value via the property accessor will also automatically cast the provided value to the cell's type.


### PR DESCRIPTION
Previously, `require 'cgi'` was only called in `cell.rb`, but there are other components in the Axlsx module that also use this dependency, including `Axlsx::SeriesTitle`, `Axlsx::StrVal`, `Axlsx::Title` (drawing), `Axlsx::Comment`, `Axlsx::ConditionalFormattingRule`, and `Axlsx::HeaderFooter`.

By requiring cgi at the module level, we ensure that this dependency is available to all components in the Axlsx module, which can prevent issues if someone is requiring specific components that depend on cgi.

This change improves the maintainability and reliability of the codebase by ensuring that all components have access to the required dependencies.

Close #282

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).