### PR TITLE
Fix Minitest/AssertKindOf offenses

### DIFF
--- a/test/drawing/tc_area_chart.rb
+++ b/test/drawing/tc_area_chart.rb
@@ -15,8 +15,8 @@ class TestAreaChart < Test::Unit::TestCase
   def test_initialization
     assert_equal(:standard, @chart.grouping, "grouping defualt incorrect")
     assert_equal(@chart.series_type, Axlsx::AreaSeries, "series type incorrect")
-    assert(@chart.cat_axis.is_a?(Axlsx::CatAxis), "category axis not created")
-    assert(@chart.val_axis.is_a?(Axlsx::ValAxis), "value access not created")
+    assert_kind_of(Axlsx::CatAxis, @chart.cat_axis, "category axis not created")
+    assert_kind_of(Axlsx::ValAxis, @chart.val_axis, "value access not created")
   end
 
   def test_grouping

--- a/test/drawing/tc_bar_3D_chart.rb
+++ b/test/drawing/tc_bar_3D_chart.rb
@@ -16,8 +16,8 @@ class TestBar3DChart < Test::Unit::TestCase
     assert_equal(:clustered, @chart.grouping, "grouping defualt incorrect")
     assert_equal(@chart.series_type, Axlsx::BarSeries, "series type incorrect")
     assert_equal(:bar, @chart.bar_dir, " bar direction incorrect")
-    assert(@chart.cat_axis.is_a?(Axlsx::CatAxis), "category axis not created")
-    assert(@chart.val_axis.is_a?(Axlsx::ValAxis), "value access not created")
+    assert_kind_of(Axlsx::CatAxis, @chart.cat_axis, "category axis not created")
+    assert_kind_of(Axlsx::ValAxis, @chart.val_axis, "value access not created")
   end
 
   def test_bar_direction

--- a/test/drawing/tc_bar_chart.rb
+++ b/test/drawing/tc_bar_chart.rb
@@ -16,8 +16,8 @@ class TestBarChart < Test::Unit::TestCase
     assert_equal(:clustered, @chart.grouping, "grouping defualt incorrect")
     assert_equal(@chart.series_type, Axlsx::BarSeries, "series type incorrect")
     assert_equal(:bar, @chart.bar_dir, " bar direction incorrect")
-    assert(@chart.cat_axis.is_a?(Axlsx::CatAxis), "category axis not created")
-    assert(@chart.val_axis.is_a?(Axlsx::ValAxis), "value access not created")
+    assert_kind_of(Axlsx::CatAxis, @chart.cat_axis, "category axis not created")
+    assert_kind_of(Axlsx::ValAxis, @chart.val_axis, "value access not created")
   end
 
   def test_bar_direction

--- a/test/drawing/tc_bar_series.rb
+++ b/test/drawing/tc_bar_series.rb
@@ -22,8 +22,8 @@ class TestBarSeries < Test::Unit::TestCase
     assert_equal(@series.data.class, Axlsx::NumDataSource, "data option applied")
     assert_equal(:cone, @series.shape, "series shape has been applied")
     assert_equal('5A5A5A', @series.series_color, 'series color has been applied')
-    assert(@series.data.is_a?(Axlsx::NumDataSource))
-    assert(@series.labels.is_a?(Axlsx::AxDataSource))
+    assert_kind_of(Axlsx::NumDataSource, @series.data)
+    assert_kind_of(Axlsx::AxDataSource, @series.labels)
   end
 
   def test_colors

--- a/test/drawing/tc_bubble_chart.rb
+++ b/test/drawing/tc_bubble_chart.rb
@@ -27,8 +27,8 @@ class TestBubbleChart < Test::Unit::TestCase
 
   def test_initialization
     assert_equal(@chart.series_type, Axlsx::BubbleSeries, "series type incorrect")
-    assert(@chart.xValAxis.is_a?(Axlsx::ValAxis), "independant value axis not created")
-    assert(@chart.yValAxis.is_a?(Axlsx::ValAxis), "dependant value axis not created")
+    assert_kind_of(Axlsx::ValAxis, @chart.xValAxis, "independant value axis not created")
+    assert_kind_of(Axlsx::ValAxis, @chart.yValAxis, "dependant value axis not created")
   end
 
   def test_to_xml_string

--- a/test/drawing/tc_chart.rb
+++ b/test/drawing/tc_chart.rb
@@ -39,8 +39,8 @@ class TestChart < Test::Unit::TestCase
   end
 
   def test_to_from_marker_access
-    assert(@chart.to.is_a?(Axlsx::Marker))
-    assert(@chart.from.is_a?(Axlsx::Marker))
+    assert_kind_of(Axlsx::Marker, @chart.to)
+    assert_kind_of(Axlsx::Marker, @chart.from)
   end
 
   def test_bg_color
