### PR TITLE
Don't change hyperlinks 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 CHANGELOG
 ---------
 - **Unreleased**
+  - [PR #316](https://github.com/caxlsx/caxlsx/pull/316) Prevent camelization of hyperlink locations
 
 
 - **October.30.23**: 4.0.0

--- a/lib/axlsx/workbook/worksheet/worksheet_hyperlink.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_hyperlink.rb
@@ -60,7 +60,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = +'')
       str << '<hyperlink '
-      serialized_attributes str, location_or_id
+      serialized_attributes str, location_or_id, false
       str << '/>'
     end
 

--- a/test/workbook/worksheet/tc_worksheet_hyperlink.rb
+++ b/test/workbook/worksheet/tc_worksheet_hyperlink.rb
@@ -55,4 +55,12 @@ class TestWorksheetHyperlink < Test::Unit::TestCase
     assert_equal(0, doc.xpath("//xmlns:hyperlink[@location='#{@a.location}']").size)
     assert_equal(1, doc.xpath("//xmlns:hyperlink[@r:id='#{@a.relationship.Id}']").size)
   end
+
+  def test_to_xml_string_with_underscores
+    @a.location = "'dummy_sheet_2'!A1"
+    doc = Nokogiri::XML(@ws.to_xml_string)
+    assert_equal(1, doc.xpath("//xmlns:hyperlink/@location").size)
+    assert_equal(@a.location, doc.xpath("//xmlns:hyperlink/@location").first.value)
+  end
+
 end

--- a/test/workbook/worksheet/tc_worksheet_hyperlink.rb
+++ b/test/workbook/worksheet/tc_worksheet_hyperlink.rb
@@ -59,8 +59,8 @@ class TestWorksheetHyperlink < Test::Unit::TestCase
   def test_to_xml_string_with_underscores
     @a.location = "'dummy_sheet_2'!A1"
     doc = Nokogiri::XML(@ws.to_xml_string)
+
     assert_equal(1, doc.xpath("//xmlns:hyperlink/@location").size)
     assert_equal(@a.location, doc.xpath("//xmlns:hyperlink/@location").first.value)
   end
-
 end


### PR DESCRIPTION
### Description
`sheet.add_hyperlink()` converts the given location to "lower camel case", altering sheet names containing underscores in the process, making them invalid.

This PR turns off camelization, as suggested in #311. Closes #311.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).