### PR TITLE
Escape formulas by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
   - Fix `Workbook#sheet_by_name` not returning sheets with encoded characters in the name
   - Raise exception if `axlsx_styler` gem is present as its code was merged directly into `caxlsx` in v3.3.0
   - Add 'SortState' and 'SortCondition' classes to the 'AutoFilter' class to add sorting to the generated file.
+  - [PR #189](https://github.com/caxlsx/caxlsx/pull/189) - Make `Axlsx::escape_formulas` true by default to mitigate [Formula Injection](https://www.owasp.org/index.php/CSV_Injection) vulnerabilities.
 
 - **April.23.23**: 3.4.1
   - [PR #209](https://github.com/caxlsx/caxlsx/pull/209) - Revert characters other than `=` being considered as formulas.

--- a/README.md
+++ b/README.md
@@ -124,23 +124,19 @@ Currently the following additional gems are available:
 
 ## Security
 
-To prevent [Formula Injection](https://www.owasp.org/index.php/CSV_Injection) vulnerabilities, set the following in an initializer:
-
-```ruby
-Axlsx.escape_formulas = true
-```
-
-Then, set the following on each cell you'd like to add a formula:
+To prevent [Formula Injection](https://www.owasp.org/index.php/CSV_Injection) vulnerabilities, as of version 4.0, axlsx escapes all formulas by default. To permit formulas on a specific cell, please use:
 
 ```ruby
 cell.escape_formulas = false
 ```
 
-Refer to examples/escape_formula.md for how to set `escape_formulas` on the workbook, worksheet, row and/or cell level.
+You may set `escape_formulas` on the workbook, worksheet, row and/or cell level. Refer to examples/escape_formula.md for details.
 
-**Important:** The global setting `Axlsx.escape_formulas = true` will become the default in the next major release (Axlsx 4.0).
-If you do not wish to set `Axlsx.escape_formulas = true` now, at a minimum, please set `Axlsx.escape_formulas = false` to
-ensure continuity when upgrading.
+To allow formulas globally by default (which was the behavior in axlsx 3.x and prior), you may set the following in an initializer:
+
+```ruby
+Axlsx.escape_formulas = false
+```
 
 ## Known Software Interoperability Issues
 

--- a/examples/basic_formula_example.md
+++ b/examples/basic_formula_example.md
@@ -7,6 +7,8 @@ You could insert formulas
 ```ruby
 require 'axlsx'
 
+Axlsx.escape_formulas = false
+
 p = Axlsx::Package.new
 wb = p.workbook
 

--- a/examples/cached_formula_example.md
+++ b/examples/cached_formula_example.md
@@ -7,6 +7,8 @@ When you add a formula in Excel, it immediately calculates its value and store i
 ```ruby
 require 'axlsx'
 
+Axlsx.escape_formulas = false
+
 p = Axlsx::Package.new
 wb = p.workbook
 

--- a/examples/column_outlines_example.md
+++ b/examples/column_outlines_example.md
@@ -7,6 +7,8 @@ If you have a list of data that you want to group and summarize, you can create 
 ```ruby
 require 'axlsx'
 
+Axlsx.escape_formulas = false
+
 p = Axlsx::Package.new
 wb = p.workbook
 

--- a/examples/complex_example.md
+++ b/examples/complex_example.md
@@ -7,6 +7,8 @@ This is a complex example with a worksheet full of data.
 ```ruby
 require 'axlsx'
 
+Axlsx.escape_formulas = false
+
 p = Axlsx::Package.new
 wb = p.workbook
 

--- a/examples/defined_name_example.md
+++ b/examples/defined_name_example.md
@@ -7,6 +7,8 @@ You could use defined names in formulas
 ```ruby
 require 'axlsx'
 
+Axlsx.escape_formulas = false
+
 p = Axlsx::Package.new
 wb = p.workbook
 

--- a/examples/row_outlines_example.md
+++ b/examples/row_outlines_example.md
@@ -7,6 +7,8 @@ If you have a list of data that you want to group and summarize, you can create 
 ```ruby
 require 'axlsx'
 
+Axlsx.escape_formulas = false
+
 p = Axlsx::Package.new
 wb = p.workbook
 

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -220,7 +220,7 @@ module Axlsx
   # See https://www.owasp.org/index.php/CSV_Injection for details.
   # @return [Boolean]
   def self.escape_formulas
-    !defined?(@escape_formulas) || @escape_formulas.nil? ? false : @escape_formulas
+    !defined?(@escape_formulas) || @escape_formulas.nil? ? true : @escape_formulas
   end
 
   # Sets whether to treat values starting with an equals sign as formulas or as literal strings.

--- a/test/tc_axlsx.rb
+++ b/test/tc_axlsx.rb
@@ -165,7 +165,7 @@ class TestAxlsx < Test::Unit::TestCase
   def test_escape_formulas
     Axlsx.instance_variable_set(:@escape_formulas, nil)
 
-    refute Axlsx.escape_formulas
+    assert Axlsx.escape_formulas
 
     Axlsx.escape_formulas = true
 

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -512,7 +512,7 @@ class TestCell < Test::Unit::TestCase
 
   def test_to_xml_string_array_formula
     p = Axlsx::Package.new
-    ws = p.workbook.add_worksheet do |sheet|
+    ws = p.workbook.add_worksheet(escape_formulas: false) do |sheet|
       sheet.add_row ["{=SUM(C2:C11*D2:D11)}"]
     end
     doc = Nokogiri::XML(ws.to_xml_string)

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -411,7 +411,7 @@ class TestCell < Test::Unit::TestCase
 
   def test_to_xml_string_formula
     p = Axlsx::Package.new
-    ws = p.workbook.add_worksheet do |sheet|
+    ws = p.workbook.add_worksheet(escape_formulas: false) do |sheet|
       sheet.add_row ["=IF(2+2=4,4,5)"]
     end
     doc = Nokogiri::XML(ws.to_xml_string)


### PR DESCRIPTION
### Description

It's a rebased version of #189 as I can't push to the original PR, nor change the base branch for the PR.

It sets the global default of `escape_formulas` to true and should be released in 4.0

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).