@@ -115,7 +115,7 @@ class TestChart < Test::Unit::TestCase
     assert_nil(Axlsx.instance_values_for(@chart)[:d_lbls])
     @chart.d_lbls.d_lbl_pos = :t
 
-    assert(@chart.d_lbls.is_a?(Axlsx::DLbls), 'DLbls instantiated on access')
+    assert_kind_of(Axlsx::DLbls, @chart.d_lbls, 'DLbls instantiated on access')
   end
 
   def test_plot_visible_only

--- a/test/drawing/tc_drawing.rb
+++ b/test/drawing/tc_drawing.rb
@@ -15,7 +15,7 @@ class TestDrawing < Test::Unit::TestCase
   def test_add_chart
     chart = @ws.add_chart(Axlsx::Pie3DChart, title: "bob", start_at: [0, 0], end_at: [1, 1])
 
-    assert(chart.is_a?(Axlsx::Pie3DChart), "must create a chart")
+    assert_kind_of(Axlsx::Pie3DChart, chart, "must create a chart")
     assert_equal(@ws.workbook.charts.last, chart, "must be added to workbook charts collection")
     assert_equal(@ws.drawing.anchors.last.object.chart, chart, "an anchor has been created and holds a reference to this chart")
     anchor = @ws.drawing.anchors.last
@@ -29,8 +29,8 @@ class TestDrawing < Test::Unit::TestCase
     src = "#{File.dirname(__FILE__)}/../fixtures/image1.jpeg"
     image = @ws.add_image(image_src: src, start_at: [0, 0], width: 600, height: 400)
 
-    assert(@ws.drawing.anchors.last.is_a?(Axlsx::OneCellAnchor))
-    assert(image.is_a?(Axlsx::Pic))
+    assert_kind_of(Axlsx::OneCellAnchor, @ws.drawing.anchors.last)
+    assert_kind_of(Axlsx::Pic, image)
     assert_equal(600, image.width)
     assert_equal(400, image.height)
   end
@@ -39,8 +39,8 @@ class TestDrawing < Test::Unit::TestCase
     src = "#{File.dirname(__FILE__)}/../fixtures/image1.jpeg"
     image = @ws.add_image(image_src: src, start_at: [0, 0], end_at: [15, 0])
 
-    assert(@ws.drawing.anchors.last.is_a?(Axlsx::TwoCellAnchor))
-    assert(image.is_a?(Axlsx::Pic))
+    assert_kind_of(Axlsx::TwoCellAnchor, @ws.drawing.anchors.last)
+    assert_kind_of(Axlsx::Pic, image)
   end
 
   def test_charts

--- a/test/drawing/tc_graphic_frame.rb
+++ b/test/drawing/tc_graphic_frame.rb
@@ -13,7 +13,7 @@ class TestGraphicFrame < Test::Unit::TestCase
   def teardown; end
 
   def test_initialization
-    assert(@frame.anchor.is_a?(Axlsx::TwoCellAnchor))
+    assert_kind_of(Axlsx::TwoCellAnchor, @frame.anchor)
     assert_equal(@frame.chart, @chart)
   end
 

--- a/test/drawing/tc_line_3d_chart.rb
+++ b/test/drawing/tc_line_3d_chart.rb
@@ -15,9 +15,9 @@ class TestLine3DChart < Test::Unit::TestCase
   def test_initialization
     assert_equal(:standard, @chart.grouping, "grouping defualt incorrect")
     assert_equal(@chart.series_type, Axlsx::LineSeries, "series type incorrect")
-    assert(@chart.catAxis.is_a?(Axlsx::CatAxis), "category axis not created")
-    assert(@chart.valAxis.is_a?(Axlsx::ValAxis), "value access not created")
-    assert(@chart.serAxis.is_a?(Axlsx::SerAxis), "value access not created")
+    assert_kind_of(Axlsx::CatAxis, @chart.catAxis, "category axis not created")
+    assert_kind_of(Axlsx::ValAxis, @chart.valAxis, "value access not created")
+    assert_kind_of(Axlsx::SerAxis, @chart.serAxis, "value access not created")
   end
 
   def test_grouping

--- a/test/drawing/tc_line_chart.rb
+++ b/test/drawing/tc_line_chart.rb
@@ -15,8 +15,8 @@ class TestLineChart < Test::Unit::TestCase
   def test_initialization
     assert_equal(:standard, @chart.grouping, "grouping defualt incorrect")
     assert_equal(@chart.series_type, Axlsx::LineSeries, "series type incorrect")
