### PR TITLE
Add label rotation for labels and gridline color option for axes

### DIFF
--- a/lib/axlsx/drawing/axis.rb
+++ b/lib/axlsx/drawing/axis.rb
@@ -16,7 +16,7 @@ module Axlsx
       @format_code = "General"
       @delete = @label_rotation = 0
       @scaling = Scaling.new(orientation: :minMax)
-      @title = @color = nil
+      @title = @color = @gridline_color = nil
       self.ax_pos = :b
       self.tick_lbl_pos = :nextTo
       self.format_code = "General"
@@ -75,6 +75,11 @@ module Axlsx
     # @return [Boolean]
     attr_reader :gridlines
 
+    # the fill color to use in the gridline shape properties. This should be a 6 character long hex string
+    # e.g. FF0000 for red
+    # @return [String]
+    attr_reader :gridline_color
+
     # specifies if gridlines should be shown in the chart
     # @return [Boolean]
     attr_reader :delete
@@ -88,6 +93,10 @@ module Axlsx
     # @see color
     def color=(color_rgb)
       @color = color_rgb
+    end
+
+    def gridline_color=(color_rgb)
+      @gridline_color = color_rgb
     end
 
     # The crossing axis for this axis
@@ -159,6 +168,14 @@ module Axlsx
         str << '<c:spPr>'
         str << '<a:ln>'
         str << '<a:noFill/>'
+        str << '</a:ln>'
+        str << '</c:spPr>'
+      elsif gridlines && !gridline_color.to_s.empty?
+        str << '<c:spPr>'
+        str << '<a:ln>'
+        str << '<a:solidFill>'
+        str << '<a:srgbClr val="' << gridline_color.to_s << '"/>'
+        str << '</a:solidFill>'
         str << '</a:ln>'
         str << '</c:spPr>'
       end

--- a/lib/axlsx/drawing/d_lbls.rb
+++ b/lib/axlsx/drawing/d_lbls.rb
@@ -40,12 +40,17 @@ module Axlsx
        :show_leader_lines].each do |attr|
         send("#{attr}=", false)
       end
+      self.label_rotation = 0
     end
 
     # The chart type that is using this data lables instance.
     # This affects the xml output as not all chart types support the
     # same data label attributes.
     attr_reader :chart_type
+
+    # specifies how the degree of label rotation
+    # @return [Integer]
+    attr_reader :label_rotation
 
     # The position of the data labels in the chart
     # @see d_lbl_pos= for a list of allowed values
@@ -69,11 +74,23 @@ module Axlsx
       @d_lbl_pos = label_position
     end
 
+    # Specify the degree of label rotation to apply to labels
+    # default 0
+    def label_rotation=(v)
+      Axlsx.validate_int(v)
+      adjusted = v.to_i * 60000
+      Axlsx.validate_angle(adjusted)
+      @label_rotation = adjusted
+    end
+
     # serializes the data labels
     # @return [String]
     def to_xml_string(str = +'')
       validate_attributes_for_chart_type
       str << '<c:dLbls>'
+
+      str << '<c:txPr><a:bodyPr rot="' << label_rotation.to_s << '"/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:endParaRPr/></a:p></c:txPr>'
+
       instance_vals = Axlsx.instance_values_for(self)
       %w(d_lbl_pos show_legend_key show_val show_cat_name show_ser_name show_percent show_bubble_size show_leader_lines).each do |key|
         next unless instance_vals.key?(key) && !instance_vals[key].nil?


### PR DESCRIPTION
### Description
This PR adds two properties:
- rotation for d_lbls to be able to e.g. rotate labels of bars in a bar graph
- gridlines color for axes

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).