### PR TITLE
Use `class.name` instead of `class.to_s`

### DIFF
--- a/lib/axlsx/drawing/area_chart.rb
+++ b/lib/axlsx/drawing/area_chart.rb
@@ -63,7 +63,7 @@ module Axlsx
     # chart based on the actual class type and not a fixed node name.
     # @return [String]
     def node_name
-      path = self.class.to_s
+      path = self.class.name
       if i = path.rindex('::')
         path = path[(i + 2)..-1]
       end

--- a/lib/axlsx/drawing/line_chart.rb
+++ b/lib/axlsx/drawing/line_chart.rb
@@ -63,7 +63,7 @@ module Axlsx
     # chart based on the actual class type and not a fixed node name.
     # @return [String]
     def node_name
-      path = self.class.to_s
+      path = self.class.name
       if i = path.rindex('::')
         path = path[(i + 2)..-1]
       end


### PR DESCRIPTION
`class.name` is faster, uses less memory than `class.to_s`, and can be used in this context.

This micro optimization does not have practical effect, it is just a reference for the future in case this approach will be needed in other parts of the library

```
Comparison (IPS):
         Object.name: 13528803.0 i/s
         Object.to_s:  8213612.0 i/s - 1.65x  (± 0.00) slower

Comparison (Memory):
         Object.name:          0 allocated
         Object.to_s:         40 allocated - Infx more
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).