### PR TITLE
Fix Style/Semicolon offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,9 +46,6 @@ Security:
 Style:
   Enabled: true
 
-Style/Semicolon:
-  AllowAsExpressionSeparator: true
-
 Style/NumericLiterals:
   Exclude:
     - 'lib/**/*'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -247,16 +247,6 @@ Style/RedundantRegexpEscape:
 Style/SafeNavigation:
   Enabled: false
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowIfMethodIsEmpty.
-Style/SingleLineMethods:
-  Exclude:
-    - 'lib/axlsx/workbook/workbook.rb'
-    - 'lib/axlsx/workbook/worksheet/cell.rb'
-    - 'lib/axlsx/workbook/worksheet/conditional_formatting.rb'
-    - 'lib/axlsx/workbook/worksheet/rich_text_run.rb'
-    - 'test/workbook/worksheet/auto_filter/tc_filters.rb'
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/SlicingWithRange:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -250,7 +250,12 @@ Style/SafeNavigation:
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowIfMethodIsEmpty.
 Style/SingleLineMethods:
-  Enabled: false
+  Exclude:
+    - 'lib/axlsx/workbook/workbook.rb'
+    - 'lib/axlsx/workbook/worksheet/cell.rb'
+    - 'lib/axlsx/workbook/worksheet/conditional_formatting.rb'
+    - 'lib/axlsx/workbook/worksheet/rich_text_run.rb'
+    - 'test/workbook/worksheet/auto_filter/tc_filters.rb'
 
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/SlicingWithRange:

--- a/lib/axlsx/content_type/abstract_content_type.rb
+++ b/lib/axlsx/content_type/abstract_content_type.rb
@@ -18,7 +18,10 @@ module Axlsx
 
     # The content type.
     # @see Axlsx#validate_content_type
-    def content_type=(v) Axlsx.validate_content_type v; @content_type = v end
+    def content_type=(v)
+      Axlsx.validate_content_type v
+      @content_type = v
+    end
     alias :ContentType= :content_type=
 
     # Serialize the contenty type to xml

--- a/lib/axlsx/content_type/default.rb
+++ b/lib/axlsx/content_type/default.rb
@@ -12,7 +12,10 @@ module Axlsx
     alias :Extension :extension
 
     # Sets the file extension for this content type.
-    def extension=(v) Axlsx.validate_string v; @extension = v end
+    def extension=(v)
+      Axlsx.validate_string v
+      @extension = v
+    end
     alias :Extension= :extension=
 
     # Serializes this object to xml

--- a/lib/axlsx/content_type/override.rb
+++ b/lib/axlsx/content_type/override.rb
@@ -12,7 +12,10 @@ module Axlsx
     alias :PartName :part_name
 
     # The name and location of the part.
-    def part_name=(v) Axlsx.validate_string v; @part_name = v end
+    def part_name=(v)
+      Axlsx.validate_string v
+      @part_name = v
+    end
     alias :PartName= :part_name=
 
     # Serializes this object to xml

--- a/lib/axlsx/doc_props/app.rb
+++ b/lib/axlsx/doc_props/app.rb
@@ -132,89 +132,156 @@ module Axlsx
     alias :DocSecurity :doc_security
 
     # Sets the template property of your app.xml file
-    def template=(v) Axlsx.validate_string v; @template = v; end
+    def template=(v)
+      Axlsx.validate_string v
+      @template = v
+    end
     alias :Template= :template=
 
     # Sets the manager property of your app.xml file
-    def manager=(v) Axlsx.validate_string v; @manager = v; end
+    def manager=(v)
+      Axlsx.validate_string v
+      @manager = v
+    end
     alias :Manager= :manager=
 
     # Sets the company property of your app.xml file
-    def company=(v) Axlsx.validate_string v; @company = v; end
+    def company=(v)
+      Axlsx.validate_string v
+      @company = v
+    end
     alias :Company= :company=
+
     # Sets the pages property of your app.xml file
-    def pages=(v) Axlsx.validate_int v; @pages = v; end
+    def pages=(v)
+      Axlsx.validate_int v
+      @pages = v
+    end
 
     # Sets the words property of your app.xml file
-    def words=(v) Axlsx.validate_int v; @words = v; end
+    def words=(v)
+      Axlsx.validate_int v
+      @words = v
+    end
     alias :Words= :words=
 
     # Sets the characters property of your app.xml file
-    def characters=(v) Axlsx.validate_int v; @characters = v; end
+    def characters=(v)
+      Axlsx.validate_int v
+      @characters = v
+    end
     alias :Characters= :characters=
 
     # Sets the presentation_format property of your app.xml file
-    def presentation_format=(v) Axlsx.validate_string v; @presentation_format = v; end
+    def presentation_format=(v)
+      Axlsx.validate_string v
+      @presentation_format = v
+    end
     alias :PresentationFormat= :presentation_format=
 
     # Sets the lines property of your app.xml file
-    def lines=(v) Axlsx.validate_int v; @lines = v; end
+    def lines=(v)
+      Axlsx.validate_int v
+      @lines = v
+    end
     alias :Lines= :lines=
 
     # Sets the paragraphs property of your app.xml file
-    def paragraphs=(v) Axlsx.validate_int v; @paragraphs = v; end
+    def paragraphs=(v)
+      Axlsx.validate_int v
+      @paragraphs = v
+    end
     alias :Paragraphs= :paragraphs=
 
     # sets the slides property of your app.xml file
-    def slides=(v) Axlsx.validate_int v; @slides = v; end
+    def slides=(v)
+      Axlsx.validate_int v
+      @slides = v
+    end
     alias :Slides= :slides=
 
     # sets the notes property of your app.xml file
-    def notes=(v) Axlsx.validate_int v; @notes = v; end
+    def notes=(v)
+      Axlsx.validate_int v
+      @notes = v
+    end
     alias :Notes= :notes=
 
     # Sets the total_time property of your app.xml file
-    def total_time=(v) Axlsx.validate_int v; @total_time = v; end
+    def total_time=(v)
+      Axlsx.validate_int v
+      @total_time = v
+    end
     alias :TotalTime= :total_time=
 
     # Sets the hidden_slides property of your app.xml file
-    def hidden_slides=(v) Axlsx.validate_int v; @hidden_slides = v; end
+    def hidden_slides=(v)
+      Axlsx.validate_int v
+      @hidden_slides = v
+    end
     alias :HiddenSlides= :hidden_slides=
 
     # Sets the m_m_clips property of your app.xml file
-    def m_m_clips=(v) Axlsx.validate_int v; @m_m_clips = v; end
+    def m_m_clips=(v)
+      Axlsx.validate_int v
+      @m_m_clips = v
+    end
     alias :MMClips= :m_m_clips=
 
     # Sets the scale_crop property of your app.xml file
-    def scale_crop=(v) Axlsx.validate_boolean v; @scale_crop = v; end
+    def scale_crop=(v)
+      Axlsx.validate_boolean v
+      @scale_crop = v
+    end
     alias :ScaleCrop= :scale_crop=
 
     # Sets the links_up_to_date property of your app.xml file
-    def links_up_to_date=(v) Axlsx.validate_boolean v; @links_up_to_date = v; end
+    def links_up_to_date=(v)
+      Axlsx.validate_boolean v
+      @links_up_to_date = v
+    end
     alias :LinksUpToDate= :links_up_to_date=
 
     # Sets the characters_with_spaces property of your app.xml file
-    def characters_with_spaces=(v) Axlsx.validate_int v; @characters_with_spaces = v; end
+    def characters_with_spaces=(v)
+      Axlsx.validate_int v
+      @characters_with_spaces = v
+    end
     alias :CharactersWithSpaces= :characters_with_spaces=
 
     # Sets the share_doc property of your app.xml file
-    def shared_doc=(v) Axlsx.validate_boolean v; @shared_doc = v; end
+    def shared_doc=(v)
+      Axlsx.validate_boolean v
+      @shared_doc = v
+    end
     alias :SharedDoc= :shared_doc=
 
     # Sets the hyperlink_base property of your app.xml file
-    def hyperlink_base=(v) Axlsx.validate_string v; @hyperlink_base = v; end
+    def hyperlink_base=(v)
+      Axlsx.validate_string v
+      @hyperlink_base = v
+    end
     alias :HyperlinkBase= :hyperlink_base=
 
     # Sets the HyperLinksChanged property of your app.xml file
-    def hyperlinks_changed=(v) Axlsx.validate_boolean v; @hyperlinks_changed = v; end
+    def hyperlinks_changed=(v)
+      Axlsx.validate_boolean v
+      @hyperlinks_changed = v
+    end
     alias :HyperLinksChanged= :hyperlinks_changed=
 
     # Sets the app_version property of your app.xml file
-    def app_version=(v) Axlsx.validate_string v; @app_version = v; end
+    def app_version=(v)
+      Axlsx.validate_string v
+      @app_version = v
+    end
     alias :AppVersion= :app_version=
 
     # Sets the doc_security property of your app.xml file
-    def doc_security=(v) Axlsx.validate_int v; @doc_security = v; end
+    def doc_security=(v)
+      Axlsx.validate_int v
+      @doc_security = v
+    end
     alias :DocSecurity= :doc_security=
 
     # Serialize the app.xml document

--- a/lib/axlsx/drawing/area_series.rb
+++ b/lib/axlsx/drawing/area_series.rb
@@ -101,9 +101,15 @@ module Axlsx
     private
 
     # assigns the data for this series
-    def data=(v) DataTypeValidator.validate "Series.data", [NumDataSource], v; @data = v; end
+    def data=(v)
+      DataTypeValidator.validate "Series.data", [NumDataSource], v
+      @data = v
+    end
 
     # assigns the labels for this series
-    def labels=(v) DataTypeValidator.validate "Series.labels", [AxDataSource], v; @labels = v; end
+    def labels=(v)
+      DataTypeValidator.validate "Series.labels", [AxDataSource], v
+      @labels = v
+    end
   end
 end

--- a/lib/axlsx/drawing/axis.rb
+++ b/lib/axlsx/drawing/axis.rb
@@ -99,29 +99,47 @@ module Axlsx
 
     # The position of the axis
     # must be one of [:l, :r, :t, :b]