-    assert(@chart.cat_axis.is_a?(Axlsx::CatAxis), "category axis not created")
-    assert(@chart.val_axis.is_a?(Axlsx::ValAxis), "value access not created")
+    assert_kind_of(Axlsx::CatAxis, @chart.cat_axis, "category axis not created")
+    assert_kind_of(Axlsx::ValAxis, @chart.val_axis, "value access not created")
   end
 
   def test_grouping

--- a/test/drawing/tc_one_cell_anchor.rb
+++ b/test/drawing/tc_one_cell_anchor.rb
@@ -21,11 +21,11 @@ class TestOneCellAnchor < Test::Unit::TestCase
   end
 
   def test_from
-    assert(@anchor.from.is_a?(Axlsx::Marker))
+    assert_kind_of(Axlsx::Marker, @anchor.from)
   end
 
   def test_object
-    assert(@anchor.object.is_a?(Axlsx::Pic))
+    assert_kind_of(Axlsx::Pic, @anchor.object)
   end
 
   def test_index

--- a/test/drawing/tc_pic.rb
+++ b/test/drawing/tc_pic.rb
@@ -34,11 +34,11 @@ class TestPic < Test::Unit::TestCase
 
   def test_anchor_swapping
     # swap from one cell to two cell when end_at is specified
-    assert(@image.anchor.is_a?(Axlsx::OneCellAnchor))
+    assert_kind_of(Axlsx::OneCellAnchor, @image.anchor)
     start_at = @image.anchor.from
     @image.end_at 10, 5
 
-    assert(@image.anchor.is_a?(Axlsx::TwoCellAnchor))
+    assert_kind_of(Axlsx::TwoCellAnchor, @image.anchor)
     assert_equal(start_at.col, @image.anchor.from.col)
     assert_equal(start_at.row, @image.anchor.from.row)
     assert_equal(10, @image.anchor.to.col)
@@ -47,7 +47,7 @@ class TestPic < Test::Unit::TestCase
     # swap from two cell to one cell when width or height are specified
     @image.width = 200
 
-    assert(@image.anchor.is_a?(Axlsx::OneCellAnchor))
+    assert_kind_of(Axlsx::OneCellAnchor, @image.anchor)
     assert_equal(start_at.col, @image.anchor.from.col)
     assert_equal(start_at.row, @image.anchor.from.row)
     assert_equal(200, @image.width)

--- a/test/drawing/tc_scatter_chart.rb
+++ b/test/drawing/tc_scatter_chart.rb
@@ -33,8 +33,8 @@ class TestScatterChart < Test::Unit::TestCase
   def test_initialization
     assert_equal(:lineMarker, @chart.scatterStyle, "scatterStyle defualt incorrect")
     assert_equal(@chart.series_type, Axlsx::ScatterSeries, "series type incorrect")
-    assert(@chart.xValAxis.is_a?(Axlsx::ValAxis), "independant value axis not created")
-    assert(@chart.yValAxis.is_a?(Axlsx::ValAxis), "dependant value axis not created")
+    assert_kind_of(Axlsx::ValAxis, @chart.xValAxis, "independant value axis not created")
+    assert_kind_of(Axlsx::ValAxis, @chart.yValAxis, "dependant value axis not created")
   end
 
   def test_to_xml_string

--- a/test/stylesheet/tc_border.rb
+++ b/test/stylesheet/tc_border.rb
@@ -13,7 +13,7 @@ class TestBorder < Test::Unit::TestCase
     assert_nil(@b.diagonalUp)
     assert_nil(@b.diagonalDown)
     assert_nil(@b.outline)
-    assert(@b.prs.is_a?(Axlsx::SimpleTypedList))
+    assert_kind_of(Axlsx::SimpleTypedList, @b.prs)
   end
 
   def test_diagonalUp

--- a/test/stylesheet/tc_border_pr.rb
+++ b/test/stylesheet/tc_border_pr.rb
@@ -18,7 +18,7 @@ class TestBorderPr < Test::Unit::TestCase
   def test_color
     assert_raise(ArgumentError) { @bpr.color = :red }
     assert_nothing_raised { @bpr.color = Axlsx::Color.new rgb: "FF000000" }
-    assert(@bpr.color.is_a?(Axlsx::Color))
+    assert_kind_of(Axlsx::Color, @bpr.color)
   end
 
   def test_style

--- a/test/stylesheet/tc_dxf.rb
+++ b/test/stylesheet/tc_dxf.rb
@@ -22,37 +22,37 @@ class TestDxf < Test::Unit::TestCase
   def test_alignment
     assert_raise(ArgumentError) { @item.alignment = -1.1 }
     assert_nothing_raised { @item.alignment = Axlsx::CellAlignment.new }
