### PR TITLE
Use attr_reader for use autowidth

### DIFF
--- a/lib/axlsx/workbook/workbook.rb
+++ b/lib/axlsx/workbook/workbook.rb
@@ -280,7 +280,7 @@ module Axlsx
     #     calculation. Thus the performance benefits of turning this off are
     #     marginal unless you are creating a very large sheet.
     # @return [Boolean]
-    def use_autowidth() @use_autowidth; end
+    attr_reader :use_autowidth
 
     # see @use_autowidth
     def use_autowidth=(v = true) Axlsx.validate_boolean v; @use_autowidth = v; end


### PR DESCRIPTION
Offense found by `fasterer` gem.

Using `attr_reader` for both uniformity and performance (10-20% improvement according to the Ruby version)

Close #318

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).