-    def ax_pos=(v) RestrictionValidator.validate "#{self.class}.ax_pos", [:l, :r, :b, :t], v; @ax_pos = v; end
+    def ax_pos=(v)
+      RestrictionValidator.validate "#{self.class}.ax_pos", [:l, :r, :b, :t], v
+      @ax_pos = v
+    end
     alias :axPos= :ax_pos=
 
     # the position of the tick labels
     # must be one of [:nextTo, :high, :low1]
-    def tick_lbl_pos=(v) RestrictionValidator.validate "#{self.class}.tick_lbl_pos", [:nextTo, :high, :low, :none], v; @tick_lbl_pos = v; end
+    def tick_lbl_pos=(v)
+      RestrictionValidator.validate "#{self.class}.tick_lbl_pos", [:nextTo, :high, :low, :none], v
+      @tick_lbl_pos = v
+    end
     alias :tickLblPos= :tick_lbl_pos=
 
     # The number format format code for this axis
     # default :General
-    def format_code=(v) Axlsx.validate_string(v); @format_code = v; end
+    def format_code=(v)
+      Axlsx.validate_string(v)
+      @format_code = v
+    end
 
     # Specify if gridlines should be shown for this axis
     # default true
-    def gridlines=(v) Axlsx.validate_boolean(v); @gridlines = v; end
+    def gridlines=(v)
+      Axlsx.validate_boolean(v)
+      @gridlines = v
+    end
 
     # Specify if axis should be removed from the chart
     # default false
-    def delete=(v) Axlsx.validate_boolean(v); @delete = v; end
+    def delete=(v)
+      Axlsx.validate_boolean(v)
+      @delete = v
+    end
 
     # specifies how the perpendicular axis is crossed
     # must be one of [:autoZero, :min, :max]
-    def crosses=(v) RestrictionValidator.validate "#{self.class}.crosses", [:autoZero, :min, :max], v; @crosses = v; end
+    def crosses=(v)
+      RestrictionValidator.validate "#{self.class}.crosses", [:autoZero, :min, :max], v
+      @crosses = v
+    end
 
     # Specify the degree of label rotation to apply to labels
     # default true

--- a/lib/axlsx/drawing/bar_series.rb
+++ b/lib/axlsx/drawing/bar_series.rb
@@ -43,7 +43,10 @@ module Axlsx
     end
 
     # @see colors
-    def colors=(v) DataTypeValidator.validate "BarSeries.colors", [Array], v; @colors = v end
+    def colors=(v)
+      DataTypeValidator.validate "BarSeries.colors", [Array], v
+      @colors = v
+    end
 
     def series_color=(v)
       @series_color = v
@@ -85,9 +88,15 @@ module Axlsx
     private
 
     # assigns the data for this series
-    def data=(v) DataTypeValidator.validate "Series.data", [NumDataSource], v; @data = v; end
+    def data=(v)
+      DataTypeValidator.validate "Series.data", [NumDataSource], v
+      @data = v
+    end
 
     # assigns the labels for this series
-    def labels=(v) DataTypeValidator.validate "Series.labels", [AxDataSource], v; @labels = v; end
+    def labels=(v)
+      DataTypeValidator.validate "Series.labels", [AxDataSource], v
+      @labels = v
+    end
   end
 end

--- a/lib/axlsx/drawing/cat_axis.rb
+++ b/lib/axlsx/drawing/cat_axis.rb
@@ -45,24 +45,39 @@ module Axlsx
     LBL_OFFSET_REGEX = /0*(([0-9])|([1-9][0-9])|([1-9][0-9][0-9])|1000)/.freeze
 
     # @see tick_lbl_skip
-    def tick_lbl_skip=(v) Axlsx.validate_unsigned_int(v); @tick_lbl_skip = v; end
+    def tick_lbl_skip=(v)
+      Axlsx.validate_unsigned_int(v)
+      @tick_lbl_skip = v
+    end
     alias :tickLblSkip= :tick_lbl_skip=
 
     # @see tick_mark_skip
-    def tick_mark_skip=(v) Axlsx.validate_unsigned_int(v); @tick_mark_skip = v; end
+    def tick_mark_skip=(v)
+      Axlsx.validate_unsigned_int(v)
+      @tick_mark_skip = v
+    end
     alias :tickMarkSkip= :tick_mark_skip=
 
     # From the docs: This element specifies that this axis is a date or text axis based on the data that is used for the axis labels, not a specific choice.
-    def auto=(v) Axlsx.validate_boolean(v); @auto = v; end
+    def auto=(v)
+      Axlsx.validate_boolean(v)
+      @auto = v
+    end
 
     # specifies how the perpendicular axis is crossed
     # must be one of [:ctr, :l, :r]
-    def lbl_algn=(v) RestrictionValidator.validate "#{self.class}.lbl_algn", [:ctr, :l, :r], v; @lbl_algn = v; end
+    def lbl_algn=(v)
+      RestrictionValidator.validate "#{self.class}.lbl_algn", [:ctr, :l, :r], v
+      @lbl_algn = v
+    end
     alias :lblAlgn= :lbl_algn=
 
     # The offset of the labels
     # must be between a string between 0 and 1000
-    def lbl_offset=(v) RegexValidator.validate "#{self.class}.lbl_offset", LBL_OFFSET_REGEX, v; @lbl_offset = v; end
+    def lbl_offset=(v)
+      RegexValidator.validate "#{self.class}.lbl_offset", LBL_OFFSET_REGEX, v
+      @lbl_offset = v
+    end
     alias :lblOffset= :lbl_offset=
 
     # Serializes the object

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -62,7 +62,10 @@ module Axlsx
 
     # Configures the vary_colors options for this chart
     # @param [Boolean] v The value to set
-    def vary_colors=(v) Axlsx.validate_boolean(v); @vary_colors = v; end
+    def vary_colors=(v)
+      Axlsx.validate_boolean(v)
+      @vary_colors = v
+    end
 
     # The title object for the chart.
     # @return [Title]
@@ -149,21 +152,33 @@ module Axlsx
     # Show the legend in the chart
     # @param [Boolean] v
     # @return [Boolean]
-    def show_legend=(v) Axlsx.validate_boolean(v); @show_legend = v; end
+    def show_legend=(v)
+      Axlsx.validate_boolean(v)
+      @show_legend = v
+    end
 
     # How to display blank values
     # @see display_blanks_as
     # @param [Symbol] v
     # @return [Symbol]
-    def display_blanks_as=(v) Axlsx.validate_display_blanks_as(v); @display_blanks_as = v; end
+    def display_blanks_as=(v)
+      Axlsx.validate_display_blanks_as(v)
+      @display_blanks_as = v
+    end
 
     # The style for the chart.
     # see ECMA Part 1 §21.2.2.196
     # @param [Integer] v must be between 1 and 48
-    def style=(v) DataTypeValidator.validate "Chart.style", Integer, v, ->(arg) { arg >= 1 && arg <= 48 }; @style = v; end
+    def style=(v)
+      DataTypeValidator.validate "Chart.style", Integer, v, ->(arg) { arg >= 1 && arg <= 48 }
+      @style = v
+    end
 
     # @see legend_position
-    def legend_position=(v) RestrictionValidator.validate "Chart.legend_position", [:b, :l, :r, :t, :tr], v; @legend_position = v; end
+    def legend_position=(v)
+      RestrictionValidator.validate "Chart.legend_position", [:b, :l, :r, :t, :tr], v
+      @legend_position = v
+    end
 
     # backwards compatibility to allow chart.to and chart.from access to anchor markers
     # @note This will be disconinued in version 2.0.0. Please use the end_at method
@@ -194,12 +209,18 @@ module Axlsx
     # Whether only data from visible cells should be plotted.
     # @param [Boolean] v
     # @return [Boolean]
-    def plot_visible_only=(v) Axlsx.validate_boolean(v); @plot_visible_only = v; end
+    def plot_visible_only=(v)
+      Axlsx.validate_boolean(v)
+      @plot_visible_only = v
+    end
 
     # Whether the chart area shall have rounded corners.
     # @param [Boolean] v
     # @return [Boolean]
-    def rounded_corners=(v) Axlsx.validate_boolean(v); @rounded_corners = v; end
+    def rounded_corners=(v)
+      Axlsx.validate_boolean(v)
+      @rounded_corners = v
+    end
 
     # Serializes the object
     # @param [String] str
@@ -290,7 +311,10 @@ module Axlsx
     end
 
     # sets the view_3D object for the chart
-    def view_3D=(v) DataTypeValidator.validate "#{self.class}.view_3D", View3D, v; @view_3D = v; end
+    def view_3D=(v)
+      DataTypeValidator.validate "#{self.class}.view_3D", View3D, v
+      @view_3D = v
+    end
     alias :view3D= :view_3D=
   end
 end

--- a/lib/axlsx/drawing/hyperlink.rb
+++ b/lib/axlsx/drawing/hyperlink.rb
@@ -52,7 +52,10 @@ module Axlsx
     # @see endSnd
     # @param [Boolean] v The boolean value indicating the termination of playing sounds on click
     # @return [Boolean]
-    def end_snd=(v) Axlsx.validate_boolean(v); @end_snd = v end
+    def end_snd=(v)
+      Axlsx.validate_boolean(v)
+      @end_snd = v
+    end
     alias :endSnd= :end_snd=
 
     # indicates that the link has already been clicked.
@@ -62,7 +65,10 @@ module Axlsx
 
     # @see highlightClick
     # @param [Boolean] v The value to assign
-    def highlight_click=(v) Axlsx.validate_boolean(v); @highlight_click = v end
+    def highlight_click=(v)
+      Axlsx.validate_boolean(v)
+      @highlight_click = v
+    end
     alias :highlightClick= :highlight_click=
 
     # From the specs: Specifies whether to add this URI to the history when navigating to it. This allows for the viewing of this presentation without the storing of history information on the viewing machine. If this attribute is omitted, then a value of 1 or true is assumed.
@@ -71,7 +77,10 @@ module Axlsx
 
     # @see history
     # param [Boolean] v The value to assing