-    assert(@item.alignment.is_a?(Axlsx::CellAlignment))
+    assert_kind_of(Axlsx::CellAlignment, @item.alignment)
   end
 
   def test_protection
     assert_raise(ArgumentError) { @item.protection = -1.1 }
     assert_nothing_raised { @item.protection = Axlsx::CellProtection.new }
-    assert(@item.protection.is_a?(Axlsx::CellProtection))
+    assert_kind_of(Axlsx::CellProtection, @item.protection)
   end
 
   def test_numFmt
     assert_raise(ArgumentError) { @item.numFmt = 1 }
     assert_nothing_raised { @item.numFmt = Axlsx::NumFmt.new }
-    assert @item.numFmt.is_a? Axlsx::NumFmt
+    assert_kind_of Axlsx::NumFmt, @item.numFmt
   end
 
   def test_fill
     assert_raise(ArgumentError) { @item.fill = 1 }
     assert_nothing_raised { @item.fill = Axlsx::Fill.new(Axlsx::PatternFill.new(patternType: :solid, fgColor: Axlsx::Color.new(rgb: "FF000000"))) }
-    assert @item.fill.is_a? Axlsx::Fill
+    assert_kind_of Axlsx::Fill, @item.fill
   end
 
   def test_font
     assert_raise(ArgumentError) { @item.font = 1 }
     assert_nothing_raised { @item.font = Axlsx::Font.new }
-    assert @item.font.is_a? Axlsx::Font
+    assert_kind_of Axlsx::Font, @item.font
   end
 
   def test_border
     assert_raise(ArgumentError) { @item.border = 1 }
     assert_nothing_raised { @item.border = Axlsx::Border.new }
-    assert @item.border.is_a? Axlsx::Border
+    assert_kind_of Axlsx::Border, @item.border
   end
 
   def test_to_xml

--- a/test/stylesheet/tc_fill.rb
+++ b/test/stylesheet/tc_fill.rb
@@ -10,7 +10,7 @@ class TestFill < Test::Unit::TestCase
   def teardown; end
 
   def test_initialiation
-    assert(@item.fill_type.is_a?(Axlsx::PatternFill))
+    assert_kind_of(Axlsx::PatternFill, @item.fill_type)
     assert_raise(ArgumentError) { Axlsx::Fill.new }
     assert_nothing_raised { Axlsx::Fill.new(Axlsx::GradientFill.new) }
   end

--- a/test/stylesheet/tc_font.rb
+++ b/test/stylesheet/tc_font.rb
@@ -119,7 +119,7 @@ class TestFont < Test::Unit::TestCase
   def test_color
     assert_raise(ArgumentError) { @item.color = -7 }
     assert_nothing_raised { @item.color = Axlsx::Color.new(rgb: "00000000") }
-    assert(@item.color.is_a?(Axlsx::Color))
+    assert_kind_of(Axlsx::Color, @item.color)
   end
 
   # def sz=(v) Axlsx::validate_unsigned_int v; @sz=v end

--- a/test/stylesheet/tc_gradient_fill.rb
+++ b/test/stylesheet/tc_gradient_fill.rb
@@ -16,7 +16,7 @@ class TestGradientFill < Test::Unit::TestCase
     assert_nil(@item.right)
     assert_nil(@item.top)
     assert_nil(@item.bottom)
-    assert(@item.stop.is_a?(Axlsx::SimpleTypedList))
+    assert_kind_of(Axlsx::SimpleTypedList, @item.stop)
   end
 
   def test_type
@@ -59,7 +59,7 @@ class TestGradientFill < Test::Unit::TestCase
     @item.stop << Axlsx::GradientStop.new(Axlsx::Color.new(rgb: "00000000"), 0.5)
 
     assert_equal(1, @item.stop.size)
-    assert(@item.stop.last.is_a?(Axlsx::GradientStop))
+    assert_kind_of(Axlsx::GradientStop, @item.stop.last)
   end
 
   def test_to_xml_string

--- a/test/stylesheet/tc_styles.rb
+++ b/test/stylesheet/tc_styles.rb
@@ -80,8 +80,8 @@ class TestStyles < Test::Unit::TestCase
     @styles.parse_num_fmt_options(f_code)
 
     assert_equal(@styles.numFmts.last.numFmtId, max + 1, "new numfmts gets next available id")
-    assert(@styles.parse_num_fmt_options(num_fmt).is_a?(Integer), "Should return the provided num_fmt if not dxf")
-    assert(@styles.parse_num_fmt_options(num_fmt.merge({ type: :dxf })).is_a?(Axlsx::NumFmt), "Makes a new NumFmt if dxf")
+    assert_kind_of(Integer, @styles.parse_num_fmt_options(num_fmt), "Should return the provided num_fmt if not dxf")
+    assert_kind_of(Axlsx::NumFmt, @styles.parse_num_fmt_options(num_fmt.merge({ type: :dxf })), "Makes a new NumFmt if dxf")
   end
 
   def test_parse_border_options_hash_required_keys
