### PR TITLE
Use symbol conversion instead of to_sym

### DIFF
--- a/lib/axlsx/stylesheet/styles.rb
+++ b/lib/axlsx/stylesheet/styles.rb
@@ -364,7 +364,7 @@ module Axlsx
     #   { :border => { :style => :thick, :color => "FFFF0000", :edges => [:top, :bottom] }
     # @return [Border|Integer]
     def parse_border_options(options = {})
-      if options[:border].nil? && Border::EDGES.all? { |x| options["border_#{x}".to_sym].nil? }
+      if options[:border].nil? && Border::EDGES.all? { |x| options[:"border_#{x}"].nil? }
         return nil
       end
 
@@ -409,7 +409,7 @@ module Axlsx
       end
 
       Border::EDGES.each do |edge|
-        val = options["border_#{edge}".to_sym]
+        val = options[:"border_#{edge}"]
 
         if val
           borders_array << val.merge(edges: [edge])
@@ -430,8 +430,8 @@ module Axlsx
           end
         end
 
-        if options["border_#{edge}".to_sym]
-          edge_b_opts = edge_b_opts.merge(options["border_#{edge}".to_sym])
+        if options[:"border_#{edge}"]
+          edge_b_opts = edge_b_opts.merge(options[:"border_#{edge}"])
           skip_edge = false
         end
 

--- a/test/stylesheet/tc_styles.rb
+++ b/test/stylesheet/tc_styles.rb
@@ -323,7 +323,7 @@ class TestStyles < Test::Unit::TestCase
     }
 
     borders.each do |edge, b_opts|
-      @styles.add_style("border_#{edge}".to_sym => b_opts)
+      @styles.add_style("border_#{edge}": b_opts)
 
       current_border = @styles.borders.last
 

--- a/test/tc_axlsx.rb
+++ b/test/tc_axlsx.rb
@@ -126,7 +126,7 @@ class TestAxlsx < Test::Unit::TestCase
   class InstanceValuesSubject
     def initialize(args = {})
       args.each do |key, v|
-        instance_variable_set("@#{key}".to_sym, v)
+        instance_variable_set(:"@#{key}", v)
       end
     end
   end

--- a/test/workbook/worksheet/tc_data_validation.rb
+++ b/test/workbook/worksheet/tc_data_validation.rb
@@ -47,22 +47,22 @@ class TestDataValidation < Test::Unit::TestCase
 
   def test_boolean_attribute_validation
     @boolean_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be boolean") { @dv.send("#{key}=".to_sym, 'A') }
-      assert_nothing_raised { @dv.send("#{key}=".to_sym, value) }
+      assert_raise(ArgumentError, "#{key} must be boolean") { @dv.send(:"#{key}=", 'A') }
+      assert_nothing_raised { @dv.send(:"#{key}=", value) }
     end
   end
 
   def test_string_attribute_validation
     @string_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be string") { @dv.send("#{key}=".to_sym, :symbol) }
-      assert_nothing_raised { @dv.send("#{key}=".to_sym, value) }
+      assert_raise(ArgumentError, "#{key} must be string") { @dv.send(:"#{key}=", :symbol) }
+      assert_nothing_raised { @dv.send(:"#{key}=", value) }
     end
   end
 
   def test_symbol_attribute_validation
     @symbol_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be symbol") { @dv.send("#{key}=".to_sym, "foo") }
-      assert_nothing_raised { @dv.send("#{key}=".to_sym, value) }
+      assert_raise(ArgumentError, "#{key} must be symbol") { @dv.send(:"#{key}=", "foo") }
+      assert_nothing_raised { @dv.send(:"#{key}=", value) }
     end
   end
 

--- a/test/workbook/worksheet/tc_sheet_protection.rb
+++ b/test/workbook/worksheet/tc_sheet_protection.rb
@@ -47,8 +47,8 @@ class TestSheetProtection < Test::Unit::TestCase
 
   def test_boolean_attribute_validation
     @boolean_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be boolean") { @sp.send("#{key}=".to_sym, 'A') }
-      assert_nothing_raised { @sp.send("#{key}=".to_sym, value) }
+      assert_raise(ArgumentError, "#{key} must be boolean") { @sp.send(:"#{key}=", 'A') }
+      assert_nothing_raised { @sp.send(:"#{key}=", value) }
     end
   end
 

--- a/test/workbook/worksheet/tc_sheet_view.rb
+++ b/test/workbook/worksheet/tc_sheet_view.rb
@@ -47,29 +47,29 @@ class TestSheetView < Test::Unit::TestCase
 
   def test_boolean_attribute_validation
     @boolean_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be boolean") { @sv.send("#{key}=".to_sym, 'A') }
-      assert_nothing_raised { @sv.send("#{key}=".to_sym, value) }
+      assert_raise(ArgumentError, "#{key} must be boolean") { @sv.send(:"#{key}=", 'A') }
+      assert_nothing_raised { @sv.send(:"#{key}=", value) }
     end
   end
 
   def test_string_attribute_validation
     @string_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be string") { @sv.send("#{key}=".to_sym, :symbol) }
-      assert_nothing_raised { @sv.send("#{key}=".to_sym, value) }
+      assert_raise(ArgumentError, "#{key} must be string") { @sv.send(:"#{key}=", :symbol) }
+      assert_nothing_raised { @sv.send(:"#{key}=", value) }
     end
   end
 
   def test_symbol_attribute_validation
     @symbol_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be symbol") { @sv.send("#{key}=".to_sym, "foo") }
-      assert_nothing_raised { @sv.send("#{key}=".to_sym, value) }
+      assert_raise(ArgumentError, "#{key} must be symbol") { @sv.send(:"#{key}=", "foo") }
+      assert_nothing_raised { @sv.send(:"#{key}=", value) }
     end
   end
 
   def test_integer_attribute_validation
     @integer_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be integer") { @sv.send("#{key}=".to_sym, "foo") }
-      assert_nothing_raised { @sv.send("#{key}=".to_sym, value) }
+      assert_raise(ArgumentError, "#{key} must be integer") { @sv.send(:"#{key}=", "foo") }
+      assert_nothing_raised { @sv.send(:"#{key}=", value) }
     end
   end
 


### PR DESCRIPTION
Compared to String#to_sym, symbol conversion is:

- 6 character shorter
- Highlighted as a symbol (at least by TextMate and VS Code)
- 7% faster

This offense is not being detected by Rubocop because caxlsx is using an old version which works on 2.6 and the current version does not detect this problem because of rubocop/rubocop#12373

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).