-    def history=(v) Axlsx.validate_boolean(v); @history = v end
+    def history=(v)
+      Axlsx.validate_boolean(v)
+      @history = v
+    end
 
     # From the specs: Specifies the target frame that is to be used when opening this hyperlink. When the hyperlink is activated this attribute is used to determine if a new window is launched for viewing or if an existing one can be used. If this attribute is omitted, than a new window is opened.
     # @return [String]

--- a/lib/axlsx/drawing/line_series.rb
+++ b/lib/axlsx/drawing/line_series.rb
@@ -101,9 +101,15 @@ module Axlsx
     private
 
     # assigns the data for this series
-    def data=(v) DataTypeValidator.validate "Series.data", [NumDataSource], v; @data = v; end
+    def data=(v)
+      DataTypeValidator.validate "Series.data", [NumDataSource], v
+      @data = v
+    end
 
     # assigns the labels for this series
-    def labels=(v) DataTypeValidator.validate "Series.labels", [AxDataSource], v; @labels = v; end
+    def labels=(v)
+      DataTypeValidator.validate "Series.labels", [AxDataSource], v
+      @labels = v
+    end
   end
 end

--- a/lib/axlsx/drawing/marker.rb
+++ b/lib/axlsx/drawing/marker.rb
@@ -34,13 +34,28 @@ module Axlsx
     attr_reader :rowOff
 
     # @see col
-    def col=(v) Axlsx.validate_unsigned_int v; @col = v end
+    def col=(v)
+      Axlsx.validate_unsigned_int v
+      @col = v
+    end
+
     # @see colOff
-    def colOff=(v) Axlsx.validate_int v; @colOff = v end
+    def colOff=(v)
+      Axlsx.validate_int v
+      @colOff = v
+    end
+
     # @see row
-    def row=(v) Axlsx.validate_unsigned_int v; @row = v end
+    def row=(v)
+      Axlsx.validate_unsigned_int v
+      @row = v
+    end
+
     # @see rowOff
-    def rowOff=(v) Axlsx.validate_int v; @rowOff = v end
+    def rowOff=(v)
+      Axlsx.validate_int v
+      @rowOff = v
+    end
 
     # shortcut to set the column, row position for this marker
     # @param col the column for the marker, a Cell object or a string reference like "B7"

--- a/lib/axlsx/drawing/one_cell_anchor.rb
+++ b/lib/axlsx/drawing/one_cell_anchor.rb
@@ -60,10 +60,16 @@ module Axlsx
 
     #
     # @see height
-    def height=(v) Axlsx.validate_unsigned_int(v); @height = v; end
+    def height=(v)
+      Axlsx.validate_unsigned_int(v)
+      @height = v
+    end
 
     # @see width
-    def width=(v) Axlsx.validate_unsigned_int(v); @width = v; end
+    def width=(v)
+      Axlsx.validate_unsigned_int(v)
+      @width = v
+    end
 
     # The index of this anchor in the drawing
     # @return [Integer]

--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -91,13 +91,22 @@ module Axlsx
     end
 
     # @see name
-    def name=(v) Axlsx.validate_string(v); @name = v; end
+    def name=(v)
+      Axlsx.validate_string(v)
+      @name = v
+    end
 
     # @see descr
-    def descr=(v) Axlsx.validate_string(v); @descr = v; end
+    def descr=(v)
+      Axlsx.validate_string(v)
+      @descr = v
+    end
 
     # @see remote
-    def remote=(v) Axlsx.validate_boolean(v); @remote = v; end
+    def remote=(v)
+      Axlsx.validate_boolean(v)
+      @remote = v
+    end
 
     def remote?
       remote == 1 || remote.to_s == 'true'

--- a/lib/axlsx/drawing/pie_series.rb
+++ b/lib/axlsx/drawing/pie_series.rb
@@ -36,10 +36,16 @@ module Axlsx
     end
 
     # @see colors
-    def colors=(v) DataTypeValidator.validate "BarSeries.colors", [Array], v; @colors = v end
+    def colors=(v)
+      DataTypeValidator.validate "BarSeries.colors", [Array], v
+      @colors = v
+    end
 
     # @see explosion
-    def explosion=(v) Axlsx.validate_unsigned_int(v); @explosion = v; end
+    def explosion=(v)
+      Axlsx.validate_unsigned_int(v)
+      @explosion = v
+    end
 
     # Serializes the object
     # @param [String] str
@@ -63,9 +69,15 @@ module Axlsx
     private
 
     # assigns the data for this series
-    def data=(v) DataTypeValidator.validate "Series.data", [NumDataSource], v; @data = v; end
+    def data=(v)
+      DataTypeValidator.validate "Series.data", [NumDataSource], v
+      @data = v
+    end
 
     # assigns the labels for this series
-    def labels=(v) DataTypeValidator.validate "Series.labels", [AxDataSource], v; @labels = v; end
+    def labels=(v)
+      DataTypeValidator.validate "Series.labels", [AxDataSource], v
+      @labels = v
+    end
   end
 end

--- a/lib/axlsx/drawing/scaling.rb
+++ b/lib/axlsx/drawing/scaling.rb
@@ -35,14 +35,28 @@ module Axlsx
     attr_reader :min
 
     # @see logBase
-    def logBase=(v) DataTypeValidator.validate "Scaling.logBase", [Integer], v, ->(arg) { arg >= 2 && arg <= 1000 }; @logBase = v; end
+    def logBase=(v)
+      DataTypeValidator.validate "Scaling.logBase", [Integer], v, ->(arg) { arg >= 2 && arg <= 1000 }
+      @logBase = v
+    end
+
     # @see orientation
-    def orientation=(v) RestrictionValidator.validate "Scaling.orientation", [:minMax, :maxMin], v; @orientation = v; end
+    def orientation=(v)
+      RestrictionValidator.validate "Scaling.orientation", [:minMax, :maxMin], v
+      @orientation = v
+    end
+
     # @see max
-    def max=(v) DataTypeValidator.validate "Scaling.max", Float, v; @max = v; end
+    def max=(v)
+      DataTypeValidator.validate "Scaling.max", Float, v
+      @max = v
+    end
 
     # @see min
-    def min=(v) DataTypeValidator.validate "Scaling.min", Float, v; @min = v; end
+    def min=(v)
+      DataTypeValidator.validate "Scaling.min", Float, v
+      @min = v
+    end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/drawing/ser_axis.rb
+++ b/lib/axlsx/drawing/ser_axis.rb
@@ -22,11 +22,17 @@ module Axlsx
     end
 
     # @see tickLblSkip
-    def tick_lbl_skip=(v) Axlsx.validate_unsigned_int(v); @tick_lbl_skip = v; end
+    def tick_lbl_skip=(v)
+      Axlsx.validate_unsigned_int(v)
+      @tick_lbl_skip = v
+    end
     alias :tickLblSkip= :tick_lbl_skip=
 
     # @see tickMarkSkip
-    def tick_mark_skip=(v) Axlsx.validate_unsigned_int(v); @tick_mark_skip = v; end
+    def tick_mark_skip=(v)
+      Axlsx.validate_unsigned_int(v)
+      @tick_mark_skip = v
+    end
     alias :tickMarkSkip= :tick_mark_skip=
 
     # Serializes the object

--- a/lib/axlsx/drawing/series.rb
+++ b/lib/axlsx/drawing/series.rb
@@ -40,7 +40,10 @@ module Axlsx
     end
 
     # @see order
-    def order=(v) Axlsx.validate_unsigned_int(v); @order = v; end
+    def order=(v)
+      Axlsx.validate_unsigned_int(v)
+      @order = v
+    end
 
     # @see title
     def title=(v)
@@ -52,7 +55,10 @@ module Axlsx
     private
 
     # assigns the chart for this series
-    def chart=(v) DataTypeValidator.validate "Series.chart", Chart, v; @chart = v; end
+    def chart=(v)
+      DataTypeValidator.validate "Series.chart", Chart, v
+      @chart = v
+    end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/drawing/view_3D.rb
+++ b/lib/axlsx/drawing/view_3D.rb
@@ -78,11 +78,17 @@ module Axlsx
     alias :rotY= :rot_y=
 
     # @see depth_percent
-    def depth_percent=(v) RegexValidator.validate "#{self.class}.depth_percent", DEPTH_PERCENT_REGEX, v; @depth_percent = v; end
+    def depth_percent=(v)
+      RegexValidator.validate "#{self.class}.depth_percent", DEPTH_PERCENT_REGEX, v
+      @depth_percent = v
+    end
     alias :depthPercent= :depth_percent=
 
     # @see r_ang_ax
-    def r_ang_ax=(v) Axlsx.validate_boolean(v); @r_ang_ax = v; end
+    def r_ang_ax=(v)
+      Axlsx.validate_boolean(v)
+      @r_ang_ax = v
+    end
     alias :rAngAx= :r_ang_ax=
 
     # @see perspective

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -69,7 +69,10 @@ module Axlsx
     end
 
     # @see workbook
-    def workbook=(workbook) DataTypeValidator.validate :Package_workbook, Workbook, workbook; @workbook = workbook; end
+    def workbook=(workbook)
+      DataTypeValidator.validate :Package_workbook, Workbook, workbook
+      @workbook = workbook
+    end
 
     # Serialize your workbook to disk as an xlsx document.
     #

--- a/lib/axlsx/rels/relationship.rb
+++ b/lib/axlsx/rels/relationship.rb
@@ -92,12 +92,22 @@ module Axlsx
     end
 
     # @see Target
-    def Target=(v) Axlsx.validate_string v; @Target = v end
+    def Target=(v)
+      Axlsx.validate_string v
+      @Target = v
+    end
+
     # @see Type
-    def Type=(v) Axlsx.validate_relationship_type v; @Type = v end
+    def Type=(v)
+      Axlsx.validate_relationship_type v
+      @Type = v
+    end
 
     # @see TargetMode
-    def TargetMode=(v) RestrictionValidator.validate 'Relationship.TargetMode', [:External, :Internal], v; @TargetMode = v; end
+    def TargetMode=(v)
+      RestrictionValidator.validate 'Relationship.TargetMode', [:External, :Internal], v
+      @TargetMode = v
+    end
 
     # serialize relationship
     # @param [String] str

--- a/lib/axlsx/stylesheet/border.rb
+++ b/lib/axlsx/stylesheet/border.rb
@@ -43,15 +43,24 @@ module Axlsx
     attr_reader :prs
 
     # @see diagonalUp