@@ -94,7 +94,7 @@ class TestStyles < Test::Unit::TestCase
     b_opts = { border: { diagonalUp: 1, edges: [:left, :right], color: "FFDADADA", style: :thick } }
     b = @styles.parse_border_options b_opts
 
-    assert(b.is_a?(Integer))
+    assert_kind_of(Integer, b)
     assert_equal(@styles.parse_border_options(b_opts.merge({ type: :dxf })).class, Axlsx::Border)
     assert_equal(1, @styles.borders.last.diagonalUp, "border options are passed in to the initializer")
   end
@@ -110,8 +110,8 @@ class TestStyles < Test::Unit::TestCase
 
     assert_nil(top, "unspecified top edge should not be created")
     assert_nil(bottom, "unspecified bottom edge should not be created")
-    assert(left.is_a?(Axlsx::BorderPr), "specified left edge is set")
-    assert(right.is_a?(Axlsx::BorderPr), "specified right edge is set")
+    assert_kind_of(Axlsx::BorderPr, left, "specified left edge is set")
+    assert_kind_of(Axlsx::BorderPr, right, "specified right edge is set")
     assert_equal(left.style, right.style, "edge parts have the same style")
     assert_equal(:thick, left.style, "the style is THICK")
     assert_equal(right.color.rgb, left.color.rgb, "edge parts are colors are the same")
@@ -132,12 +132,12 @@ class TestStyles < Test::Unit::TestCase
     b = @styles.parse_border_options(b_opts)
     b2 = @styles.parse_border_options(border: b, type: :dxf)
 
-    assert(b2.is_a?(Axlsx::Border), "Cloned existing border object")
+    assert_kind_of(Axlsx::Border, b2, "Cloned existing border object")
   end
 
   def test_parse_alignment_options
     assert_nil(@styles.parse_alignment_options, "noop if :alignment is not set")
-    assert(@styles.parse_alignment_options(alignment: {}).is_a?(Axlsx::CellAlignment))
+    assert_kind_of(Axlsx::CellAlignment, @styles.parse_alignment_options(alignment: {}))
   end
 
   def test_parse_font_using_defaults
@@ -173,7 +173,7 @@ class TestStyles < Test::Unit::TestCase
     }
 
     assert_nil(@styles.parse_font_options, "noop if no font keys are set")
-    assert(@styles.parse_font_options(b: 1).is_a?(Integer), "return index of font if not :dxf type")
+    assert_kind_of(Integer, @styles.parse_font_options(b: 1), "return index of font if not :dxf type")
     assert_equal(@styles.parse_font_options(b: 1, type: :dxf).class, Axlsx::Font, "return font object if :dxf type")
 
     f = @styles.parse_font_options(options.merge(type: :dxf))
@@ -188,7 +188,7 @@ class TestStyles < Test::Unit::TestCase
 
   def test_parse_fill_options
     assert_nil(@styles.parse_fill_options, "noop if no fill keys are set")
-    assert(@styles.parse_fill_options(bg_color: "DE").is_a?(Integer), "return index of fill if not :dxf type")
+    assert_kind_of(Integer, @styles.parse_fill_options(bg_color: "DE"), "return index of fill if not :dxf type")
     assert_equal(@styles.parse_fill_options(bg_color: "DE", type: :dxf).class, Axlsx::Fill, "return fill object if :dxf type")
     f = @styles.parse_fill_options(bg_color: "DE", type: :dxf)
 
@@ -222,7 +222,7 @@ class TestStyles < Test::Unit::TestCase
     assert_equal(xf.borderId, Axlsx::STYLE_THIN_BORDER, "border id is set")
     assert_equal(xf.numFmtId, Axlsx::NUM_FMT_PERCENT, "number format id is set")
 
-    assert(xf.alignment.is_a?(Axlsx::CellAlignment), "alignment was created")
+    assert_kind_of(Axlsx::CellAlignment, xf.alignment, "alignment was created")
     assert_equal(:left, xf.alignment.horizontal, "horizontal alignment applied")
     assert(xf.protection.hidden, "hidden protection set")
     assert(xf.protection.locked, "cell locking set")
@@ -261,10 +261,10 @@ class TestStyles < Test::Unit::TestCase
     assert_equal(font_count, @styles.fonts.size, "font not created under styles")
     assert_equal(fill_count, @styles.fills.size, "fill not created under styles")
 
