### PR TITLE
Fix Style/PreferredHashMethods offense

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -271,13 +271,6 @@ Style/PerlBackrefs:
   Exclude:
     - 'test/workbook/worksheet/tc_sheet_protection.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: short, verbose
-Style/PreferredHashMethods:
-  Exclude:
-    - 'lib/axlsx.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: same_as_string_literals, single_quotes, double_quotes

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -33,7 +33,7 @@ require 'bigdecimal'
 require 'set'
 require 'time'
 
-if Gem.loaded_specs.has_key?("axlsx_styler")
+if Gem.loaded_specs.key?("axlsx_styler")
   raise StandardError, "Please remove `axlsx_styler` from your Gemfile, the associated functionality is now built-in to `caxlsx` directly."
 end
 


### PR DESCRIPTION
`Gem.loaded_specs` is a hash, so it is safe to use `key?` and enable this cop

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).