-    def diagonal_up=(v) Axlsx.validate_boolean v; @diagonal_up = v end
+    def diagonal_up=(v)
+      Axlsx.validate_boolean v
+      @diagonal_up = v
+    end
     alias :diagonalUp= :diagonal_up=
 
     # @see diagonalDown
-    def diagonal_down=(v) Axlsx.validate_boolean v; @diagonal_down = v end
+    def diagonal_down=(v)
+      Axlsx.validate_boolean v
+      @diagonal_down = v
+    end
     alias :diagonalDown= :diagonal_down=
 
     # @see outline
-    def outline=(v) Axlsx.validate_boolean v; @outline = v end
+    def outline=(v)
+      Axlsx.validate_boolean v
+      @outline = v
+    end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/border_pr.rb
+++ b/lib/axlsx/stylesheet/border_pr.rb
@@ -53,11 +53,22 @@ module Axlsx
     end
 
     # @see name
-    def name=(v) RestrictionValidator.validate "BorderPr.name", [:start, :end, :left, :right, :top, :bottom, :diagonal, :vertical, :horizontal], v; @name = v end
+    def name=(v)
+      RestrictionValidator.validate "BorderPr.name", [:start, :end, :left, :right, :top, :bottom, :diagonal, :vertical, :horizontal], v
+      @name = v
+    end
+
     # @see color
-    def color=(v) DataTypeValidator.validate(:color, Color, v); @color = v end
+    def color=(v)
+      DataTypeValidator.validate(:color, Color, v)
+      @color = v
+    end
+
     # @see style
-    def style=(v) RestrictionValidator.validate "BorderPr.style", [:none, :thin, :medium, :dashed, :dotted, :thick, :double, :hair, :mediumDashed, :dashDot, :mediumDashDot, :dashDotDot, :mediumDashDotDot, :slantDashDot], v; @style = v end
+    def style=(v)
+      RestrictionValidator.validate "BorderPr.style", [:none, :thin, :medium, :dashed, :dotted, :thick, :double, :hair, :mediumDashed, :dashDot, :mediumDashDot, :dashDotDot, :mediumDashDotDot, :slantDashDot], v
+      @style = v
+    end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/cell_alignment.rb
+++ b/lib/axlsx/stylesheet/cell_alignment.rb
@@ -86,34 +86,63 @@ module Axlsx
     alias :readingOrder :reading_order
 
     # @see horizontal
-    def horizontal=(v) Axlsx.validate_horizontal_alignment v; @horizontal = v end
+    def horizontal=(v)
+      Axlsx.validate_horizontal_alignment v
+      @horizontal = v
+    end
+
     # @see vertical
-    def vertical=(v) Axlsx.validate_vertical_alignment v; @vertical = v end
+    def vertical=(v)
+      Axlsx.validate_vertical_alignment v
+      @vertical = v
+    end
+
     # @see textRotation
-    def text_rotation=(v) Axlsx.validate_unsigned_int v; @text_rotation = v end
+    def text_rotation=(v)
+      Axlsx.validate_unsigned_int v
+      @text_rotation = v
+    end
     alias :textRotation= :text_rotation=
 
     # @see wrapText
-    def wrap_text=(v) Axlsx.validate_boolean v; @wrap_text = v end
+    def wrap_text=(v)
+      Axlsx.validate_boolean v
+      @wrap_text = v
+    end
     alias :wrapText= :wrap_text=
 
     # @see indent
-    def indent=(v) Axlsx.validate_unsigned_int v; @indent = v end
+    def indent=(v)
+      Axlsx.validate_unsigned_int v
+      @indent = v
+    end
 
     # @see relativeIndent
-    def relative_indent=(v) Axlsx.validate_int v; @relative_indent = v end
+    def relative_indent=(v)
+      Axlsx.validate_int v
+      @relative_indent = v
+    end
     alias :relativeIndent= :relative_indent=
 
     # @see justifyLastLine
-    def justify_last_line=(v) Axlsx.validate_boolean v; @justify_last_line = v end
+    def justify_last_line=(v)
+      Axlsx.validate_boolean v
+      @justify_last_line = v
+    end
     alias :justifyLastLine= :justify_last_line=
 
     # @see shrinkToFit
-    def shrink_to_fit=(v) Axlsx.validate_boolean v; @shrink_to_fit = v end
+    def shrink_to_fit=(v)
+      Axlsx.validate_boolean v
+      @shrink_to_fit = v
+    end
     alias :shrinkToFit= :shrink_to_fit=
 
     # @see readingOrder
-    def reading_order=(v) Axlsx.validate_unsigned_int v; @reading_order = v end
+    def reading_order=(v)
+      Axlsx.validate_unsigned_int v
+      @reading_order = v
+    end
     alias :readingOrder= :reading_order=
 
     # Serializes the object

--- a/lib/axlsx/stylesheet/cell_protection.rb
+++ b/lib/axlsx/stylesheet/cell_protection.rb
@@ -26,9 +26,16 @@ module Axlsx
     end
 
     # @see hidden
-    def hidden=(v) Axlsx.validate_boolean v; @hidden = v end
+    def hidden=(v)
+      Axlsx.validate_boolean v
+      @hidden = v
+    end
+
     # @see locked
-    def locked=(v) Axlsx.validate_boolean v; @locked = v end
+    def locked=(v)
+      Axlsx.validate_boolean v
+      @locked = v
+    end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/cell_style.rb
+++ b/lib/axlsx/stylesheet/cell_style.rb
@@ -48,17 +48,40 @@ module Axlsx
     attr_reader :customBuiltin
 
     # @see name
-    def name=(v) Axlsx.validate_string v; @name = v end
+    def name=(v)
+      Axlsx.validate_string v
+      @name = v
+    end
+
     # @see xfId
-    def xfId=(v) Axlsx.validate_unsigned_int v; @xfId = v end
+    def xfId=(v)
+      Axlsx.validate_unsigned_int v
+      @xfId = v
+    end
+
     # @see builtinId
-    def builtinId=(v) Axlsx.validate_unsigned_int v; @builtinId = v end
+    def builtinId=(v)
+      Axlsx.validate_unsigned_int v
+      @builtinId = v
+    end
+
     # @see iLivel
-    def iLevel=(v) Axlsx.validate_unsigned_int v; @iLevel = v end
+    def iLevel=(v)
+      Axlsx.validate_unsigned_int v
+      @iLevel = v
+    end
+
     # @see hidden
-    def hidden=(v) Axlsx.validate_boolean v; @hidden = v end
+    def hidden=(v)
+      Axlsx.validate_boolean v
+      @hidden = v
+    end
+
     # @see customBuiltin
-    def customBuiltin=(v) Axlsx.validate_boolean v; @customBuiltin = v end
+    def customBuiltin=(v)
+      Axlsx.validate_boolean v
+      @customBuiltin = v
+    end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/color.rb
+++ b/lib/axlsx/stylesheet/color.rb
@@ -47,7 +47,10 @@ module Axlsx
     attr_reader :tint
 
     # @see auto
-    def auto=(v) Axlsx.validate_boolean v; @auto = v end
+    def auto=(v)
+      Axlsx.validate_boolean v
+      @auto = v
+    end
 
     # @see color
     def rgb=(v)
@@ -61,7 +64,10 @@ module Axlsx
     end
 
     # @see tint
-    def tint=(v) Axlsx.validate_float v; @tint = v end
+    def tint=(v)
+      Axlsx.validate_float v
+      @tint = v
+    end
 
     # This version does not support themes
     # def theme=(v) Axlsx::validate_unsigned_integer v; @theme = v end

--- a/lib/axlsx/stylesheet/dxf.rb
+++ b/lib/axlsx/stylesheet/dxf.rb
@@ -49,17 +49,40 @@ module Axlsx
     end
 
     # @see Dxf#alignment
-    def alignment=(v) DataTypeValidator.validate "Dxf.alignment", CellAlignment, v; @alignment = v end
+    def alignment=(v)
+      DataTypeValidator.validate "Dxf.alignment", CellAlignment, v
+      @alignment = v
+    end
+
     # @see protection
-    def protection=(v) DataTypeValidator.validate "Dxf.protection", CellProtection, v; @protection = v end
+    def protection=(v)
+      DataTypeValidator.validate "Dxf.protection", CellProtection, v
+      @protection = v
+    end
+
     # @see numFmt
-    def numFmt=(v) DataTypeValidator.validate "Dxf.numFmt", NumFmt, v; @numFmt = v end
+    def numFmt=(v)
+      DataTypeValidator.validate "Dxf.numFmt", NumFmt, v
+      @numFmt = v
+    end
+
     # @see font
-    def font=(v) DataTypeValidator.validate "Dxf.font", Font, v; @font = v end
+    def font=(v)
+      DataTypeValidator.validate "Dxf.font", Font, v
+      @font = v
+    end
+
     # @see border
-    def border=(v) DataTypeValidator.validate "Dxf.border", Border, v; @border = v end
+    def border=(v)
+      DataTypeValidator.validate "Dxf.border", Border, v
+      @border = v
+    end
+
     # @see fill
-    def fill=(v) DataTypeValidator.validate "Dxf.fill", Fill, v; @fill = v end
+    def fill=(v)
+      DataTypeValidator.validate "Dxf.fill", Fill, v
+      @fill = v
+    end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/fill.rb
+++ b/lib/axlsx/stylesheet/fill.rb
@@ -28,6 +28,9 @@ module Axlsx
     end
 
     # @see fill_type
-    def fill_type=(v) DataTypeValidator.validate "Fill.fill_type", [PatternFill, GradientFill], v; @fill_type = v; end
+    def fill_type=(v)
+      DataTypeValidator.validate "Fill.fill_type", [PatternFill, GradientFill], v
+      @fill_type = v
+    end
   end
 end

--- a/lib/axlsx/stylesheet/font.rb
+++ b/lib/axlsx/stylesheet/font.rb
@@ -112,15 +112,34 @@ module Axlsx
     attr_reader :sz
 
     # @see name
-    def name=(v) Axlsx.validate_string v; @name = v end
+    def name=(v)
+      Axlsx.validate_string v
+      @name = v
+    end
+
     # @see charset
