### PR TITLE
Fix frozen string error for scatter series with non-default marker

### DIFF
--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -121,7 +121,7 @@ module Axlsx
       if !@show_marker
         '<c:symbol val="none"/>'
       elsif @marker_symbol != :default
-        '<c:symbol val="' << @marker_symbol.to_s << '"/>'
+        +'<c:symbol val="' << @marker_symbol.to_s << '"/>'
       end.to_s
     end
   end

--- a/test/drawing/tc_scatter_series.rb
+++ b/test/drawing/tc_scatter_series.rb
@@ -60,6 +60,15 @@ class TestScatterSeries < Test::Unit::TestCase
     assert_equal(1, doc.xpath("//a:ln[@w='#{@series.ln_width}']").length)
   end
 
+  def test_to_xml_string_non_default_marker
+    @chart = @ws.add_chart Axlsx::ScatterChart, title: 'Line chart', scatter_style: :smoothMarker
+    @series = @chart.add_series xData: [1, 2, 4], yData: [1, 3, 9]
+    @series.marker_symbol = :circle
+    doc = Nokogiri::XML(@chart.to_xml_string)
+
+    assert_equal(1, doc.xpath("//c:symbol[@val='#{@series.marker_symbol}']").length)
+  end
+
   def test_false_show_marker
     @chart = @ws.add_chart Axlsx::ScatterChart, title: 'Smooth Chart', scatter_style: :smoothMarker
     @series = @chart.add_series xData: [1, 2, 4], yData: [1, 3, 9]


### PR DESCRIPTION
### Description

While I was preparing #308 , I found a small bug: we introduced frozen string literals _and_ changed `'XY' + str` to `'XY' << str` which ended up in an error saying you can't modify a frozen string. I added a test to cover the code branch and fixed the issue

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).