-    assert(dxf.border.is_a?(Axlsx::Border), "border is set")
+    assert_kind_of(Axlsx::Border, dxf.border, "border is set")
     assert_nil(dxf.numFmt, "number format is not set")
 
-    assert(dxf.alignment.is_a?(Axlsx::CellAlignment), "alignment was created")
+    assert_kind_of(Axlsx::CellAlignment, dxf.alignment, "alignment was created")
     assert_equal(:left, dxf.alignment.horizontal, "horizontal alignment applied")
     assert(dxf.protection.hidden, "hidden protection set")
     assert(dxf.protection.locked, "cell locking set")

--- a/test/stylesheet/tc_xf.rb
+++ b/test/stylesheet/tc_xf.rb
@@ -30,13 +30,13 @@ class TestXf < Test::Unit::TestCase
   def test_alignment
     assert_raise(ArgumentError) { @item.alignment = -1.1 }
     assert_nothing_raised { @item.alignment = Axlsx::CellAlignment.new }
-    assert(@item.alignment.is_a?(Axlsx::CellAlignment))
+    assert_kind_of(Axlsx::CellAlignment, @item.alignment)
   end
 
   def test_protection
     assert_raise(ArgumentError) { @item.protection = -1.1 }
     assert_nothing_raised { @item.protection = Axlsx::CellProtection.new }
-    assert(@item.protection.is_a?(Axlsx::CellProtection))
+    assert_kind_of(Axlsx::CellProtection, @item.protection)
   end
 
   def test_numFmtId

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -118,9 +118,9 @@ class TestPackage < Test::Unit::TestCase
   end
 
   def test_default_objects_are_created
-    assert(Axlsx.instance_values_for(@package)["app"].is_a?(Axlsx::App), 'App object not created')
-    assert(Axlsx.instance_values_for(@package)["core"].is_a?(Axlsx::Core), 'Core object not created')
-    assert(@package.workbook.is_a?(Axlsx::Workbook), 'Workbook object not created')
+    assert_kind_of(Axlsx::App, Axlsx.instance_values_for(@package)["app"], 'App object not created')
+    assert_kind_of(Axlsx::Core, Axlsx.instance_values_for(@package)["core"], 'Core object not created')
+    assert_kind_of(Axlsx::Workbook, @package.workbook, 'Workbook object not created')
     assert_empty(Axlsx::Package.new.workbook.worksheets, 'Workbook should not have sheets by default')
   end
 
@@ -296,7 +296,7 @@ class TestPackage < Test::Unit::TestCase
   end
 
   def test_workbook_is_a_workbook
-    assert @package.workbook.is_a? Axlsx::Workbook
+    assert_kind_of Axlsx::Workbook, @package.workbook
   end
 
   def test_base_content_types
@@ -326,7 +326,7 @@ class TestPackage < Test::Unit::TestCase
   def test_to_stream
     stream = @package.to_stream
 
-    assert(stream.is_a?(StringIO))
+    assert_kind_of(StringIO, stream)
     # this is just a roundabout guess for a package as it is build now
     # in testing.
     assert_operator(stream.size, :>, 80_000)

--- a/test/workbook/tc_shared_strings_table.rb
+++ b/test/workbook/tc_shared_strings_table.rb
@@ -14,7 +14,7 @@ class TestSharedStringsTable < Test::Unit::TestCase
   end
 
   def test_workbook_has_shared_strings
-    assert(@p.workbook.shared_strings.is_a?(Axlsx::SharedStringsTable), "shared string table was not created")
+    assert_kind_of(Axlsx::SharedStringsTable, @p.workbook.shared_strings, "shared string table was not created")
   end
 
   def test_count

--- a/test/workbook/worksheet/auto_filter/tc_auto_filter.rb
+++ b/test/workbook/worksheet/auto_filter/tc_auto_filter.rb
@@ -22,13 +22,13 @@ class TestAutoFilter < Test::Unit::TestCase
   end
 
   def test_columns
-    assert @auto_filter.columns.is_a?(Axlsx::SimpleTypedList)
+    assert_kind_of Axlsx::SimpleTypedList, @auto_filter.columns
     assert_equal @auto_filter.columns.allowed_types, [Axlsx::FilterColumn]
   end
 
   def test_add_column
     @auto_filter.add_column(0, :filters) do |column|
-      assert column.is_a? FilterColumn
+      assert_kind_of FilterColumn, column
     end
   end
 

--- a/test/workbook/worksheet/auto_filter/tc_filter_column.rb
+++ b/test/workbook/worksheet/auto_filter/tc_filter_column.rb
@@ -17,7 +17,7 @@ class TestFilterColumn < Test::Unit::TestCase
   end
 
   def test_initailize_filter_type