-    def charset=(v) Axlsx.validate_unsigned_int v; @charset = v end
+    def charset=(v)
+      Axlsx.validate_unsigned_int v
+      @charset = v
+    end
+
     # @see family
-    def family=(v) Axlsx.validate_unsigned_int v; @family = v end
+    def family=(v)
+      Axlsx.validate_unsigned_int v
+      @family = v
+    end
+
     # @see b
-    def b=(v) Axlsx.validate_boolean v; @b = v end
+    def b=(v)
+      Axlsx.validate_boolean v
+      @b = v
+    end
+
     # @see i
-    def i=(v) Axlsx.validate_boolean v; @i = v end
+    def i=(v)
+      Axlsx.validate_boolean v
+      @i = v
+    end
 
     # @see u
     def u=(v)
@@ -131,19 +150,46 @@ module Axlsx
     end
 
     # @see strike
-    def strike=(v) Axlsx.validate_boolean v; @strike = v end
+    def strike=(v)
+      Axlsx.validate_boolean v
+      @strike = v
+    end
+
     # @see outline
-    def outline=(v) Axlsx.validate_boolean v; @outline = v end
+    def outline=(v)
+      Axlsx.validate_boolean v
+      @outline = v
+    end
+
     # @see shadow
-    def shadow=(v) Axlsx.validate_boolean v; @shadow = v end
+    def shadow=(v)
+      Axlsx.validate_boolean v
+      @shadow = v
+    end
+
     # @see condense
-    def condense=(v) Axlsx.validate_boolean v; @condense = v end
+    def condense=(v)
+      Axlsx.validate_boolean v
+      @condense = v
+    end
+
     # @see extend
-    def extend=(v) Axlsx.validate_boolean v; @extend = v end
+    def extend=(v)
+      Axlsx.validate_boolean v
+      @extend = v
+    end
+
     # @see color
-    def color=(v) DataTypeValidator.validate "Font.color", Color, v; @color = v end
+    def color=(v)
+      DataTypeValidator.validate "Font.color", Color, v
+      @color = v
+    end
+
     # @see sz
-    def sz=(v) Axlsx.validate_unsigned_int v; @sz = v end
+    def sz=(v)
+      Axlsx.validate_unsigned_int v
+      @sz = v
+    end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/gradient_fill.rb
+++ b/lib/axlsx/stylesheet/gradient_fill.rb
@@ -55,10 +55,16 @@ module Axlsx
     attr_reader :stop
 
     # @see type
-    def type=(v) Axlsx.validate_gradient_type v; @type = v end
+    def type=(v)
+      Axlsx.validate_gradient_type v
+      @type = v
+    end
 
     # @see degree
-    def degree=(v) Axlsx.validate_float v; @degree = v end
+    def degree=(v)
+      Axlsx.validate_float v
+      @degree = v
+    end
 
     # @see left
     def left=(v)

--- a/lib/axlsx/stylesheet/gradient_stop.rb
+++ b/lib/axlsx/stylesheet/gradient_stop.rb
@@ -22,9 +22,16 @@ module Axlsx
     end
 
     # @see color
-    def color=(v) DataTypeValidator.validate "GradientStop.color", Color, v; @color = v end
+    def color=(v)
+      DataTypeValidator.validate "GradientStop.color", Color, v
+      @color = v
+    end
+
     # @see position
-    def position=(v) DataTypeValidator.validate "GradientStop.position", Float, v, ->(arg) { arg >= 0 && arg <= 1 }; @position = v end
+    def position=(v)
+      DataTypeValidator.validate "GradientStop.position", Float, v, ->(arg) { arg >= 0 && arg <= 1 }
+      @position = v
+    end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/num_fmt.rb
+++ b/lib/axlsx/stylesheet/num_fmt.rb
@@ -61,10 +61,16 @@ module Axlsx
     attr_reader :numFmtId
 
     # @see numFmtId
-    def numFmtId=(v) Axlsx.validate_unsigned_int v; @numFmtId = v end
+    def numFmtId=(v)
+      Axlsx.validate_unsigned_int v
+      @numFmtId = v
+    end
 
     # @see formatCode
-    def formatCode=(v) Axlsx.validate_string v; @formatCode = v end
+    def formatCode=(v)
+      Axlsx.validate_string v
+      @formatCode = v
+    end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/pattern_fill.rb
+++ b/lib/axlsx/stylesheet/pattern_fill.rb
@@ -49,11 +49,22 @@ module Axlsx
     attr_reader :patternType
 
     # @see fgColor
-    def fgColor=(v) DataTypeValidator.validate "PatternFill.fgColor", Color, v; @fgColor = v end
+    def fgColor=(v)
+      DataTypeValidator.validate "PatternFill.fgColor", Color, v
+      @fgColor = v
+    end
+
     # @see bgColor
-    def bgColor=(v) DataTypeValidator.validate "PatternFill.bgColor", Color, v; @bgColor = v end
+    def bgColor=(v)
+      DataTypeValidator.validate "PatternFill.bgColor", Color, v
+      @bgColor = v
+    end
+
     # @see patternType
-    def patternType=(v) Axlsx.validate_pattern_type v; @patternType = v end
+    def patternType=(v)
+      Axlsx.validate_pattern_type v
+      @patternType = v
+    end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/styles.rb
+++ b/lib/axlsx/stylesheet/styles.rb
@@ -472,7 +472,12 @@ module Axlsx
         # If this is a standard xf we pull from numFmts the highest current and increment for num_fmt
         options[:num_fmt] ||= (@numFmts.map(&:numFmtId).max + 1) if options[:type] != :dxf
         numFmt = NumFmt.new(numFmtId: options[:num_fmt] || 0, formatCode: options[:format_code].to_s)
-        options[:type] == :dxf ? numFmt : (numFmts << numFmt; numFmt.numFmtId)
+        if options[:type] == :dxf
+          numFmt
+        else
+          numFmts << numFmt
+          numFmt.numFmtId
+        end
       else
         options[:num_fmt]
       end
@@ -534,8 +539,10 @@ module Axlsx
       @cellXfs << Xf.new(borderId: 0, xfId: 0, numFmtId: 14, fontId: 0, fillId: 0, applyNumberFormat: 1)
       @cellXfs.lock
 
-      @dxfs = SimpleTypedList.new(Dxf, "dxfs"); @dxfs.lock
-      @tableStyles = TableStyles.new(defaultTableStyle: "TableStyleMedium9", defaultPivotStyle: "PivotStyleLight16"); @tableStyles.lock
+      @dxfs = SimpleTypedList.new(Dxf, "dxfs")
+      @dxfs.lock
+      @tableStyles = TableStyles.new(defaultTableStyle: "TableStyleMedium9", defaultPivotStyle: "PivotStyleLight16")
+      @tableStyles.lock
     end
   end
 end

--- a/lib/axlsx/stylesheet/table_style.rb
+++ b/lib/axlsx/stylesheet/table_style.rb
@@ -33,11 +33,22 @@ module Axlsx
     attr_reader :table
 
     # @see name
-    def name=(v) Axlsx.validate_string v; @name = v end
+    def name=(v)
+      Axlsx.validate_string v
+      @name = v
+    end
+
     # @see pivot
-    def pivot=(v) Axlsx.validate_boolean v; @pivot = v end
+    def pivot=(v)
+      Axlsx.validate_boolean v
+      @pivot = v
+    end
+
     # @see table
-    def table=(v) Axlsx.validate_boolean v; @table = v end
+    def table=(v)
+      Axlsx.validate_boolean v
+      @table = v
+    end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/table_style_element.rb
+++ b/lib/axlsx/stylesheet/table_style_element.rb
@@ -58,13 +58,22 @@ module Axlsx
     attr_reader :dxfId
 
     # @see type
-    def type=(v) Axlsx.validate_table_element_type v; @type = v end
+    def type=(v)
+      Axlsx.validate_table_element_type v
+      @type = v
+    end
 
     # @see size
-    def size=(v) Axlsx.validate_unsigned_int v; @size = v end
+    def size=(v)
+      Axlsx.validate_unsigned_int v
+      @size = v
+    end
 
     # @see dxfId
-    def dxfId=(v) Axlsx.validate_unsigned_int v; @dxfId = v end
+    def dxfId=(v)
+      Axlsx.validate_unsigned_int v
+      @dxfId = v
+    end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/table_styles.rb
+++ b/lib/axlsx/stylesheet/table_styles.rb
@@ -26,9 +26,16 @@ module Axlsx
     attr_reader :defaultPivotStyle
 
     # @see defaultTableStyle
-    def defaultTableStyle=(v) Axlsx.validate_string(v); @defaultTableStyle = v; end
+    def defaultTableStyle=(v)
+      Axlsx.validate_string(v)
+      @defaultTableStyle = v
+    end
+
     # @see defaultPivotStyle
-    def defaultPivotStyle=(v) Axlsx.validate_string(v); @defaultPivotStyle = v; end
+    def defaultPivotStyle=(v)
+      Axlsx.validate_string(v)
+      @defaultPivotStyle = v
+    end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/stylesheet/xf.rb
+++ b/lib/axlsx/stylesheet/xf.rb
@@ -95,41 +95,94 @@ module Axlsx
     attr_reader :applyProtection
 
     # @see Xf#alignment
-    def alignment=(v) DataTypeValidator.validate "Xf.alignment", CellAlignment, v; @alignment = v end
+    def alignment=(v)
+      DataTypeValidator.validate "Xf.alignment", CellAlignment, v
+      @alignment = v
+    end
 
     # @see protection
-    def protection=(v) DataTypeValidator.validate "Xf.protection", CellProtection, v; @protection = v end
+    def protection=(v)
+      DataTypeValidator.validate "Xf.protection", CellProtection, v
+      @protection = v
+    end
 
     # @see numFmtId
-    def numFmtId=(v) Axlsx.validate_unsigned_int v; @numFmtId = v end
+    def numFmtId=(v)
+      Axlsx.validate_unsigned_int v
+      @numFmtId = v
+    end
 
     # @see fontId
-    def fontId=(v) Axlsx.validate_unsigned_int v; @fontId = v end
+    def fontId=(v)
+      Axlsx.validate_unsigned_int v
+      @fontId = v
+    end
+
     # @see fillId
