### PR TITLE
Refactor error assertions

### DIFF
--- a/test/content_type/tc_content_type.rb
+++ b/test/content_type/tc_content_type.rb
@@ -10,8 +10,9 @@ class TestContentType < Test::Unit::TestCase
 
   def test_valid_document
     schema = Nokogiri::XML::Schema(File.open(Axlsx::CONTENT_TYPES_XSD))
+    errors = schema.validate(@doc)
 
-    assert_empty(schema.validate(@doc).map { |e| puts e.message; e.message })
+    assert_empty(errors)
   end
 
   def test_pre_built_types

--- a/test/doc_props/tc_app.rb
+++ b/test/doc_props/tc_app.rb
@@ -36,11 +36,8 @@ class TestApp < Test::Unit::TestCase
   def test_valid_document
     schema = Nokogiri::XML::Schema(File.open(Axlsx::APP_XSD))
     doc = Nokogiri::XML(@app.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors << error
-    end
+    errors = schema.validate(doc)
 
-    assert_equal(0, errors.size, "app.xml invalid#{errors.map(&:message)}")
+    assert_empty(errors)
   end
 end

--- a/test/doc_props/tc_core.rb
+++ b/test/doc_props/tc_core.rb
@@ -12,13 +12,9 @@ class TestCore < Test::Unit::TestCase
 
   def test_valid_document
     schema = Nokogiri::XML::Schema(File.open(Axlsx::CORE_XSD))
-    errors = []
-    schema.validate(@doc).each do |error|
-      puts error.message
-      errors << error
-    end
+    errors = schema.validate(@doc)
 
-    assert_equal(0, errors.size, "core.xml Invalid#{errors.map(&:message)}")
+    assert_empty(errors)
   end
 
   def test_populates_created

--- a/test/drawing/tc_area_chart.rb
+++ b/test/drawing/tc_area_chart.rb
@@ -28,12 +28,8 @@ class TestAreaChart < Test::Unit::TestCase
   def test_to_xml
     schema = Nokogiri::XML::Schema(File.open(Axlsx::DRAWING_XSD))
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 end

--- a/test/drawing/tc_bar_3D_chart.rb
+++ b/test/drawing/tc_bar_3D_chart.rb
@@ -55,13 +55,9 @@ class TestBar3DChart < Test::Unit::TestCase
   def test_to_xml_string
     schema = Nokogiri::XML::Schema(File.open(Axlsx::DRAWING_XSD))
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 
   def test_to_xml_string_has_axes_in_correct_order

--- a/test/drawing/tc_bar_chart.rb
+++ b/test/drawing/tc_bar_chart.rb
@@ -55,13 +55,9 @@ class TestBarChart < Test::Unit::TestCase
   def test_to_xml_string
     schema = Nokogiri::XML::Schema(File.open(Axlsx::DRAWING_XSD))
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 
   def test_to_xml_string_has_axes_in_correct_order

--- a/test/drawing/tc_bubble_chart.rb
+++ b/test/drawing/tc_bubble_chart.rb
@@ -34,12 +34,8 @@ class TestBubbleChart < Test::Unit::TestCase
   def test_to_xml_string
     schema = Nokogiri::XML::Schema(File.open(Axlsx::DRAWING_XSD))
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 end

--- a/test/drawing/tc_chart.rb
+++ b/test/drawing/tc_chart.rb
@@ -137,9 +137,9 @@ class TestChart < Test::Unit::TestCase
   def test_to_xml_string
     schema = Nokogiri::XML::Schema(File.open(Axlsx::DRAWING_XSD))
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = schema.validate(doc).map { |error| puts error.message; error }
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 
   def test_to_xml_string_for_display_blanks_as

--- a/test/drawing/tc_drawing.rb
+++ b/test/drawing/tc_drawing.rb
@@ -83,12 +83,8 @@ class TestDrawing < Test::Unit::TestCase
     schema = Nokogiri::XML::Schema(File.open(Axlsx::DRAWING_XSD))
     @ws.add_chart(Axlsx::Pie3DChart)
     doc = Nokogiri::XML(@ws.drawing.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 end

--- a/test/drawing/tc_line_3d_chart.rb
+++ b/test/drawing/tc_line_3d_chart.rb
@@ -35,12 +35,8 @@ class TestLine3DChart < Test::Unit::TestCase
   def test_to_xml
     schema = Nokogiri::XML::Schema(File.open(Axlsx::DRAWING_XSD))
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 end

--- a/test/drawing/tc_line_chart.rb
+++ b/test/drawing/tc_line_chart.rb
@@ -28,12 +28,8 @@ class TestLineChart < Test::Unit::TestCase
   def test_to_xml
     schema = Nokogiri::XML::Schema(File.open(Axlsx::DRAWING_XSD))
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 end

--- a/test/drawing/tc_pic.rb
+++ b/test/drawing/tc_pic.rb
@@ -110,13 +110,9 @@ class TestPic < Test::Unit::TestCase
   def test_to_xml
     schema = Nokogiri::XML::Schema(File.open(Axlsx::DRAWING_XSD))
     doc = Nokogiri::XML(@image.anchor.drawing.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 
   def test_to_xml_has_correct_r_id

--- a/test/drawing/tc_pie_3D_chart.rb
+++ b/test/drawing/tc_pie_3D_chart.rb
@@ -21,8 +21,8 @@ class TestPie3DChart < Test::Unit::TestCase
   def test_to_xml
     schema = Nokogiri::XML::Schema(File.open(Axlsx::DRAWING_XSD))
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = schema.validate(doc).map { |error| puts error.message; error }
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 end

--- a/test/drawing/tc_pie_chart.rb
+++ b/test/drawing/tc_pie_chart.rb
@@ -19,8 +19,8 @@ class TestPieChart < Test::Unit::TestCase
   def test_to_xml
     schema = Nokogiri::XML::Schema(File.open(Axlsx::DRAWING_XSD))
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = schema.validate(doc).map { |error| puts error.message; error }
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 end

--- a/test/drawing/tc_scatter_chart.rb
+++ b/test/drawing/tc_scatter_chart.rb
@@ -40,12 +40,8 @@ class TestScatterChart < Test::Unit::TestCase
   def test_to_xml_string
     schema = Nokogiri::XML::Schema(File.open(Axlsx::DRAWING_XSD))
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 end

--- a/test/drawing/tc_series_title.rb
+++ b/test/drawing/tc_series_title.rb
@@ -39,9 +39,8 @@ class TestSeriesTitle < Test::Unit::TestCase
     @title.text = "&><'\""
 
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = doc.errors
 
-    assert_empty(errors, "invalid xml: #{errors.map(&:to_s).join(', ')}")
+    assert_empty(doc.errors)
   end
 
   def test_to_xml_string_for_special_characters_in_cell
@@ -52,8 +51,7 @@ class TestSeriesTitle < Test::Unit::TestCase
     @title.cell = cell
 
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = doc.errors
 
-    assert_empty(errors, "invalid xml: #{errors.map(&:to_s).join(', ')}")
+    assert_empty(doc.errors)
   end
 end

--- a/test/drawing/tc_title.rb
+++ b/test/drawing/tc_title.rb
@@ -69,9 +69,8 @@ class TestTitle < Test::Unit::TestCase
   def test_to_xml_string_for_special_characters
     @chart.title.text = "&><'\""
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = doc.errors
 
-    assert_empty(errors, "invalid xml: #{errors.map(&:to_s).join(', ')}")
+    assert_empty(doc.errors)
   end
 
   def test_to_xml_string_for_special_characters_in_cell
@@ -80,8 +79,7 @@ class TestTitle < Test::Unit::TestCase
 
     @chart.title.cell = cell
     doc = Nokogiri::XML(@chart.to_xml_string)
-    errors = doc.errors
 
-    assert_empty(errors, "invalid xml: #{errors.map(&:to_s).join(', ')}")
+    assert_empty(doc.errors)
   end
 end

--- a/test/rels/tc_relationships.rb
+++ b/test/rels/tc_relationships.rb
@@ -20,19 +20,13 @@ class TestRelationships < Test::Unit::TestCase
     @rels = Axlsx::Relationships.new
     schema = Nokogiri::XML::Schema(File.open(Axlsx::RELS_XSD))
     doc = Nokogiri::XML(@rels.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      puts error.message
-      errors << error
-    end
+    errors = schema.validate(doc)
+
+    assert_empty(errors)
 
     @rels << Axlsx::Relationship.new(nil, Axlsx::WORKSHEET_R, "bar")
     doc = Nokogiri::XML(@rels.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      puts error.message
-      errors << error
-    end
+    errors = schema.validate(doc)
 
     assert_empty(errors)
   end

--- a/test/stylesheet/tc_styles.rb
+++ b/test/stylesheet/tc_styles.rb
@@ -12,11 +12,7 @@ class TestStyles < Test::Unit::TestCase
   def test_valid_document
     schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
     doc = Nokogiri::XML(@styles.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
+    errors = schema.validate(doc)
 
     assert_empty(errors)
   end
@@ -303,11 +299,7 @@ class TestStyles < Test::Unit::TestCase
 
     schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
     doc = Nokogiri::XML(@styles.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
+    errors = schema.validate(doc)
 
     assert_empty(errors)
   end

--- a/test/workbook/tc_shared_strings_table.rb
+++ b/test/workbook/tc_shared_strings_table.rb
@@ -39,13 +39,9 @@ class TestSharedStringsTable < Test::Unit::TestCase
   def test_valid_document
     schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
     doc = Nokogiri::XML(@p.workbook.shared_strings.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      puts error.message
-      errors << error
-    end
+    errors = schema.validate(doc)
 
-    assert_equal(0, errors.size, "sharedStirngs.xml Invalid#{errors.map(&:message)}")
+    assert_empty(errors)
   end
 
   def test_remove_control_characters_in_xml_serialization

--- a/test/workbook/tc_workbook.rb
+++ b/test/workbook/tc_workbook.rb
@@ -116,13 +116,9 @@ class TestWorkbook < Test::Unit::TestCase
   def test_to_xml
     schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
     doc = Nokogiri::XML(@wb.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 
   def test_to_xml_reversed

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -571,12 +571,8 @@ class TestCell < Test::Unit::TestCase
 
     schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
     doc = Nokogiri::XML(@ws.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 end

--- a/test/workbook/worksheet/tc_pivot_table.rb
+++ b/test/workbook/worksheet/tc_pivot_table.rb
@@ -5,13 +5,9 @@ require 'tc_helper'
 def shared_test_pivot_table_xml_validity(pivot_table)
   schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
   doc = Nokogiri::XML(pivot_table.to_xml_string)
-  errors = []
-  schema.validate(doc).each do |error|
-    errors.push error
-    puts error.message
-  end
+  errors = schema.validate(doc)
 
-  assert_empty(errors, "error free validation")
+  assert_empty(errors)
 end
 
 class TestPivotTable < Test::Unit::TestCase

--- a/test/workbook/worksheet/tc_pivot_table_cache_definition.rb
+++ b/test/workbook/worksheet/tc_pivot_table_cache_definition.rb
@@ -45,13 +45,9 @@ class TestPivotTableCacheDefinition < Test::Unit::TestCase
   def test_to_xml_string
     schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
     doc = Nokogiri::XML(@cache_definition.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 
   def test_to_xml_string_for_special_characters
@@ -59,8 +55,7 @@ class TestPivotTableCacheDefinition < Test::Unit::TestCase
     cell.value = "&><'\""
 
     doc = Nokogiri::XML(@cache_definition.to_xml_string)
-    errors = doc.errors
 
-    assert_empty(errors, "invalid xml: #{errors.map(&:to_s).join(', ')}")
+    assert_empty(doc.errors)
   end
 end

--- a/test/workbook/worksheet/tc_rich_text_run.rb
+++ b/test/workbook/worksheet/tc_rich_text_run.rb
@@ -166,13 +166,9 @@ class RichTextRun < Test::Unit::TestCase
   def test_to_xml
     schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
     doc = Nokogiri::XML(@ws.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      puts error.message
-      errors.push error
-    end
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
 
     assert(doc.xpath('//rPr/b[@val=1]'))
     assert(doc.xpath('//rPr/i[@val=0]'))

--- a/test/workbook/worksheet/tc_table.rb
+++ b/test/workbook/worksheet/tc_table.rb
@@ -65,13 +65,9 @@ class TestTable < Test::Unit::TestCase
     table = @ws.add_table("A1:D5")
     schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
     doc = Nokogiri::XML(table.to_xml_string)
-    errors = []
-    schema.validate(doc).each do |error|
-      errors.push error
-      puts error.message
-    end
+    errors = schema.validate(doc)
 
-    assert_empty(errors, "error free validation")
+    assert_empty(errors)
   end
 
   def test_to_xml_string_for_special_characters
@@ -80,8 +76,7 @@ class TestTable < Test::Unit::TestCase
 
     table = @ws.add_table("A1:D5")
     doc = Nokogiri::XML(table.to_xml_string)
-    errors = doc.errors
 
-    assert_empty(errors, "invalid xml: #{errors.map(&:to_s).join(', ')}")
+    assert_empty(doc.errors)
   end
 end

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -447,8 +447,9 @@ class TestWorksheet < Test::Unit::TestCase
   def test_to_xml_string
     schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
     doc = Nokogiri::XML(@ws.to_xml_string)
+    errors = schema.validate(doc)
 
-    assert_empty(schema.validate(doc).map { |e| puts e.message; e }, "error free validation")
+    assert_empty(errors)
   end
 
   def test_styles
@@ -487,8 +488,9 @@ class TestWorksheet < Test::Unit::TestCase
     @ws.add_pivot_table 'G5:G6', 'A1:D10'
     schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
     doc = Nokogiri::XML(@ws.to_xml_string)
+    errors = schema.validate(doc)
 
-    assert_empty(schema.validate(doc).map { |e| puts e.message; e }, schema.validate(doc).map(&:message).join('\n'))
+    assert_empty(errors)
   end
 
   def test_relationships


### PR DESCRIPTION
Replaced size check with empty array check for error messages.

This change simplifies the code by using the default failure message for empty errors, eliminating the need to manually map and display error messages.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).