### PR TITLE
Fix data validations for none type validations to show warnings only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
   - Add 'SortState' and 'SortCondition' classes to the 'AutoFilter' class to add sorting to the generated file.
   - [PR #189](https://github.com/caxlsx/caxlsx/pull/189) - Make `Axlsx::escape_formulas` true by default to mitigate [Formula Injection](https://www.owasp.org/index.php/CSV_Injection) vulnerabilities.
   - [PR #269](https://github.com/caxlsx/caxlsx/pull/269) - Add optional interpolation points to icon sets
+  - [PR #304](https://github.com/caxlsx/caxlsx/pull/304) - Fix data validations for none type validations
 
 - **April.23.23**: 3.4.1
   - [PR #209](https://github.com/caxlsx/caxlsx/pull/209) - Revert characters other than `=` being considered as formulas.

--- a/lib/axlsx/workbook/worksheet/data_validation.rb
+++ b/lib/axlsx/workbook/worksheet/data_validation.rb
@@ -254,17 +254,15 @@ module Axlsx
       attributes = [:allowBlank, :error, :errorStyle, :errorTitle, :prompt, :promptTitle, :showErrorMessage, :showInputMessage, :sqref, :type]
 
       if [:whole, :decimal, :data, :time, :date, :textLength].include?(@type)
-        attributes << [:operator, :formula1]
-        attributes << [:formula2] if [:between, :notBetween].include?(@operator)
+        attributes << :operator << :formula1
+        attributes << :formula2 if [:between, :notBetween].include?(@operator)
       elsif @type == :list
-        attributes << [:showDropDown, :formula1]
+        attributes << :showDropDown << :formula1
       elsif @type == :custom
-        attributes << [:formula1]
-      else
-        attributes = []
+        attributes << :formula1
       end
 
-      attributes.flatten!
+      attributes
     end
   end
 end

--- a/test/workbook/worksheet/tc_data_validation.rb
+++ b/test/workbook/worksheet/tc_data_validation.rb
@@ -239,6 +239,24 @@ class TestDataValidation < Test::Unit::TestCase
     assert doc.xpath("//xmlns:worksheet/xmlns:dataValidations/xmlns:dataValidation/xmlns:formula1='=5/2'")
   end
 
+  def test_none_to_xml
+    p = Axlsx::Package.new
+    @ws = p.workbook.add_worksheet name: "data_validation"
+    @ws.add_data_validation("A1", { type: :none,
+                                    showInputMessage: true, promptTitle: 'Be careful!',
+                                    prompt: 'This is a warning to be extra careful editing this cell' })
+
+    doc = Nokogiri::XML.parse(@ws.to_xml_string)
+
+    # test attributes
+    assert_equal(1, doc.xpath("//xmlns:worksheet/xmlns:dataValidations[@count='1']/xmlns:dataValidation[@sqref='A1']
+      [@promptTitle='Be careful!'][@prompt='This is a warning to be extra careful editing this cell']
+      [@allowBlank=1][@showInputMessage=1][@type='none']").size)
+    assert doc.xpath("//xmlns:worksheet/xmlns:dataValidations[@count='1']/xmlns:dataValidation[@sqref='A1']
+      [@promptTitle='Be careful!'][@prompt='This is a warning to be extra careful editing this cell']
+      [@allowBlank=1][@showInputMessage=1][@type='none']")
+  end
+
   def test_multiple_datavalidations_to_xml
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet name: "data_validation"
@@ -276,6 +294,15 @@ class TestDataValidation < Test::Unit::TestCase
   def test_empty_attributes
     v = Axlsx::DataValidation.new
 
-    assert_nil(v.send(:get_valid_attributes))
+    assert_equal([:allowBlank,
+                  :error,
+                  :errorStyle,
+                  :errorTitle,
+                  :prompt,
+                  :promptTitle,
+                  :showErrorMessage,
+                  :showInputMessage,
+                  :sqref,
+                  :type], v.send(:get_valid_attributes))
   end
 end


### PR DESCRIPTION
### Description

Recently I had to generate an excel sheet where one of the cells got a warning message when the client moves the cursor on it. To do that, I added a `none` type validation to the cell which means there are no bad values, but we'll have the message shown.

However, I've run into a `undefined method `include?' for nil:NilClass` error doing it, so I quickly looked into the source code and found the issue.

With the fix in place, you can run this code snippet to get the expected result

```ruby
sheet.add_data_validation('B1:B10',
  type: :none,
  showInputMessage: true,
  prompt: 'Be extra careful editing this cell!')
```

![image](https://github.com/caxlsx/caxlsx/assets/1900366/9cf526c9-08e2-427d-b505-305e19e71820)


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).