-    def fillId=(v) Axlsx.validate_unsigned_int v; @fillId = v end
+    def fillId=(v)
+      Axlsx.validate_unsigned_int v
+      @fillId = v
+    end
+
     # @see borderId
-    def borderId=(v) Axlsx.validate_unsigned_int v; @borderId = v end
+    def borderId=(v)
+      Axlsx.validate_unsigned_int v
+      @borderId = v
+    end
+
     # @see xfId
-    def xfId=(v) Axlsx.validate_unsigned_int v; @xfId = v end
+    def xfId=(v)
+      Axlsx.validate_unsigned_int v
+      @xfId = v
+    end
+
     # @see quotePrefix
-    def quotePrefix=(v) Axlsx.validate_boolean v; @quotePrefix = v end
+    def quotePrefix=(v)
+      Axlsx.validate_boolean v
+      @quotePrefix = v
+    end
+
     # @see pivotButton
-    def pivotButton=(v) Axlsx.validate_boolean v; @pivotButton = v end
+    def pivotButton=(v)
+      Axlsx.validate_boolean v
+      @pivotButton = v
+    end
+
     # @see applyNumberFormat
-    def applyNumberFormat=(v) Axlsx.validate_boolean v; @applyNumberFormat = v end
+    def applyNumberFormat=(v)
+      Axlsx.validate_boolean v
+      @applyNumberFormat = v
+    end
+
     # @see applyFont
-    def applyFont=(v) Axlsx.validate_boolean v; @applyFont = v end
+    def applyFont=(v)
+      Axlsx.validate_boolean v
+      @applyFont = v
+    end
+
     # @see applyFill
-    def applyFill=(v) Axlsx.validate_boolean v; @applyFill = v end
+    def applyFill=(v)
+      Axlsx.validate_boolean v
+      @applyFill = v
+    end
 
     # @see applyBorder
-    def applyBorder=(v) Axlsx.validate_boolean v; @applyBorder = v end
+    def applyBorder=(v)
+      Axlsx.validate_boolean v
+      @applyBorder = v
+    end
 
     # @see applyAlignment
-    def applyAlignment=(v) Axlsx.validate_boolean v; @applyAlignment = v end
+    def applyAlignment=(v)
+      Axlsx.validate_boolean v
+      @applyAlignment = v
+    end
 
     # @see applyProtection
-    def applyProtection=(v) Axlsx.validate_boolean v; @applyProtection = v end
+    def applyProtection=(v)
+      Axlsx.validate_boolean v
+      @applyProtection = v
+    end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/workbook/workbook.rb
+++ b/lib/axlsx/workbook/workbook.rb
@@ -252,11 +252,17 @@ module Axlsx
     def date1904() @@date1904; end
 
     # see @date1904
-    def date1904=(v) Axlsx.validate_boolean v; @@date1904 = v; end
+    def date1904=(v)
+      Axlsx.validate_boolean v
+      @@date1904 = v
+    end
 
     # Sets the date1904 attribute to the provided boolean
     # @return [Boolean]
-    def self.date1904=(v) Axlsx.validate_boolean v; @@date1904 = v; end
+    def self.date1904=(v)
+      Axlsx.validate_boolean v
+      @@date1904 = v
+    end
 
     # retrieves the date1904 attribute
     # @return [Boolean]
@@ -283,7 +289,10 @@ module Axlsx
     attr_reader :use_autowidth
 
     # see @use_autowidth
-    def use_autowidth=(v = true) Axlsx.validate_boolean v; @use_autowidth = v; end
+    def use_autowidth=(v = true)
+      Axlsx.validate_boolean v
+      @use_autowidth = v
+    end
 
     # Font size of bold fonts is multiplied with this
     # Used for automatic calculation of cell widths with bold text

--- a/lib/axlsx/workbook/workbook.rb
+++ b/lib/axlsx/workbook/workbook.rb
@@ -249,7 +249,9 @@ module Axlsx
 
     # Instance level access to the class variable 1904
     # @return [Boolean]
-    def date1904() @@date1904; end
+    def date1904
+      @@date1904
+    end
 
     # see @date1904
     def date1904=(v)
@@ -266,7 +268,9 @@ module Axlsx
 
     # retrieves the date1904 attribute
     # @return [Boolean]
-    def self.date1904() @@date1904; end
+    def self.date1904
+      @@date1904
+    end
 
     # Whether to treat values starting with an equals sign as formulas or as literal strings.
     # Allowing user-generated data to be interpreted as formulas is a security risk.

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -189,7 +189,9 @@ module Axlsx
     attr_reader :font_name
 
     # @see font_name
-    def font_name=(v) set_run_style :validate_string, :font_name, v; end
+    def font_name=(v)
+      set_run_style :validate_string, :font_name, v
+    end
 
     # The inline charset property for the cell
     # As far as I can tell, this is pretty much ignored. However, based on the spec it should be one of the following:
@@ -216,7 +218,9 @@ module Axlsx
     attr_reader :charset
 
     # @see charset
-    def charset=(v) set_run_style :validate_unsigned_int, :charset, v; end
+    def charset=(v)
+      set_run_style :validate_unsigned_int, :charset, v
+    end
 
     # The inline family property for the cell
     # @return [Integer]
@@ -237,49 +241,63 @@ module Axlsx
     attr_reader :b
 
     # @see b
-    def b=(v) set_run_style :validate_boolean, :b, v; end
+    def b=(v)
+      set_run_style :validate_boolean, :b, v
+    end
 
     # The inline italic property for the cell
     # @return [Boolean]
     attr_reader :i
 
     # @see i
-    def i=(v) set_run_style :validate_boolean, :i, v; end
+    def i=(v)
+      set_run_style :validate_boolean, :i, v
+    end
 
     # The inline strike property for the cell
     # @return [Boolean]
     attr_reader :strike
 
     # @see strike
-    def strike=(v) set_run_style :validate_boolean, :strike, v; end
+    def strike=(v)
+      set_run_style :validate_boolean, :strike, v
+    end
 
     # The inline outline property for the cell
     # @return [Boolean]
     attr_reader :outline
 
     # @see outline
-    def outline=(v) set_run_style :validate_boolean, :outline, v; end
+    def outline=(v)
+      set_run_style :validate_boolean, :outline, v
+    end
 
     # The inline shadow property for the cell
     # @return [Boolean]
     attr_reader :shadow
 
     # @see shadow
-    def shadow=(v) set_run_style :validate_boolean, :shadow, v; end
+    def shadow=(v)
+      set_run_style :validate_boolean, :shadow, v
+    end
 
     # The inline condense property for the cell
     # @return [Boolean]
     attr_reader :condense
 
     # @see condense
-    def condense=(v) set_run_style :validate_boolean, :condense, v; end
+    def condense=(v)
+      set_run_style :validate_boolean, :condense, v
+    end
 
     # The inline extend property for the cell
     # @return [Boolean]
     attr_reader :extend
 
     # @see extend
-    def extend=(v) set_run_style :validate_boolean, :extend, v; end
+    def extend=(v)
+      set_run_style :validate_boolean, :extend, v
+    end
 
     # The inline underline property for the cell.
     # It must be one of :none, :single, :double, :singleAccounting, :doubleAccounting
@@ -307,7 +325,9 @@ module Axlsx
     attr_reader :sz
 
     # @see sz
-    def sz=(v) set_run_style :validate_unsigned_int, :sz, v; end
+    def sz=(v)
+      set_run_style :validate_unsigned_int, :sz, v
+    end
 
     # The inline vertical alignment property for the cell
     # this must be one of [:baseline, :subscript, :superscript]

--- a/lib/axlsx/workbook/worksheet/cfvo.rb
+++ b/lib/axlsx/workbook/worksheet/cfvo.rb
@@ -40,10 +40,16 @@ module Axlsx
     attr_reader :val
 
     # @see type
-    def type=(v); Axlsx.validate_conditional_formatting_value_object_type(v); @type = v end
+    def type=(v)
+      Axlsx.validate_conditional_formatting_value_object_type(v)
+      @type = v
+    end
 
     # @see gte
-    def gte=(v); Axlsx.validate_boolean(v); @gte = v end
+    def gte=(v)
+      Axlsx.validate_boolean(v)
+      @gte = v
+    end
 
     # @see val
     def val=(v)

--- a/lib/axlsx/workbook/worksheet/conditional_formatting.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting.rb
@@ -61,7 +61,9 @@ module Axlsx
     end
 
     # @see rules
-    def rules=(v); @rules = v end
+    def rules=(v)
+      @rules = v
+    end
 
     # @see sqref
     def sqref=(v)

--- a/lib/axlsx/workbook/worksheet/conditional_formatting.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting.rb
@@ -62,8 +62,12 @@ module Axlsx
 
     # @see rules
     def rules=(v); @rules = v end
+
     # @see sqref
-    def sqref=(v); Axlsx.validate_string(v); @sqref = v end
+    def sqref=(v)
+      Axlsx.validate_string(v)
+      @sqref = v
+    end
 
     # Serializes the conditional formatting element
     # @example Conditional Formatting XML looks like:

--- a/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
@@ -155,33 +155,88 @@ module Axlsx
     end
 
     # @see type
-    def type=(v); Axlsx.validate_conditional_formatting_type(v); @type = v end
+    def type=(v)
+      Axlsx.validate_conditional_formatting_type(v)
+      @type = v
+    end
+
     # @see aboveAverage
-    def aboveAverage=(v); Axlsx.validate_boolean(v); @aboveAverage = v end
+    def aboveAverage=(v)
+      Axlsx.validate_boolean(v)
+      @aboveAverage = v
+    end
+
     # @see bottom
-    def bottom=(v); Axlsx.validate_boolean(v); @bottom = v end
+    def bottom=(v)
+      Axlsx.validate_boolean(v)
+      @bottom = v
+    end
+
     # @see dxfId
-    def dxfId=(v); Axlsx.validate_unsigned_numeric(v); @dxfId = v end
+    def dxfId=(v)
+      Axlsx.validate_unsigned_numeric(v)
+      @dxfId = v
+    end
+
     # @see equalAverage
