### PR TITLE
Fix example generator script's load path

### DIFF
--- a/examples/generate.rb
+++ b/examples/generate.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+$LOAD_PATH.unshift "#{File.dirname(__FILE__)}/../lib"
+
 files = if !ARGV.empty?
           ARGV.select { |file| File.exist?(file) }
         else
@@ -10,6 +12,6 @@ files.each do |file|
   puts "Executing #{file.split('.')[0].tr('_', ' ')}"
   code = File.read(file).match(/```ruby(?<code>.+)```/m)[:code]
   unless code.nil?
-    eval(['$LOAD_PATH.unshift "#{File.dirname(__FILE__)}/../lib"', code].join("\n"))
+    eval(code)
   end
 end


### PR DESCRIPTION
### Description

I meant to generate a few example files using Ruby 3.3.0, but I ran into a LoadError:

```bash
> ./generate.rb
Executing 3d line chart example
<internal:/.asdf/installs/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require': cannot load such file -- axlsx (LoadError)
        from <internal:/.asdf/installs/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
        from (eval at ./generate.rb:13):3:in `block in <main>'
        from ./generate.rb:13:in `eval'
        from ./generate.rb:13:in `block in <main>'
        from ./generate.rb:9:in `each'
        from ./generate.rb:9:in `<main>
```

I've looked into what could've caused it, and finally I opened a bug report for Ruby: https://bugs.ruby-lang.org/issues/20175

On the other hand, I realized that we're not populating the `$LOAD_PATH` correctly inside the eval block, we should do it only once, outside of the eval.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- I added an entry to the [changelog](../blob/master/CHANGELOG.md).