### PR TITLE
Improve validated accessor definition

### DIFF
--- a/lib/axlsx/util/accessors.rb
+++ b/lib/axlsx/util/accessors.rb
@@ -44,19 +44,21 @@ module Axlsx
         validated_attr_accessor(symbols, :validate_boolean)
       end
 
-      # Template for defining validated write accessors
-      SETTER = "def %s=(value) Axlsx::%s(value); @%s = value; end"
-
       # Creates the reader and writer access methods
-      # @param [Array] symbols The names of the attributes to create
-      # @param [String] validator The axlsx validation method to use when
+      # @param [Array<Symbol, String>] symbols The names of the attributes to create
+      # @param [Symbol|String] validator The axlsx validation method to use when
       # validating assignation.
       # @see lib/axlsx/util/validators.rb
       def validated_attr_accessor(symbols, validator)
         symbols.each do |symbol|
           attr_reader symbol
 
-          module_eval(format(SETTER, symbol, validator, symbol), __FILE__, __LINE__)
+          module_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
+            def #{symbol}=(value)      # def name=(value)
+              Axlsx.#{validator} value #   Axlsx.validate_string value
+              @#{symbol} = value       #   @name = value
+            end                        # end
+          RUBY_EVAL
         end
       end
     end


### PR DESCRIPTION
- Fix documentation
- Use a heredoc to define a multi-line string, which makes the code easier to understand at a glance.
- Error Handling: If there's an error in the method definition, it will be easier to debug because the error message will point to the exact line of code where the error occurred.
- Provide a comment block showing the aspect of an interpolated method https://rubystyle.guide/#eval-comment-docs

Old approach:
```
Error: test_add_selection(TestSheetView): RuntimeError: Hello
~/dev/caxlsx/lib/axlsx/util/accessors.rb:59:in `right_to_left='

--> module_eval(format(SETTER, symbol, validator, symbol), __FILE__, __LINE__)
```


New approach:
```
Error: test_to_xml(TestSheetView): RuntimeError: Hello
~/dev/caxlsx/lib/axlsx/util/accessors.rb:58:in `right_to_left='

    module_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
      def #{symbol}=(value)      # def name=(value)
-->     raise 'Hello'
        Axlsx.#{validator} value #   Axlsx.validate_string value
        @#{symbol} = value       #   @name = value
      end                        # end
    RUBY_EVAL
```

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).