-    def equalAverage=(v); Axlsx.validate_boolean(v); @equalAverage = v end
+    def equalAverage=(v)
+      Axlsx.validate_boolean(v)
+      @equalAverage = v
+    end
+
     # @see priority
-    def priority=(v); Axlsx.validate_unsigned_numeric(v); @priority = v end
+    def priority=(v)
+      Axlsx.validate_unsigned_numeric(v)
+      @priority = v
+    end
+
     # @see operator
-    def operator=(v); Axlsx.validate_conditional_formatting_operator(v); @operator = v end
+    def operator=(v)
+      Axlsx.validate_conditional_formatting_operator(v)
+      @operator = v
+    end
+
     # @see text
-    def text=(v); Axlsx.validate_string(v); @text = v end
+    def text=(v)
+      Axlsx.validate_string(v)
+      @text = v
+    end
+
     # @see percent
-    def percent=(v); Axlsx.validate_boolean(v); @percent = v end
+    def percent=(v)
+      Axlsx.validate_boolean(v)
+      @percent = v
+    end
+
     # @see rank
-    def rank=(v); Axlsx.validate_unsigned_numeric(v); @rank = v end
+    def rank=(v)
+      Axlsx.validate_unsigned_numeric(v)
+      @rank = v
+    end
+
     # @see stdDev
-    def stdDev=(v); Axlsx.validate_unsigned_numeric(v); @stdDev = v end
+    def stdDev=(v)
+      Axlsx.validate_unsigned_numeric(v)
+      @stdDev = v
+    end
+
     # @see stopIfTrue
-    def stopIfTrue=(v); Axlsx.validate_boolean(v); @stopIfTrue = v end
+    def stopIfTrue=(v)
+      Axlsx.validate_boolean(v)
+      @stopIfTrue = v
+    end
+
     # @see timePeriod
-    def timePeriod=(v); Axlsx.validate_time_period_type(v); @timePeriod = v end
+    def timePeriod=(v)
+      Axlsx.validate_time_period_type(v)
+      @timePeriod = v
+    end
+
     # @see formula
-    def formula=(v); [*v].each { |x| Axlsx.validate_string(x) }; @formula = [*v].map { |form| ::CGI.escapeHTML(form) } end
+    def formula=(v)
+      [*v].each { |x| Axlsx.validate_string(x) }
+      @formula = [*v].map { |form| ::CGI.escapeHTML(form) }
+    end
 
     # @see color_scale
     def color_scale=(v)

--- a/lib/axlsx/workbook/worksheet/data_validation.rb
+++ b/lib/axlsx/workbook/worksheet/data_validation.rb
@@ -178,31 +178,58 @@ module Axlsx
     attr_reader :type
 
     # @see formula1
-    def formula1=(v); Axlsx.validate_string(v); @formula1 = v end
+    def formula1=(v)
+      Axlsx.validate_string(v)
+      @formula1 = v
+    end
 
     # @see formula2
-    def formula2=(v); Axlsx.validate_string(v); @formula2 = v end
+    def formula2=(v)
+      Axlsx.validate_string(v)
+      @formula2 = v
+    end
 
     # @see allowBlank
-    def allowBlank=(v); Axlsx.validate_boolean(v); @allowBlank = v end
+    def allowBlank=(v)
+      Axlsx.validate_boolean(v)
+      @allowBlank = v
+    end
 
     # @see error
-    def error=(v); Axlsx.validate_string(v); @error = v end
+    def error=(v)
+      Axlsx.validate_string(v)
+      @error = v
+    end
 
     # @see errorStyle
-    def errorStyle=(v); Axlsx.validate_data_validation_error_style(v); @errorStyle = v end
+    def errorStyle=(v)
+      Axlsx.validate_data_validation_error_style(v)
+      @errorStyle = v
+    end
 
     # @see errorTitle
-    def errorTitle=(v); Axlsx.validate_string(v); @errorTitle = v end
+    def errorTitle=(v)
+      Axlsx.validate_string(v)
+      @errorTitle = v
+    end
 
     # @see operator
-    def operator=(v); Axlsx.validate_data_validation_operator(v); @operator = v end
+    def operator=(v)
+      Axlsx.validate_data_validation_operator(v)
+      @operator = v
+    end
 
     # @see prompt
-    def prompt=(v); Axlsx.validate_string(v); @prompt = v end
+    def prompt=(v)
+      Axlsx.validate_string(v)
+      @prompt = v
+    end
 
     # @see promptTitle
-    def promptTitle=(v); Axlsx.validate_string(v); @promptTitle = v end
+    def promptTitle=(v)
+      Axlsx.validate_string(v)
+      @promptTitle = v
+    end
 
     # @see showDropDown
     def showDropDown=(v)
@@ -219,16 +246,28 @@ module Axlsx
     end
 
     # @see showErrorMessage
-    def showErrorMessage=(v); Axlsx.validate_boolean(v); @showErrorMessage = v end
+    def showErrorMessage=(v)
+      Axlsx.validate_boolean(v)
+      @showErrorMessage = v
+    end
 
     # @see showInputMessage
-    def showInputMessage=(v); Axlsx.validate_boolean(v); @showInputMessage = v end
+    def showInputMessage=(v)
+      Axlsx.validate_boolean(v)
+      @showInputMessage = v
+    end
 
     # @see sqref
-    def sqref=(v); Axlsx.validate_string(v); @sqref = v end
+    def sqref=(v)
+      Axlsx.validate_string(v)
+      @sqref = v
+    end
 
     # @see type
-    def type=(v); Axlsx.validate_data_validation_type(v); @type = v end
+    def type=(v)
+      Axlsx.validate_data_validation_type(v)
+      @type = v
+    end
 
     # Serializes the data validation
     # @param [String] str

--- a/lib/axlsx/workbook/worksheet/icon_set.rb
+++ b/lib/axlsx/workbook/worksheet/icon_set.rb
@@ -56,7 +56,10 @@ module Axlsx
     attr_reader :interpolationPoints
 
     # @see iconSet
-    def iconSet=(v); Axlsx.validate_icon_set(v); @iconSet = v end
+    def iconSet=(v)
+      Axlsx.validate_icon_set(v)
+      @iconSet = v
+    end
 
     # @see interpolationPoints
     def interpolationPoints=(v)
@@ -66,13 +69,22 @@ module Axlsx
     end
 
     # @see showValue
-    def showValue=(v); Axlsx.validate_boolean(v); @showValue = v end
+    def showValue=(v)
+      Axlsx.validate_boolean(v)
+      @showValue = v
+    end
 
     # @see percent
-    def percent=(v); Axlsx.validate_boolean(v); @percent = v end
+    def percent=(v)
+      Axlsx.validate_boolean(v)
+      @percent = v
+    end
 
     # @see reverse
-    def reverse=(v); Axlsx.validate_boolean(v); @reverse = v end
+    def reverse=(v)
+      Axlsx.validate_boolean(v)
+      @reverse = v
+    end
 
     # Serialize this object to an xml string
     # @param [String] str

--- a/lib/axlsx/workbook/worksheet/page_margins.rb
+++ b/lib/axlsx/workbook/worksheet/page_margins.rb
@@ -78,17 +78,40 @@ module Axlsx
     end
 
     # @see left
-    def left=(v); Axlsx.validate_unsigned_numeric(v); @left = v end
+    def left=(v)
+      Axlsx.validate_unsigned_numeric(v)
+      @left = v
+    end
+
     # @see right
-    def right=(v); Axlsx.validate_unsigned_numeric(v); @right = v end
+    def right=(v)
+      Axlsx.validate_unsigned_numeric(v)
+      @right = v
+    end
+
     # @see top
-    def top=(v); Axlsx.validate_unsigned_numeric(v); @top = v end
+    def top=(v)
+      Axlsx.validate_unsigned_numeric(v)
+      @top = v
+    end
+
     # @see bottom
-    def bottom=(v); Axlsx.validate_unsigned_numeric(v); @bottom = v end
+    def bottom=(v)
+      Axlsx.validate_unsigned_numeric(v)
+      @bottom = v
+    end
+
     # @see header
-    def header=(v); Axlsx.validate_unsigned_numeric(v); @header = v end
+    def header=(v)
+      Axlsx.validate_unsigned_numeric(v)
+      @header = v
+    end
+
     # @see footer
-    def footer=(v); Axlsx.validate_unsigned_numeric(v); @footer = v end
+    def footer=(v)
+      Axlsx.validate_unsigned_numeric(v)
+      @footer = v
+    end
 
     # Serializes the page margins element
     # @param [String] str

--- a/lib/axlsx/workbook/worksheet/page_setup.rb
+++ b/lib/axlsx/workbook/worksheet/page_setup.rb
@@ -198,17 +198,40 @@ module Axlsx
     end
 
     # @see fit_to_height
-    def fit_to_height=(v); Axlsx.validate_unsigned_int(v); @fit_to_height = v; end
+    def fit_to_height=(v)
+      Axlsx.validate_unsigned_int(v)
+      @fit_to_height = v
+    end
+
     # @see fit_to_width
-    def fit_to_width=(v); Axlsx.validate_unsigned_int(v); @fit_to_width = v; end
+    def fit_to_width=(v)
+      Axlsx.validate_unsigned_int(v)
+      @fit_to_width = v
+    end
+
     # @see orientation
-    def orientation=(v); Axlsx.validate_page_orientation(v); @orientation = v; end
+    def orientation=(v)
+      Axlsx.validate_page_orientation(v)
+      @orientation = v
+    end
+
     # @see paper_height
-    def paper_height=(v); Axlsx.validate_number_with_unit(v); @paper_height = v; end
+    def paper_height=(v)
+      Axlsx.validate_number_with_unit(v)
+      @paper_height = v
+    end
+
     # @see paper_width
-    def paper_width=(v); Axlsx.validate_number_with_unit(v); @paper_width = v; end
+    def paper_width=(v)
+      Axlsx.validate_number_with_unit(v)
+      @paper_width = v
+    end
+
     # @see scale
-    def scale=(v); Axlsx.validate_scale_10_400(v); @scale = v; end
+    def scale=(v)
+      Axlsx.validate_scale_10_400(v)
+      @scale = v
+    end
 
     # convenience method to achieve sanity when setting fit_to_width and fit_to_height
     # as they both default to 1 if only their counterpart is specified.

