### PR TITLE
Use encoding constant instead of hardcoded string

### DIFF
--- a/lib/axlsx/util/constants.rb
+++ b/lib/axlsx/util/constants.rb
@@ -398,7 +398,7 @@ module Axlsx
   # x0D Carriage Return (Cr)
   # x09 Character Tabulation
   # @see https://www.codetable.net/asciikeycodes
-  pattern = "\x0-\x08\x0B\x0C\x0E-\x1F".encode('UTF-8')
+  pattern = "\x0-\x08\x0B\x0C\x0E-\x1F".encode(Encoding::UTF_8)
 
   # The regular expression used to remove control characters from worksheets
   CONTROL_CHARS = pattern.freeze


### PR DESCRIPTION
Ref: https://ruby-doc.org/core-2.6.10/Encoding.html#class-Encoding-label-Changing+an+encoding

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).