-    assert @filter_column.filter.is_a?(Axlsx::Filters)
+    assert_kind_of Axlsx::Filters, @filter_column.filter
     assert_equal 1, @filter_column.filter.filter_items.size
   end
 

--- a/test/workbook/worksheet/auto_filter/tc_filters.rb
+++ b/test/workbook/worksheet/auto_filter/tc_filters.rb
@@ -25,12 +25,12 @@ class TestFilters < Test::Unit::TestCase
   end
 
   def test_filters_items
-    assert @filters.filter_items.is_a?(Array)
+    assert_kind_of Array, @filters.filter_items
     assert_equal 2, @filters.filter_items.size
   end
 
   def test_date_group_items
-    assert @filters.date_group_items.is_a?(Array)
+    assert_kind_of Array, @filters.date_group_items
     assert_equal 1, @filters.date_group_items.size
   end
 

--- a/test/workbook/worksheet/auto_filter/tc_sort_state.rb
+++ b/test/workbook/worksheet/auto_filter/tc_sort_state.rb
@@ -14,13 +14,13 @@ class TestSortState < Test::Unit::TestCase
   end
 
   def test_sort_conditions
-    assert @sort_state.sort_conditions.is_a?(Axlsx::SimpleTypedList)
+    assert_kind_of Axlsx::SimpleTypedList, @sort_state.sort_conditions
     assert_equal @sort_state.sort_conditions.allowed_types, [Axlsx::SortCondition]
   end
 
   def test_add_sort_conditions
     @sort_state.add_sort_condition(column_index: 0) do |condition|
-      assert condition.is_a? SortCondition
+      assert_kind_of SortCondition, condition
     end
   end
 

--- a/test/workbook/worksheet/tc_comment.rb
+++ b/test/workbook/worksheet/tc_comment.rb
@@ -43,7 +43,7 @@ class TestComment < Test::Unit::TestCase
   def test_vml_shape
     pos = Axlsx.name_to_indices(@c1.ref)
 
-    assert(@c1.vml_shape.is_a?(Axlsx::VmlShape))
+    assert_kind_of(Axlsx::VmlShape, @c1.vml_shape)
     assert_equal(@c1.vml_shape.column, pos[0])
     assert_equal(@c1.vml_shape.row, pos[1])
     assert_equal(@c1.vml_shape.row, pos[1])

--- a/test/workbook/worksheet/tc_comments.rb
+++ b/test/workbook/worksheet/tc_comments.rb
@@ -13,7 +13,7 @@ class TestComments < Test::Unit::TestCase
 
   def test_initialize
     assert_raise(ArgumentError) { Axlsx::Comments.new }
-    assert(@ws.comments.vml_drawing.is_a?(Axlsx::VmlDrawing))
+    assert_kind_of(Axlsx::VmlDrawing, @ws.comments.vml_drawing)
   end
 
   def test_add_comment

--- a/test/workbook/worksheet/tc_conditional_formatting.rb
+++ b/test/workbook/worksheet/tc_conditional_formatting.rb
@@ -35,9 +35,9 @@ class TestConditionalFormatting < Test::Unit::TestCase
                                                  data_bar: data_bar,
                                                  icon_set: icon_set })
 
-    assert(cfr.data_bar.is_a?(Axlsx::DataBar))
-    assert(cfr.icon_set.is_a?(Axlsx::IconSet))
-    assert(cfr.color_scale.is_a?(Axlsx::ColorScale))
+    assert_kind_of(Axlsx::DataBar, cfr.data_bar)
+    assert_kind_of(Axlsx::IconSet, cfr.icon_set)
+    assert_kind_of(Axlsx::ColorScale, cfr.color_scale)
     cfs = @ws.add_conditional_formatting("B2:B2", [cfr])
     doc = Nokogiri::XML.parse(cfs.last.to_xml_string)
 

--- a/test/workbook/worksheet/tc_pivot_table.rb
+++ b/test/workbook/worksheet/tc_pivot_table.rb
@@ -30,7 +30,7 @@ class TestPivotTable < Test::Unit::TestCase
     assert_equal('G5:G6', pivot_table.ref, 'ref assigned from first parameter')
     assert_equal('A1:D5', pivot_table.range, 'range assigned from second parameter')
     assert_equal('PivotTable1', pivot_table.name, 'name automatically generated')
-    assert(pivot_table.is_a?(Axlsx::PivotTable), "must create a pivot table")
+    assert_kind_of(Axlsx::PivotTable, pivot_table, "must create a pivot table")
     assert_equal(@ws.workbook.pivot_tables.last, pivot_table, "must be added to workbook pivot tables collection")
     assert_equal(@ws.pivot_tables.last, pivot_table, "must be added to worksheet pivot tables collection")
   end

