### PR TITLE
Remove conditional check for `encode` method

### DIFF
--- a/lib/axlsx/util/constants.rb
+++ b/lib/axlsx/util/constants.rb
@@ -397,9 +397,8 @@ module Axlsx
   # x0A Line Feed (Lf)
   # x0D Carriage Return (Cr)
   # x09 Character Tabulation
-  # @see http://www.codetable.net/asciikeycodes
-  pattern = "\x0-\x08\x0B\x0C\x0E-\x1F"
-  pattern = pattern.respond_to?(:encode) ? pattern.encode('UTF-8') : pattern
+  # @see https://www.codetable.net/asciikeycodes
+  pattern = "\x0-\x08\x0B\x0C\x0E-\x1F".encode('UTF-8')
 
   # The regular expression used to remove control characters from worksheets
   CONTROL_CHARS = pattern.freeze


### PR DESCRIPTION
All supported Ruby versions now support the `encode` method on strings, so the conditional check for this method has been removed. Even if the default encoding on Ruby >= 2.0 is UTF-8, this is not always the case when the `LANG` environment variable is not set to `C.UTF-8`, so the `encode` method has been preserved.

Additionally, this commit updates a link to use the `https` protocol for improved security.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).