--- a/lib/axlsx/workbook/worksheet/pane.rb
+++ b/lib/axlsx/workbook/worksheet/pane.rb
@@ -114,10 +114,16 @@ module Axlsx
     end
 
     # @see x_split
-    def x_split=(v); Axlsx.validate_unsigned_int(v); @x_split = v end
+    def x_split=(v)
+      Axlsx.validate_unsigned_int(v)
+      @x_split = v
+    end
 
     # @see y_split
-    def y_split=(v); Axlsx.validate_unsigned_int(v); @y_split = v end
+    def y_split=(v)
+      Axlsx.validate_unsigned_int(v)
+      @y_split = v
+    end
 
     # Serializes the data validation
     # @param [String] str

--- a/lib/axlsx/workbook/worksheet/rich_text_run.rb
+++ b/lib/axlsx/workbook/worksheet/rich_text_run.rb
@@ -29,7 +29,9 @@ module Axlsx
     attr_reader :font_name
 
     # @see font_name
-    def font_name=(v) set_run_style :validate_string, :font_name, v; end
+    def font_name=(v)
+      set_run_style :validate_string, :font_name, v
+    end
 
     # The inline charset property for the cell
     # As far as I can tell, this is pretty much ignored. However, based on the spec it should be one of the following:
@@ -56,7 +58,9 @@ module Axlsx
     attr_reader :charset
 
     # @see charset
-    def charset=(v) set_run_style :validate_unsigned_int, :charset, v; end
+    def charset=(v)
+      set_run_style :validate_unsigned_int, :charset, v
+    end
 
     # The inline family property for the cell
     # @return [Integer]
@@ -77,49 +81,63 @@ module Axlsx
     attr_reader :b
 
     # @see b
-    def b=(v) set_run_style :validate_boolean, :b, v; end
+    def b=(v)
+      set_run_style :validate_boolean, :b, v
+    end
 
     # The inline italic property for the cell
     # @return [Boolean]
     attr_reader :i
 
     # @see i
-    def i=(v) set_run_style :validate_boolean, :i, v; end
+    def i=(v)
+      set_run_style :validate_boolean, :i, v
+    end
 
     # The inline strike property for the cell
     # @return [Boolean]
     attr_reader :strike
 
     # @see strike
-    def strike=(v) set_run_style :validate_boolean, :strike, v; end
+    def strike=(v)
+      set_run_style :validate_boolean, :strike, v
+    end
 
     # The inline outline property for the cell
     # @return [Boolean]
     attr_reader :outline
 
     # @see outline
-    def outline=(v) set_run_style :validate_boolean, :outline, v; end
+    def outline=(v)
+      set_run_style :validate_boolean, :outline, v
+    end
 
     # The inline shadow property for the cell
     # @return [Boolean]
     attr_reader :shadow
 
     # @see shadow
-    def shadow=(v) set_run_style :validate_boolean, :shadow, v; end
+    def shadow=(v)
+      set_run_style :validate_boolean, :shadow, v
+    end
 
     # The inline condense property for the cell
     # @return [Boolean]
     attr_reader :condense
 
     # @see condense
-    def condense=(v) set_run_style :validate_boolean, :condense, v; end
+    def condense=(v)
+      set_run_style :validate_boolean, :condense, v
+    end
 
     # The inline extend property for the cell
     # @return [Boolean]
     attr_reader :extend
 
     # @see extend
-    def extend=(v) set_run_style :validate_boolean, :extend, v; end
+    def extend=(v)
+      set_run_style :validate_boolean, :extend, v
+    end
 
     # The inline underline property for the cell.
     # It must be one of :none, :single, :double, :singleAccounting, :doubleAccounting, true
@@ -148,7 +166,9 @@ module Axlsx
     attr_reader :sz
 
     # @see sz
-    def sz=(v) set_run_style :validate_unsigned_int, :sz, v; end
+    def sz=(v)
+      set_run_style :validate_unsigned_int, :sz, v
+    end
 
     # The inline vertical alignment property for the cell
     # this must be one of [:baseline, :subscript, :superscript]

--- a/lib/axlsx/workbook/worksheet/row.rb
+++ b/lib/axlsx/workbook/worksheet/row.rb
@@ -143,7 +143,10 @@ module Axlsx
     private
 
     # assigns the owning worksheet for this row
-    def worksheet=(v) DataTypeValidator.validate :row_worksheet, Worksheet, v; @worksheet = v; end
+    def worksheet=(v)
+      DataTypeValidator.validate :row_worksheet, Worksheet, v
+      @worksheet = v
+    end
 
     # Converts values, types, and style options into cells and associates them with this row.
     # A new cell is created for each item in the values array.

--- a/lib/axlsx/workbook/worksheet/selection.rb
+++ b/lib/axlsx/workbook/worksheet/selection.rb
@@ -80,7 +80,10 @@ module Axlsx
     end
 
     # @see active_cell_id
-    def active_cell_id=(v); Axlsx.validate_unsigned_int(v); @active_cell_id = v end
+    def active_cell_id=(v)
+      Axlsx.validate_unsigned_int(v)
+      @active_cell_id = v
+    end
 
     # @see pane
     def pane=(v)
@@ -89,7 +92,10 @@ module Axlsx
     end
 
     # @see sqref
-    def sqref=(v); Axlsx.validate_string(v); @sqref = v end
+    def sqref=(v)
+      Axlsx.validate_string(v)
+      @sqref = v
+    end
 
     # Serializes the data validation
     # @param [String] str

--- a/lib/axlsx/workbook/worksheet/sheet_view.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_view.rb
@@ -162,7 +162,10 @@ module Axlsx
     end
 
     # @see color_id
-    def color_id=(v); Axlsx.validate_unsigned_int(v); @color_id = v end
+    def color_id=(v)
+      Axlsx.validate_unsigned_int(v)
+      @color_id = v
+    end
 
     # @see top_left_cell
     def top_left_cell=(v)
@@ -172,22 +175,40 @@ module Axlsx
     end
 
     # @see view
-    def view=(v); Axlsx.validate_sheet_view_type(v); @view = v end
+    def view=(v)
+      Axlsx.validate_sheet_view_type(v)
+      @view = v
+    end
 
     # @see workbook_view_id
-    def workbook_view_id=(v); Axlsx.validate_unsigned_int(v); @workbook_view_id = v end
+    def workbook_view_id=(v)
+      Axlsx.validate_unsigned_int(v)
+      @workbook_view_id = v
+    end
 
     # @see zoom_scale
-    def zoom_scale=(v); Axlsx.validate_scale_0_10_400(v); @zoom_scale = v end
+    def zoom_scale=(v)
+      Axlsx.validate_scale_0_10_400(v)
+      @zoom_scale = v
+    end
 
     # @see zoom_scale_normal
-    def zoom_scale_normal=(v); Axlsx.validate_scale_0_10_400(v); @zoom_scale_normal = v end
+    def zoom_scale_normal=(v)
+      Axlsx.validate_scale_0_10_400(v)
+      @zoom_scale_normal = v
+    end
 
     # @see zoom_scale_page_layout_view
-    def zoom_scale_page_layout_view=(v); Axlsx.validate_scale_0_10_400(v); @zoom_scale_page_layout_view = v end
+    def zoom_scale_page_layout_view=(v)
+      Axlsx.validate_scale_0_10_400(v)
+      @zoom_scale_page_layout_view = v
+    end
 
     # @see zoom_scale_sheet_layout_view
-    def zoom_scale_sheet_layout_view=(v); Axlsx.validate_scale_0_10_400(v); @zoom_scale_sheet_layout_view = v end
+    def zoom_scale_sheet_layout_view=(v)
+      Axlsx.validate_scale_0_10_400(v)
+      @zoom_scale_sheet_layout_view = v
+    end
 
     # Serializes the data validation
     # @param [String] str

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -833,7 +833,10 @@ module Axlsx
       @worksheet_comments ||= WorksheetComments.new self
     end
 
-    def workbook=(v) DataTypeValidator.validate "Worksheet.workbook", Workbook, v; @workbook = v; end
+    def workbook=(v)
+      DataTypeValidator.validate "Worksheet.workbook", Workbook, v
+      @workbook = v
+    end
 
     def update_column_info(cells, widths = nil)
       cells.each_with_index do |cell, index|

--- a/test/workbook/worksheet/auto_filter/tc_filters.rb
+++ b/test/workbook/worksheet/auto_filter/tc_filters.rb
@@ -36,14 +36,18 @@ class TestFilters < Test::Unit::TestCase
 
   def test_apply_is_false_for_matching_values
     keeper = Object.new
-    def keeper.value; 'a'; end
+    def keeper.value
+      'a'
+    end
 
     refute @filters.apply(keeper)
   end
 
   def test_apply_is_true_for_non_matching_values
     hidden = Object.new
-    def hidden.value; 'b'; end
+    def hidden.value
+      'b'
+    end
 
     assert @filters.apply(hidden)
   end

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -33,7 +33,10 @@ class TestWorksheet < Test::Unit::TestCase
   end
 
   def test_name_unique
-    assert_raise(ArgumentError, "worksheet name must be unique") { n = @ws.name; @ws.workbook.add_worksheet(name: n) }
+    assert_raise(ArgumentError, "worksheet name must be unique") do
+      n = @ws.name
+      @ws.workbook.add_worksheet(name: n)
+    end
   end
 
   def test_name_unique_only_checks_other_worksheet_names


### PR DESCRIPTION
Hello,

I wanted to propose this change for quite a bit, together with all the RuboCop refactor, but I've decided to wait.

When I worked on #320 and #319 I realized that maybe it is the time to make this PR

I think that `;` in long classes helps with one-line attribute writers with validations, but after seeing the unrolled version, for me they are much more easy to read and significantly reduce the cognitive load

---

Automatically fixed with `rubocop -a`

Manual changes in production code:
- Empty line before `#pages=` in `lib/axlsx/doc_props/app.rb` for uniformity
- Remove redundant parentheses and replace ternary operator with `if...else` in `lib/axlsx/stylesheet/styles.rb` to improve readability and code coverage

Manual changes in non-production code:
- Create `errors` arrays for uniformity and readability

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).