--- a/test/workbook/worksheet/tc_pivot_table_cache_definition.rb
+++ b/test/workbook/worksheet/tc_pivot_table_cache_definition.rb
@@ -14,7 +14,7 @@ class TestPivotTableCacheDefinition < Test::Unit::TestCase
   end
 
   def test_initialization
-    assert(@cache_definition.is_a?(Axlsx::PivotTableCacheDefinition), "must create a pivot table cache definition")
+    assert_kind_of(Axlsx::PivotTableCacheDefinition, @cache_definition, "must create a pivot table cache definition")
     assert_equal(@pivot_table, @cache_definition.pivot_table, 'refers back to its pivot table')
   end
 

--- a/test/workbook/worksheet/tc_table.rb
+++ b/test/workbook/worksheet/tc_table.rb
@@ -27,7 +27,7 @@ class TestTable < Test::Unit::TestCase
     name = "test"
     table = @ws.add_table("A1:D5", name: name)
 
-    assert(table.is_a?(Axlsx::Table), "must create a table")
+    assert_kind_of(Axlsx::Table, table, "must create a table")
     assert_equal(@ws.workbook.tables.last, table, "must be added to workbook table collection")
     assert_equal(@ws.tables.last, table, "must be added to worksheet table collection")
     assert_equal(table.name, name, "options for name are applied")

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -60,45 +60,45 @@ class TestWorksheet < Test::Unit::TestCase
   end
 
   def test_page_margins
-    assert(@ws.page_margins.is_a?(Axlsx::PageMargins))
+    assert_kind_of(Axlsx::PageMargins, @ws.page_margins)
   end
 
   def test_page_margins_yeild
     @ws.page_margins do |pm|
-      assert(pm.is_a?(Axlsx::PageMargins))
+      assert_kind_of(Axlsx::PageMargins, pm)
       assert_equal(@ws.page_margins, pm)
     end
   end
 
   def test_page_setup
-    assert(@ws.page_setup.is_a?(Axlsx::PageSetup))
+    assert_kind_of(Axlsx::PageSetup, @ws.page_setup)
   end
 
   def test_page_setup_yield
     @ws.page_setup do |ps|
-      assert(ps.is_a?(Axlsx::PageSetup))
+      assert_kind_of(Axlsx::PageSetup, ps)
       assert_equal(@ws.page_setup, ps)
     end
   end
 
   def test_print_options
-    assert(@ws.print_options.is_a?(Axlsx::PrintOptions))
+    assert_kind_of(Axlsx::PrintOptions, @ws.print_options)
   end
 
   def test_print_options_yield
     @ws.print_options do |po|
-      assert(po.is_a?(Axlsx::PrintOptions))
+      assert_kind_of(Axlsx::PrintOptions, po)
       assert_equal(@ws.print_options, po)
     end
   end
 
   def test_header_footer
-    assert(@ws.header_footer.is_a?(Axlsx::HeaderFooter))
+    assert_kind_of(Axlsx::HeaderFooter, @ws.header_footer)
   end
 
   def test_header_footer_yield
     @ws.header_footer do |hf|
-      assert(hf.is_a?(Axlsx::HeaderFooter))
+      assert_kind_of(Axlsx::HeaderFooter, hf)
       assert_equal(@ws.header_footer, hf)
     end
   end
@@ -235,7 +235,7 @@ class TestWorksheet < Test::Unit::TestCase
     assert_nil @ws.drawing
     @ws.add_chart(Axlsx::Pie3DChart)
 
-    assert @ws.drawing.is_a?(Axlsx::Drawing)
+    assert_kind_of Axlsx::Drawing, @ws.drawing
   end
 
   def test_add_pivot_table
@@ -456,7 +456,7 @@ class TestWorksheet < Test::Unit::TestCase
   end
 
   def test_styles
-    assert(@ws.styles.is_a?(Axlsx::Styles), 'worksheet provides access to styles')
+    assert_kind_of(Axlsx::Styles, @ws.styles, 'worksheet provides access to styles')
   end
 
   def test_column_styles
@@ -585,7 +585,7 @@ class TestWorksheet < Test::Unit::TestCase
   end
 
   def test_protect_range
-    assert(@ws.send(:protected_ranges).is_a?(Axlsx::SimpleTypedList))
+    assert_kind_of(Axlsx::SimpleTypedList, @ws.send(:protected_ranges))
     assert_equal(0, @ws.send(:protected_ranges).size)
     @ws.protect_range('A1:A3')
 


### PR DESCRIPTION
### Description

Fix new Rubocop offenses coming from rubocop-minitest 0.34.5

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- I added an entry to the [changelog](../blob/master/CHANGELOG.md).