### PR TITLE
Convert test suite to Minitest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,9 @@ Lint:
 Minitest:
   Enabled: true
 
+Minitest/RefuteFalse:
+  Enabled: false
+
 Naming:
   Enabled: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
   - [PR #345](https://github.com/caxlsx/caxlsx/pull/345) Show outline symbols by default to match original behavior
   - [PR #334](https://github.com/caxlsx/caxlsx/pull/334) Add pattern fill options to add_style
   - [PR #342](https://github.com/caxlsx/caxlsx/pull/342) Fix show button for filter columns
+  - [PR #349](https://github.com/caxlsx/caxlsx/pull/349) Convert test suite to Minitest
 
 - **October.30.23**: 4.0.0
   - [PR #189](https://github.com/caxlsx/caxlsx/pull/189) **breaking** Make `Axlsx::escape_formulas` true by default to mitigate [Formula Injection](https://www.owasp.org/index.php/CSV_Injection) vulnerabilities.

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ end
 group :test do
   gem 'rake'
   gem 'simplecov'
-  gem 'test-unit'
+  gem 'minitest'
   gem 'timecop'
   gem 'webmock'
 end

--- a/test/content_type/tc_content_type.rb
+++ b/test/content_type/tc_content_type.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestContentType < Test::Unit::TestCase
+class TestContentType < Minitest::Test
   def setup
     @package = Axlsx::Package.new
     @doc = Nokogiri::XML(@package.send(:content_types).to_xml_string)

--- a/test/content_type/tc_default.rb
+++ b/test/content_type/tc_default.rb
@@ -2,9 +2,9 @@
 
 require 'tc_helper'
 
-class TestDefault < Test::Unit::TestCase
+class TestDefault < Minitest::Test
   def test_content_type_restriction
-    assert_raise(ArgumentError, "raises argument error if invlalid ContentType is") { Axlsx::Default.new ContentType: "asdf" }
+    assert_raises(ArgumentError, "raises argument error if invlalid ContentType is") { Axlsx::Default.new ContentType: "asdf" }
   end
 
   def test_to_xml_string

--- a/test/content_type/tc_override.rb
+++ b/test/content_type/tc_override.rb
@@ -2,9 +2,9 @@
 
 require 'tc_helper'
 
-class TestOverride < Test::Unit::TestCase
+class TestOverride < Minitest::Test
   def test_content_type_restriction
-    assert_raise(ArgumentError, "requires known content type") { Axlsx::Override.new ContentType: "asdf" }
+    assert_raises(ArgumentError, "requires known content type") { Axlsx::Override.new ContentType: "asdf" }
   end
 
   def test_to_xml

--- a/test/doc_props/tc_app.rb
+++ b/test/doc_props/tc_app.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestApp < Test::Unit::TestCase
+class TestApp < Minitest::Test
   def setup
     options = {
       Template: 'Foo.xlt',

--- a/test/doc_props/tc_core.rb
+++ b/test/doc_props/tc_core.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestCore < Test::Unit::TestCase
+class TestCore < Minitest::Test
   def setup
     @core = Axlsx::Core.new
     # could still see some false positives if the second changes between the next two calls

--- a/test/drawing/tc_area_chart.rb
+++ b/test/drawing/tc_area_chart.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestAreaChart < Test::Unit::TestCase
+class TestAreaChart < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     ws = @p.workbook.add_worksheet
@@ -20,8 +20,8 @@ class TestAreaChart < Test::Unit::TestCase
   end
 
   def test_grouping
-    assert_raise(ArgumentError, "require valid grouping") { @chart.grouping = :inverted }
-    assert_nothing_raised("allow valid grouping") { @chart.grouping = :stacked }
+    assert_raises(ArgumentError, "require valid grouping") { @chart.grouping = :inverted }
+    refute_raises { @chart.grouping = :stacked }
     assert_equal(:stacked, @chart.grouping)
   end
 

--- a/test/drawing/tc_area_series.rb
+++ b/test/drawing/tc_area_series.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestAreaSeries < Test::Unit::TestCase
+class TestAreaSeries < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet name: "hmmm"
@@ -27,14 +27,14 @@ class TestAreaSeries < Test::Unit::TestCase
     assert(@series.show_marker)
     @series.show_marker = false
 
-    refute(@series.show_marker)
+    assert_false(@series.show_marker)
   end
 
   def test_smooth
     assert(@series.smooth)
     @series.smooth = false
 
-    refute(@series.smooth)
+    assert_false(@series.smooth)
   end
 
   def test_marker_symbol

--- a/test/drawing/tc_axes.rb
+++ b/test/drawing/tc_axes.rb
@@ -2,9 +2,9 @@
 
 require 'tc_helper'
 
-class TestAxes < Test::Unit::TestCase
+class TestAxes < Minitest::Test
   def test_constructor_requires_cat_axis_first
-    assert_raise(ArgumentError) { Axlsx::Axes.new(val_axis: Axlsx::ValAxis, cat_axis: Axlsx::CatAxis) }
-    assert_nothing_raised { Axlsx::Axes.new(cat_axis: Axlsx::CatAxis, val_axis: Axlsx::ValAxis) }
+    assert_raises(ArgumentError) { Axlsx::Axes.new(val_axis: Axlsx::ValAxis, cat_axis: Axlsx::CatAxis) }
+    refute_raises { Axlsx::Axes.new(cat_axis: Axlsx::CatAxis, val_axis: Axlsx::ValAxis) }
   end
 end

--- a/test/drawing/tc_axis.rb
+++ b/test/drawing/tc_axis.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestAxis < Test::Unit::TestCase
+class TestAxis < Minitest::Test
   def setup
     @axis = Axlsx::Axis.new gridlines: false, title: 'Foo'
   end
@@ -42,26 +42,26 @@ class TestAxis < Test::Unit::TestCase
   end
 
   def test_axis_position
-    assert_raise(ArgumentError, "requires valid axis position") { @axis.ax_pos = :nowhere }
-    assert_nothing_raised("accepts valid axis position") { @axis.ax_pos = :r }
+    assert_raises(ArgumentError, "requires valid axis position") { @axis.ax_pos = :nowhere }
+    refute_raises { @axis.ax_pos = :r }
   end
 
   def test_label_rotation
-    assert_raise(ArgumentError, "requires valid angle") { @axis.label_rotation = :nowhere }
-    assert_raise(ArgumentError, "requires valid angle") { @axis.label_rotation = 91 }
-    assert_raise(ArgumentError, "requires valid angle") { @axis.label_rotation = -91 }
-    assert_nothing_raised("accepts valid angle") { @axis.label_rotation = 45 }
+    assert_raises(ArgumentError, "requires valid angle") { @axis.label_rotation = :nowhere }
+    assert_raises(ArgumentError, "requires valid angle") { @axis.label_rotation = 91 }
+    assert_raises(ArgumentError, "requires valid angle") { @axis.label_rotation = -91 }
+    refute_raises { @axis.label_rotation = 45 }
     assert_equal(45 * 60_000, @axis.label_rotation)
   end
 
   def test_tick_label_position
-    assert_raise(ArgumentError, "requires valid tick label position") { @axis.tick_lbl_pos = :nowhere }
-    assert_nothing_raised("accepts valid tick label position") { @axis.tick_lbl_pos = :high }
+    assert_raises(ArgumentError, "requires valid tick label position") { @axis.tick_lbl_pos = :nowhere }
+    refute_raises { @axis.tick_lbl_pos = :high }
   end
 
   def test_format_code
-    assert_raise(ArgumentError, "requires valid format code") { @axis.format_code = :high }
-    assert_nothing_raised("accepts valid format code") { @axis.format_code = "00.##" }
+    assert_raises(ArgumentError, "requires valid format code") { @axis.format_code = :high }
+    refute_raises { @axis.format_code = "00.##" }
   end
 
   def create_chart_with_formatting(format_string = nil)
@@ -92,13 +92,13 @@ class TestAxis < Test::Unit::TestCase
   end
 
   def test_crosses
-    assert_raise(ArgumentError, "requires valid crosses") { @axis.crosses = 1 }
-    assert_nothing_raised("accepts valid crosses") { @axis.crosses = :min }
+    assert_raises(ArgumentError, "requires valid crosses") { @axis.crosses = 1 }
+    refute_raises { @axis.crosses = :min }
   end
 
   def test_gridlines
-    assert_raise(ArgumentError, "requires valid gridlines") { @axis.gridlines = 'alice' }
-    assert_nothing_raised("accepts valid crosses") { @axis.gridlines = false }
+    assert_raises(ArgumentError, "requires valid gridlines") { @axis.gridlines = 'alice' }
+    refute_raises { @axis.gridlines = false }
   end
 
   def test_to_xml_string

--- a/test/drawing/tc_bar_3D_chart.rb
+++ b/test/drawing/tc_bar_3D_chart.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestBar3DChart < Test::Unit::TestCase
+class TestBar3DChart < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     ws = @p.workbook.add_worksheet
@@ -21,34 +21,34 @@ class TestBar3DChart < Test::Unit::TestCase
   end
 
   def test_bar_direction
-    assert_raise(ArgumentError, "require valid bar direction") { @chart.bar_dir = :left }
-    assert_nothing_raised("allow valid bar direction") { @chart.bar_dir = :col }
+    assert_raises(ArgumentError, "require valid bar direction") { @chart.bar_dir = :left }
+    refute_raises { @chart.bar_dir = :col }
     assert_equal(:col, @chart.bar_dir)
   end
 
   def test_grouping
-    assert_raise(ArgumentError, "require valid grouping") { @chart.grouping = :inverted }
-    assert_nothing_raised("allow valid grouping") { @chart.grouping = :standard }
+    assert_raises(ArgumentError, "require valid grouping") { @chart.grouping = :inverted }
+    refute_raises { @chart.grouping = :standard }
     assert_equal(:standard, @chart.grouping)
   end
 
   def test_gap_width
-    assert_raise(ArgumentError, "require valid gap width") { @chart.gap_width = -1 }
-    assert_raise(ArgumentError, "require valid gap width") { @chart.gap_width = 501 }
-    assert_nothing_raised("allow valid gapWidth") { @chart.gap_width = 200 }
+    assert_raises(ArgumentError, "require valid gap width") { @chart.gap_width = -1 }
+    assert_raises(ArgumentError, "require valid gap width") { @chart.gap_width = 501 }
+    refute_raises { @chart.gap_width = 200 }
     assert_equal(200, @chart.gap_width, 'gap width is incorrect')
   end
 
   def test_gap_depth
-    assert_raise(ArgumentError, "require valid gap_depth") { @chart.gap_depth = -1 }
-    assert_raise(ArgumentError, "require valid gap_depth") { @chart.gap_depth = 501 }
-    assert_nothing_raised("allow valid gap_depth") { @chart.gap_depth = 200 }
+    assert_raises(ArgumentError, "require valid gap_depth") { @chart.gap_depth = -1 }
+    assert_raises(ArgumentError, "require valid gap_depth") { @chart.gap_depth = 501 }
+    refute_raises { @chart.gap_depth = 200 }
     assert_equal(200, @chart.gap_depth, 'gap depth is incorrect')
   end
 
   def test_shape
-    assert_raise(ArgumentError, "require valid shape") { @chart.shape = :star }
-    assert_nothing_raised("allow valid shape") { @chart.shape = :cone }
+    assert_raises(ArgumentError, "require valid shape") { @chart.shape = :star }
+    refute_raises { @chart.shape = :cone }
     assert_equal(:cone, @chart.shape)
   end
 

--- a/test/drawing/tc_bar_chart.rb
+++ b/test/drawing/tc_bar_chart.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestBarChart < Test::Unit::TestCase
+class TestBarChart < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     ws = @p.workbook.add_worksheet
@@ -21,34 +21,34 @@ class TestBarChart < Test::Unit::TestCase
   end
 
   def test_bar_direction
-    assert_raise(ArgumentError, "require valid bar direction") { @chart.bar_dir = :left }
-    assert_nothing_raised("allow valid bar direction") { @chart.bar_dir = :col }
+    assert_raises(ArgumentError, "require valid bar direction") { @chart.bar_dir = :left }
+    refute_raises { @chart.bar_dir = :col }
     assert_equal(:col, @chart.bar_dir)
   end
 
   def test_grouping
-    assert_raise(ArgumentError, "require valid grouping") { @chart.grouping = :inverted }
-    assert_nothing_raised("allow valid grouping") { @chart.grouping = :standard }
+    assert_raises(ArgumentError, "require valid grouping") { @chart.grouping = :inverted }
+    refute_raises { @chart.grouping = :standard }
     assert_equal(:standard, @chart.grouping)
   end
 
   def test_gap_width
-    assert_raise(ArgumentError, "require valid gap width") { @chart.gap_width = -1 }
-    assert_raise(ArgumentError, "require valid gap width") { @chart.gap_width = 501 }
-    assert_nothing_raised("allow valid gap width") { @chart.gap_width = 200 }
+    assert_raises(ArgumentError, "require valid gap width") { @chart.gap_width = -1 }
+    assert_raises(ArgumentError, "require valid gap width") { @chart.gap_width = 501 }
+    refute_raises { @chart.gap_width = 200 }
     assert_equal(200, @chart.gap_width, 'gap width is incorrect')
   end
 
   def test_overlap
-    assert_raise(ArgumentError, "require valid overlap") { @chart.overlap = -101 }
-    assert_raise(ArgumentError, "require valid overlap") { @chart.overlap = 101 }
-    assert_nothing_raised("allow valid overlap") { @chart.overlap = 100 }
+    assert_raises(ArgumentError, "require valid overlap") { @chart.overlap = -101 }
+    assert_raises(ArgumentError, "require valid overlap") { @chart.overlap = 101 }
+    refute_raises { @chart.overlap = 100 }
     assert_equal(100, @chart.overlap, 'overlap is incorrect')
   end
 
   def test_shape
-    assert_raise(ArgumentError, "require valid shape") { @chart.shape = :star }
-    assert_nothing_raised("allow valid shape") { @chart.shape = :cone }
+    assert_raises(ArgumentError, "require valid shape") { @chart.shape = :star }
+    refute_raises { @chart.shape = :cone }
     assert_equal(:cone, @chart.shape)
   end
 

--- a/test/drawing/tc_bar_series.rb
+++ b/test/drawing/tc_bar_series.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestBarSeries < Test::Unit::TestCase
+class TestBarSeries < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet name: "hmmm"
@@ -31,8 +31,8 @@ class TestBarSeries < Test::Unit::TestCase
   end
 
   def test_shape
-    assert_raise(ArgumentError, "require valid shape") { @series.shape = :teardropt }
-    assert_nothing_raised("allow valid shape") { @series.shape = :box }
+    assert_raises(ArgumentError, "require valid shape") { @series.shape = :teardropt }
+    refute_raises { @series.shape = :box }
     assert_equal(:box, @series.shape)
   end
 

--- a/test/drawing/tc_bubble_chart.rb
+++ b/test/drawing/tc_bubble_chart.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestBubbleChart < Test::Unit::TestCase
+class TestBubbleChart < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     @chart = nil

--- a/test/drawing/tc_bubble_series.rb
+++ b/test/drawing/tc_bubble_series.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestBubbleSeries < Test::Unit::TestCase
+class TestBubbleSeries < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet name: "hmmm"

--- a/test/drawing/tc_cat_axis.rb
+++ b/test/drawing/tc_cat_axis.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestCatAxis < Test::Unit::TestCase
+class TestCatAxis < Minitest::Test
   def setup
     @axis = Axlsx::CatAxis.new
   end
@@ -16,17 +16,17 @@ class TestCatAxis < Test::Unit::TestCase
   end
 
   def test_auto
-    assert_raise(ArgumentError, "requires valid auto") { @axis.auto = :nowhere }
-    assert_nothing_raised("accepts valid auto") { @axis.auto = false }
+    assert_raises(ArgumentError, "requires valid auto") { @axis.auto = :nowhere }
+    refute_raises { @axis.auto = false }
   end
 
   def test_lbl_algn
-    assert_raise(ArgumentError, "requires valid label alignment") { @axis.lbl_algn = :nowhere }
-    assert_nothing_raised("accepts valid label alignment") { @axis.lbl_algn = :r }
+    assert_raises(ArgumentError, "requires valid label alignment") { @axis.lbl_algn = :nowhere }
+    refute_raises { @axis.lbl_algn = :r }
   end
 
   def test_lbl_offset
-    assert_raise(ArgumentError, "requires valid label offset") { @axis.lbl_offset = 'foo' }
-    assert_nothing_raised("accepts valid label offset") { @axis.lbl_offset = "20" }
+    assert_raises(ArgumentError, "requires valid label offset") { @axis.lbl_offset = 'foo' }
+    refute_raises { @axis.lbl_offset = "20" }
   end
 end

--- a/test/drawing/tc_cat_axis_data.rb
+++ b/test/drawing/tc_cat_axis_data.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # require 'tc_helper.rb'
 
-# class TestCatAxisData < Test::Unit::TestCase
+# class TestCatAxisData < Minitest::Test
 
 #   def setup
 #     p = Axlsx::Package.new

--- a/test/drawing/tc_chart.rb
+++ b/test/drawing/tc_chart.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestChart < Test::Unit::TestCase
+class TestChart < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     ws = @p.workbook.add_worksheet
@@ -33,8 +33,8 @@ class TestChart < Test::Unit::TestCase
   end
 
   def test_style
-    assert_raise(ArgumentError) { @chart.style = 49 }
-    assert_nothing_raised { @chart.style = 2 }
+    assert_raises(ArgumentError) { @chart.style = 49 }
+    refute_raises { @chart.style = 2 }
     assert_equal(2, @chart.style)
   end
 
@@ -44,29 +44,29 @@ class TestChart < Test::Unit::TestCase
   end
 
   def test_bg_color
-    assert_raise(ArgumentError) { @chart.bg_color = 2 }
-    assert_nothing_raised { @chart.bg_color = "FFFFFF" }
+    assert_raises(ArgumentError) { @chart.bg_color = 2 }
+    refute_raises { @chart.bg_color = "FFFFFF" }
     assert_equal("FFFFFF", @chart.bg_color)
   end
 
   def test_title_size
-    assert_raise(ArgumentError) { @chart.title_size = 2 }
-    assert_nothing_raised { @chart.title_size = "100" }
+    assert_raises(ArgumentError) { @chart.title_size = 2 }
+    refute_raises { @chart.title_size = "100" }
     assert_equal("100", @chart.title.text_size)
   end
 
   def test_vary_colors
     assert(@chart.vary_colors)
-    assert_raise(ArgumentError) { @chart.vary_colors = 7 }
-    assert_nothing_raised { @chart.vary_colors = false }
-    refute(@chart.vary_colors)
+    assert_raises(ArgumentError) { @chart.vary_colors = 7 }
+    refute_raises { @chart.vary_colors = false }
+    assert_false(@chart.vary_colors)
   end
 
   def test_display_blanks_as
     assert_equal(:gap, @chart.display_blanks_as, "default is not :gap")
-    assert_raise(ArgumentError, "did not validate possible values") { @chart.display_blanks_as = :hole }
-    assert_nothing_raised { @chart.display_blanks_as = :zero }
-    assert_nothing_raised { @chart.display_blanks_as = :span }
+    assert_raises(ArgumentError, "did not validate possible values") { @chart.display_blanks_as = :hole }
+    refute_raises { @chart.display_blanks_as = :zero }
+    refute_raises { @chart.display_blanks_as = :span }
     assert_equal(:span, @chart.display_blanks_as)
   end
 
@@ -123,7 +123,7 @@ class TestChart < Test::Unit::TestCase
     @chart.plot_visible_only = false
 
     assert_false(@chart.plot_visible_only)
-    assert_raise(ArgumentError) { @chart.plot_visible_only = "" }
+    assert_raises(ArgumentError) { @chart.plot_visible_only = "" }
   end
 
   def test_rounded_corners
@@ -131,7 +131,7 @@ class TestChart < Test::Unit::TestCase
     @chart.rounded_corners = false
 
     assert_false(@chart.rounded_corners)
-    assert_raise(ArgumentError) { @chart.rounded_corners = "" }
+    assert_raises(ArgumentError) { @chart.rounded_corners = "" }
   end
 
   def test_to_xml_string

--- a/test/drawing/tc_d_lbls.rb
+++ b/test/drawing/tc_d_lbls.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestDLbls < Test::Unit::TestCase
+class TestDLbls < Minitest::Test
   def setup
     @d_lbls = Axlsx::DLbls.new(Axlsx::Pie3DChart)
     @boolean_attributes = [:show_legend_key,
@@ -17,7 +17,7 @@ class TestDLbls < Test::Unit::TestCase
   def test_initialization
     assert_equal(:bestFit, @d_lbls.d_lbl_pos)
     @boolean_attributes.each do |attr|
-      refute(@d_lbls.send(attr))
+      assert_false(@d_lbls.send(attr))
     end
   end
 
@@ -33,15 +33,15 @@ class TestDLbls < Test::Unit::TestCase
   end
 
   def test_d_lbl_pos
-    assert_raise(ArgumentError, 'invlaid label positions are rejected') { @d_lbls.d_lbl_pos = :upside_down }
-    assert_nothing_raised('accepts valid label position') { @d_lbls.d_lbl_pos = :ctr }
+    assert_raises(ArgumentError, 'invlaid label positions are rejected') { @d_lbls.d_lbl_pos = :upside_down }
+    refute_raises { @d_lbls.d_lbl_pos = :ctr }
   end
 
   def test_boolean_attributes
     @boolean_attributes.each do |attr|
-      assert_raise(ArgumentError, "rejects non boolean value for #{attr}") { @d_lbls.send(:"#{attr}=", :foo) }
-      assert_nothing_raised("accepts boolean value for #{attr}") { @d_lbls.send(:"#{attr}=", true) }
-      assert_nothing_raised("accepts boolean value for #{attr}") { @d_lbls.send(:"#{attr}=", false) }
+      assert_raises(ArgumentError, "rejects non boolean value for #{attr}") { @d_lbls.send(:"#{attr}=", :foo) }
+      refute_raises { @d_lbls.send(:"#{attr}=", true) }
+      refute_raises { @d_lbls.send(:"#{attr}=", false) }
     end
   end
 

--- a/test/drawing/tc_data_source.rb
+++ b/test/drawing/tc_data_source.rb
@@ -2,15 +2,15 @@
 
 require 'tc_helper'
 
-class TestNumDataSource < Test::Unit::TestCase
+class TestNumDataSource < Minitest::Test
   def setup
     @data_source = Axlsx::NumDataSource.new data: ["1", "2", "3"]
   end
 
   def test_tag_name
-    assert_raise(ArgumentError) { @data_source.tag_name = :zVal }
-    assert_nothing_raised { @data_source.tag_name = :yVal }
-    assert_nothing_raised { @data_source.tag_name = :bubbleSize }
+    assert_raises(ArgumentError) { @data_source.tag_name = :zVal }
+    refute_raises { @data_source.tag_name = :yVal }
+    refute_raises { @data_source.tag_name = :bubbleSize }
   end
 
   def test_to_xml_string_strLit

--- a/test/drawing/tc_drawing.rb
+++ b/test/drawing/tc_drawing.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestDrawing < Test::Unit::TestCase
+class TestDrawing < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet

--- a/test/drawing/tc_graphic_frame.rb
+++ b/test/drawing/tc_graphic_frame.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestGraphicFrame < Test::Unit::TestCase
+class TestGraphicFrame < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet

--- a/test/drawing/tc_hyperlink.rb
+++ b/test/drawing/tc_hyperlink.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestHyperlink < Test::Unit::TestCase
+class TestHyperlink < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     ws = @p.workbook.add_worksheet
@@ -14,46 +14,46 @@ class TestHyperlink < Test::Unit::TestCase
   def teardown; end
 
   def test_href
-    assert_nothing_raised { @hyperlink.href = "http://axlsx.blogspot.com" }
+    refute_raises { @hyperlink.href = "http://axlsx.blogspot.com" }
     assert_equal("http://axlsx.blogspot.com", @hyperlink.href)
   end
 
   def test_tgtFrame
-    assert_nothing_raised { @hyperlink.tgtFrame = "http://axlsx.blogspot.com" }
+    refute_raises { @hyperlink.tgtFrame = "http://axlsx.blogspot.com" }
     assert_equal("http://axlsx.blogspot.com", @hyperlink.tgtFrame)
   end
 
   def test_tooltip
-    assert_nothing_raised { @hyperlink.tooltip = "http://axlsx.blogspot.com" }
+    refute_raises { @hyperlink.tooltip = "http://axlsx.blogspot.com" }
     assert_equal("http://axlsx.blogspot.com", @hyperlink.tooltip)
   end
 
   def test_invalidUrl
-    assert_nothing_raised { @hyperlink.invalidUrl = "http://axlsx.blogspot.com" }
+    refute_raises { @hyperlink.invalidUrl = "http://axlsx.blogspot.com" }
     assert_equal("http://axlsx.blogspot.com", @hyperlink.invalidUrl)
   end
 
   def test_action
-    assert_nothing_raised { @hyperlink.action = "flee" }
+    refute_raises { @hyperlink.action = "flee" }
     assert_equal("flee", @hyperlink.action)
   end
 
   def test_endSnd
-    assert_nothing_raised { @hyperlink.endSnd = "true" }
-    assert_raise(ArgumentError) { @hyperlink.endSnd = "bob" }
+    refute_raises { @hyperlink.endSnd = "true" }
+    assert_raises(ArgumentError) { @hyperlink.endSnd = "bob" }
     assert_equal("true", @hyperlink.endSnd)
   end
 
   def test_highlightClick
-    assert_nothing_raised { @hyperlink.highlightClick = false }
-    assert_raise(ArgumentError) { @hyperlink.highlightClick = "bob" }
-    refute(@hyperlink.highlightClick)
+    refute_raises { @hyperlink.highlightClick = false }
+    assert_raises(ArgumentError) { @hyperlink.highlightClick = "bob" }
+    assert_false(@hyperlink.highlightClick)
   end
 
   def test_history
-    assert_nothing_raised { @hyperlink.history = false }
-    assert_raise(ArgumentError) { @hyperlink.history = "bob" }
-    refute(@hyperlink.history)
+    refute_raises { @hyperlink.history = false }
+    assert_raises(ArgumentError) { @hyperlink.history = "bob" }
+    assert_false(@hyperlink.history)
   end
 
   def test_to_xml_string

--- a/test/drawing/tc_line_3d_chart.rb
+++ b/test/drawing/tc_line_3d_chart.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestLine3DChart < Test::Unit::TestCase
+class TestLine3DChart < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     ws = @p.workbook.add_worksheet
@@ -21,14 +21,14 @@ class TestLine3DChart < Test::Unit::TestCase
   end
 
   def test_grouping
-    assert_raise(ArgumentError, "require valid grouping") { @chart.grouping = :inverted }
-    assert_nothing_raised("allow valid grouping") { @chart.grouping = :stacked }
+    assert_raises(ArgumentError, "require valid grouping") { @chart.grouping = :inverted }
+    refute_raises { @chart.grouping = :stacked }
     assert_equal(:stacked, @chart.grouping)
   end
 
   def test_gapDepth
-    assert_raise(ArgumentError, "require valid gapDepth") { @chart.gapDepth = 200 }
-    assert_nothing_raised("allow valid gapDepth") { @chart.gapDepth = "200%" }
+    assert_raises(ArgumentError, "require valid gapDepth") { @chart.gapDepth = 200 }
+    refute_raises { @chart.gapDepth = "200%" }
     assert_equal("200%", @chart.gapDepth)
   end
 

--- a/test/drawing/tc_line_chart.rb
+++ b/test/drawing/tc_line_chart.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestLineChart < Test::Unit::TestCase
+class TestLineChart < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     ws = @p.workbook.add_worksheet
@@ -20,8 +20,8 @@ class TestLineChart < Test::Unit::TestCase
   end
 
   def test_grouping
-    assert_raise(ArgumentError, "require valid grouping") { @chart.grouping = :inverted }
-    assert_nothing_raised("allow valid grouping") { @chart.grouping = :stacked }
+    assert_raises(ArgumentError, "require valid grouping") { @chart.grouping = :inverted }
+    refute_raises { @chart.grouping = :stacked }
     assert_equal(:stacked, @chart.grouping)
   end
 

--- a/test/drawing/tc_line_series.rb
+++ b/test/drawing/tc_line_series.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestLineSeries < Test::Unit::TestCase
+class TestLineSeries < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet name: "hmmm"
@@ -27,14 +27,14 @@ class TestLineSeries < Test::Unit::TestCase
     assert(@series.show_marker)
     @series.show_marker = false
 
-    refute(@series.show_marker)
+    assert_false(@series.show_marker)
   end
 
   def test_smooth
     assert(@series.smooth)
     @series.smooth = false
 
-    refute(@series.smooth)
+    assert_false(@series.smooth)
   end
 
   def test_marker_symbol

--- a/test/drawing/tc_marker.rb
+++ b/test/drawing/tc_marker.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestMarker < Test::Unit::TestCase
+class TestMarker < Minitest::Test
   def setup
     @marker = Axlsx::Marker.new
   end
@@ -17,23 +17,23 @@ class TestMarker < Test::Unit::TestCase
   end
 
   def test_col
-    assert_raise(ArgumentError) { @marker.col = -1 }
-    assert_nothing_raised { @marker.col = 10 }
+    assert_raises(ArgumentError) { @marker.col = -1 }
+    refute_raises { @marker.col = 10 }
   end
 
   def test_colOff
-    assert_raise(ArgumentError) { @marker.colOff = "1" }
-    assert_nothing_raised { @marker.colOff = -10 }
+    assert_raises(ArgumentError) { @marker.colOff = "1" }
+    refute_raises { @marker.colOff = -10 }
   end
 
   def test_row
-    assert_raise(ArgumentError) { @marker.row = -1 }
-    assert_nothing_raised { @marker.row = 10 }
+    assert_raises(ArgumentError) { @marker.row = -1 }
+    refute_raises { @marker.row = 10 }
   end
 
   def test_rowOff
-    assert_raise(ArgumentError) { @marker.rowOff = "1" }
-    assert_nothing_raised { @marker.rowOff = -10 }
+    assert_raises(ArgumentError) { @marker.rowOff = "1" }
+    refute_raises { @marker.rowOff = -10 }
   end
 
   def test_coord

--- a/test/drawing/tc_named_axis_data.rb
+++ b/test/drawing/tc_named_axis_data.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # require 'tc_helper.rb'
 
-# class TestNamedAxisData < Test::Unit::TestCase
+# class TestNamedAxisData < Minitest::Test
 
 #   def setup
 #     p = Axlsx::Package.new

--- a/test/drawing/tc_num_data.rb
+++ b/test/drawing/tc_num_data.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestNumData < Test::Unit::TestCase
+class TestNumData < Minitest::Test
   def setup
     @num_data = Axlsx::NumData.new data: [1, 2, 3]
   end
@@ -14,8 +14,8 @@ class TestNumData < Test::Unit::TestCase
   def test_formula_based_cell; end
 
   def test_format_code
-    assert_raise(ArgumentError) { @num_data.format_code = 7 }
-    assert_nothing_raised { @num_data.format_code = 'foo_bar' }
+    assert_raises(ArgumentError) { @num_data.format_code = 7 }
+    refute_raises { @num_data.format_code = 'foo_bar' }
   end
 
   def test_to_xml_string

--- a/test/drawing/tc_num_val.rb
+++ b/test/drawing/tc_num_val.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestNumVal < Test::Unit::TestCase
+class TestNumVal < Minitest::Test
   def setup
     @num_val = Axlsx::NumVal.new v: 1
   end
@@ -13,8 +13,8 @@ class TestNumVal < Test::Unit::TestCase
   end
 
   def test_format_code
-    assert_raise(ArgumentError) { @num_val.format_code = 7 }
-    assert_nothing_raised { @num_val.format_code = 'foo_bar' }
+    assert_raises(ArgumentError) { @num_val.format_code = 7 }
+    refute_raises { @num_val.format_code = 'foo_bar' }
   end
 
   def test_to_xml_string

--- a/test/drawing/tc_one_cell_anchor.rb
+++ b/test/drawing/tc_one_cell_anchor.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestOneCellAnchor < Test::Unit::TestCase
+class TestOneCellAnchor < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     @ws = @p.workbook.add_worksheet
@@ -33,14 +33,14 @@ class TestOneCellAnchor < Test::Unit::TestCase
   end
 
   def test_width
-    assert_raise(ArgumentError) { @anchor.width = "a" }
-    assert_nothing_raised { @anchor.width = 600 }
+    assert_raises(ArgumentError) { @anchor.width = "a" }
+    refute_raises { @anchor.width = 600 }
     assert_equal(600, @anchor.width)
   end
 
   def test_height
-    assert_raise(ArgumentError) { @anchor.height = "a" }
-    assert_nothing_raised { @anchor.height = 400 }
+    assert_raises(ArgumentError) { @anchor.height = "a" }
+    refute_raises { @anchor.height = 400 }
     assert_equal(400, @anchor.height)
   end
 
@@ -52,7 +52,7 @@ class TestOneCellAnchor < Test::Unit::TestCase
   end
 
   def test_options
-    assert_raise(ArgumentError, 'invalid start_at') { @ws.add_image image_src: @test_img, start_at: [1] }
+    assert_raises(ArgumentError, 'invalid start_at') { @ws.add_image image_src: @test_img, start_at: [1] }
     i = @ws.add_image image_src: @test_img, start_at: [1, 2], width: 100, height: 200, name: "someimage", descr: "a neat image"
 
     assert_equal("a neat image", i.descr)

--- a/test/drawing/tc_pic.rb
+++ b/test/drawing/tc_pic.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestPic < Test::Unit::TestCase
+class TestPic < Minitest::Test
   def setup
     stub_request(:get, 'https://example.com/sample-image.png')
       .to_return(body: File.new('examples/sample.png'), status: 200)
@@ -61,49 +61,49 @@ class TestPic < Test::Unit::TestCase
   end
 
   def test_name
-    assert_raise(ArgumentError) { @image.name = 49 }
-    assert_nothing_raised { @image.name = "unknown" }
+    assert_raises(ArgumentError) { @image.name = 49 }
+    refute_raises { @image.name = "unknown" }
     assert_equal("unknown", @image.name)
   end
 
   def test_start_at
-    assert_raise(ArgumentError) { @image.start_at "a", 1 }
-    assert_nothing_raised { @image.start_at 6, 7 }
+    assert_raises(ArgumentError) { @image.start_at "a", 1 }
+    refute_raises { @image.start_at 6, 7 }
     assert_equal(6, @image.anchor.from.col)
     assert_equal(7, @image.anchor.from.row)
   end
 
   def test_width
-    assert_raise(ArgumentError) { @image.width = "a" }
-    assert_nothing_raised { @image.width = 600 }
+    assert_raises(ArgumentError) { @image.width = "a" }
+    refute_raises { @image.width = 600 }
     assert_equal(600, @image.width)
   end
 
   def test_height
-    assert_raise(ArgumentError) { @image.height = "a" }
-    assert_nothing_raised { @image.height = 600 }
+    assert_raises(ArgumentError) { @image.height = "a" }
+    refute_raises { @image.height = 600 }
     assert_equal(600, @image.height)
   end
 
   def test_image_src
-    assert_raise(ArgumentError) { @image.image_src = __FILE__ }
-    assert_raise(ArgumentError) { @image.image_src = @test_img_fake }
-    assert_nothing_raised { @image.image_src = @test_img_gif }
-    assert_nothing_raised { @image.image_src = @test_img_png }
-    assert_nothing_raised { @image.image_src = @test_img_jpg }
+    assert_raises(ArgumentError) { @image.image_src = __FILE__ }
+    assert_raises(ArgumentError) { @image.image_src = @test_img_fake }
+    refute_raises { @image.image_src = @test_img_gif }
+    refute_raises { @image.image_src = @test_img_png }
+    refute_raises { @image.image_src = @test_img_jpg }
     assert_equal(@image.image_src, @test_img_jpg)
   end
 
   def test_remote_image_src
-    assert_raise(ArgumentError) { @image_remote.image_src = @test_img_fake }
-    assert_raise(ArgumentError) { @image_remote.image_src = @test_img_remote_fake }
-    assert_nothing_raised { @image_remote.image_src = @test_img_remote_png }
+    assert_raises(ArgumentError) { @image_remote.image_src = @test_img_fake }
+    assert_raises(ArgumentError) { @image_remote.image_src = @test_img_remote_fake }
+    refute_raises { @image_remote.image_src = @test_img_remote_png }
     assert_equal(@image_remote.image_src, @test_img_remote_png)
   end
 
   def test_descr
-    assert_raise(ArgumentError) { @image.descr = 49 }
-    assert_nothing_raised { @image.descr = "test" }
+    assert_raises(ArgumentError) { @image.descr = 49 }
+    refute_raises { @image.descr = "test" }
     assert_equal("test", @image.descr)
   end
 

--- a/test/drawing/tc_picture_locking.rb
+++ b/test/drawing/tc_picture_locking.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestPictureLocking < Test::Unit::TestCase
+class TestPictureLocking < Minitest::Test
   def setup
     @item = Axlsx::PictureLocking.new
   end
@@ -15,56 +15,56 @@ class TestPictureLocking < Test::Unit::TestCase
   end
 
   def test_noGrp
-    assert_raise(ArgumentError) { @item.noGrp = -1 }
-    assert_nothing_raised { @item.noGrp = false }
-    refute(@item.noGrp)
+    assert_raises(ArgumentError) { @item.noGrp = -1 }
+    refute_raises { @item.noGrp = false }
+    assert_false(@item.noGrp)
   end
 
   def test_noRot
-    assert_raise(ArgumentError) { @item.noRot = -1 }
-    assert_nothing_raised { @item.noRot = false }
-    refute(@item.noRot)
+    assert_raises(ArgumentError) { @item.noRot = -1 }
+    refute_raises { @item.noRot = false }
+    assert_false(@item.noRot)
   end
 
   def test_noChangeAspect
-    assert_raise(ArgumentError) { @item.noChangeAspect = -1 }
-    assert_nothing_raised { @item.noChangeAspect = false }
-    refute(@item.noChangeAspect)
+    assert_raises(ArgumentError) { @item.noChangeAspect = -1 }
+    refute_raises { @item.noChangeAspect = false }
+    assert_false(@item.noChangeAspect)
   end
 
   def test_noMove
-    assert_raise(ArgumentError) { @item.noMove = -1 }
-    assert_nothing_raised { @item.noMove = false }
-    refute(@item.noMove)
+    assert_raises(ArgumentError) { @item.noMove = -1 }
+    refute_raises { @item.noMove = false }
+    assert_false(@item.noMove)
   end
 
   def test_noResize
-    assert_raise(ArgumentError) { @item.noResize = -1 }
-    assert_nothing_raised { @item.noResize = false }
-    refute(@item.noResize)
+    assert_raises(ArgumentError) { @item.noResize = -1 }
+    refute_raises { @item.noResize = false }
+    assert_false(@item.noResize)
   end
 
   def test_noEditPoints
-    assert_raise(ArgumentError) { @item.noEditPoints = -1 }
-    assert_nothing_raised { @item.noEditPoints = false }
-    refute(@item.noEditPoints)
+    assert_raises(ArgumentError) { @item.noEditPoints = -1 }
+    refute_raises { @item.noEditPoints = false }
+    assert_false(@item.noEditPoints)
   end
 
   def test_noAdjustHandles
-    assert_raise(ArgumentError) { @item.noAdjustHandles = -1 }
-    assert_nothing_raised { @item.noAdjustHandles = false }
-    refute(@item.noAdjustHandles)
+    assert_raises(ArgumentError) { @item.noAdjustHandles = -1 }
+    refute_raises { @item.noAdjustHandles = false }
+    assert_false(@item.noAdjustHandles)
   end
 
   def test_noChangeArrowheads
-    assert_raise(ArgumentError) { @item.noChangeArrowheads = -1 }
-    assert_nothing_raised { @item.noChangeArrowheads = false }
-    refute(@item.noChangeArrowheads)
+    assert_raises(ArgumentError) { @item.noChangeArrowheads = -1 }
+    refute_raises { @item.noChangeArrowheads = false }
+    assert_false(@item.noChangeArrowheads)
   end
 
   def test_noChangeShapeType
-    assert_raise(ArgumentError) { @item.noChangeShapeType = -1 }
-    assert_nothing_raised { @item.noChangeShapeType = false }
-    refute(@item.noChangeShapeType)
+    assert_raises(ArgumentError) { @item.noChangeShapeType = -1 }
+    refute_raises { @item.noChangeShapeType = false }
+    assert_false(@item.noChangeShapeType)
   end
 end

--- a/test/drawing/tc_pie_3D_chart.rb
+++ b/test/drawing/tc_pie_3D_chart.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestPie3DChart < Test::Unit::TestCase
+class TestPie3DChart < Minitest::Test
   def setup
     p = Axlsx::Package.new
     ws = p.workbook.add_worksheet

--- a/test/drawing/tc_pie_chart.rb
+++ b/test/drawing/tc_pie_chart.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestPieChart < Test::Unit::TestCase
+class TestPieChart < Minitest::Test
   def setup
     p = Axlsx::Package.new
     ws = p.workbook.add_worksheet

--- a/test/drawing/tc_pie_series.rb
+++ b/test/drawing/tc_pie_series.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestPieSeries < Test::Unit::TestCase
+class TestPieSeries < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet name: "hmmm"
@@ -18,11 +18,11 @@ class TestPieSeries < Test::Unit::TestCase
   end
 
   def test_explosion
-    assert_raise(ArgumentError, "require valid explosion") { @series.explosion = :lots }
-    assert_nothing_raised("allow valid explosion") { @series.explosion = 20 }
+    assert_raises(ArgumentError, "require valid explosion") { @series.explosion = :lots }
+    refute_raises { @series.explosion = 20 }
     assert_equal(20, @series.explosion)
     # issue 58 - explosion caused to_xml_string to fail - now tested
-    assert_nothing_raised("allow to_xml_string") { @series.to_xml_string }
+    refute_raises { @series.to_xml_string }
   end
 
   def test_to_xml_string

--- a/test/drawing/tc_scaling.rb
+++ b/test/drawing/tc_scaling.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestScaling < Test::Unit::TestCase
+class TestScaling < Minitest::Test
   def setup
     @scaling = Axlsx::Scaling.new
   end
@@ -14,22 +14,22 @@ class TestScaling < Test::Unit::TestCase
   end
 
   def test_logBase
-    assert_raise(ArgumentError) { @scaling.logBase = 1 }
-    assert_nothing_raised { @scaling.logBase = 10 }
+    assert_raises(ArgumentError) { @scaling.logBase = 1 }
+    refute_raises { @scaling.logBase = 10 }
   end
 
   def test_orientation
-    assert_raise(ArgumentError) { @scaling.orientation = "1" }
-    assert_nothing_raised { @scaling.orientation = :maxMin }
+    assert_raises(ArgumentError) { @scaling.orientation = "1" }
+    refute_raises { @scaling.orientation = :maxMin }
   end
 
   def test_max
-    assert_raise(ArgumentError) { @scaling.max = 1 }
-    assert_nothing_raised { @scaling.max = 10.5 }
+    assert_raises(ArgumentError) { @scaling.max = 1 }
+    refute_raises { @scaling.max = 10.5 }
   end
 
   def test_min
-    assert_raise(ArgumentError) { @scaling.min = 1 }
-    assert_nothing_raised { @scaling.min = 10.5 }
+    assert_raises(ArgumentError) { @scaling.min = 1 }
+    refute_raises { @scaling.min = 10.5 }
   end
 end

--- a/test/drawing/tc_scatter_chart.rb
+++ b/test/drawing/tc_scatter_chart.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestScatterChart < Test::Unit::TestCase
+class TestScatterChart < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     @chart = nil
@@ -27,7 +27,7 @@ class TestScatterChart < Test::Unit::TestCase
     @chart.scatterStyle = :marker
 
     assert_equal(:marker, @chart.scatterStyle)
-    assert_raise(ArgumentError) { @chart.scatterStyle = :buckshot }
+    assert_raises(ArgumentError) { @chart.scatterStyle = :buckshot }
   end
 
   def test_initialization

--- a/test/drawing/tc_scatter_series.rb
+++ b/test/drawing/tc_scatter_series.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestScatterSeries < Test::Unit::TestCase
+class TestScatterSeries < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet name: "hmmm"

--- a/test/drawing/tc_ser_axis.rb
+++ b/test/drawing/tc_ser_axis.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestSerAxis < Test::Unit::TestCase
+class TestSerAxis < Minitest::Test
   def setup
     @axis = Axlsx::SerAxis.new
   end
@@ -17,14 +17,14 @@ class TestSerAxis < Test::Unit::TestCase
   end
 
   def test_tick_lbl_skip
-    assert_raise(ArgumentError, "requires valid tick_lbl_skip") { @axis.tick_lbl_skip = -1 }
-    assert_nothing_raised("accepts valid tick_lbl_skip") { @axis.tick_lbl_skip = 1 }
+    assert_raises(ArgumentError, "requires valid tick_lbl_skip") { @axis.tick_lbl_skip = -1 }
+    refute_raises { @axis.tick_lbl_skip = 1 }
     assert_equal(1, @axis.tick_lbl_skip)
   end
 
   def test_tick_mark_skip
-    assert_raise(ArgumentError, "requires valid tick_mark_skip") { @axis.tick_mark_skip = :my_eyes }
-    assert_nothing_raised("accepts valid tick_mark_skip") { @axis.tick_mark_skip = 2 }
+    assert_raises(ArgumentError, "requires valid tick_mark_skip") { @axis.tick_mark_skip = :my_eyes }
+    refute_raises { @axis.tick_mark_skip = 2 }
     assert_equal(2, @axis.tick_mark_skip)
   end
 end

--- a/test/drawing/tc_series.rb
+++ b/test/drawing/tc_series.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestSeries < Test::Unit::TestCase
+class TestSeries < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet name: "hmmm"

--- a/test/drawing/tc_series_title.rb
+++ b/test/drawing/tc_series_title.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestSeriesTitle < Test::Unit::TestCase
+class TestSeriesTitle < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     ws = @p.workbook.add_worksheet
@@ -19,7 +19,7 @@ class TestSeriesTitle < Test::Unit::TestCase
   end
 
   def test_text
-    assert_raise(ArgumentError, "text must be a string") { @title.text = 123 }
+    assert_raises(ArgumentError, "text must be a string") { @title.text = 123 }
     @title.cell = @row.cells.first
     @title.text = "bob"
 
@@ -27,7 +27,7 @@ class TestSeriesTitle < Test::Unit::TestCase
   end
 
   def test_cell
-    assert_raise(ArgumentError, "cell must be a Cell") { @title.cell = "123" }
+    assert_raises(ArgumentError, "cell must be a Cell") { @title.cell = "123" }
     @title.cell = @row.cells.first
 
     assert_equal("one", @title.text)

--- a/test/drawing/tc_str_data.rb
+++ b/test/drawing/tc_str_data.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestStrData < Test::Unit::TestCase
+class TestStrData < Minitest::Test
   def setup
     @str_data = Axlsx::StrData.new data: ["1", "2", "3"]
   end

--- a/test/drawing/tc_str_val.rb
+++ b/test/drawing/tc_str_val.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestStrVal < Test::Unit::TestCase
+class TestStrVal < Minitest::Test
   def setup
     @str_val = Axlsx::StrVal.new v: "1"
     @str_val_with_special_characters = Axlsx::StrVal.new v: "a & b <c>"

--- a/test/drawing/tc_title.rb
+++ b/test/drawing/tc_title.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestTitle < Test::Unit::TestCase
+class TestTitle < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     ws = @p.workbook.add_worksheet
@@ -25,7 +25,7 @@ class TestTitle < Test::Unit::TestCase
   end
 
   def test_text
-    assert_raise(ArgumentError, "text must be a string") { @title.text = 123 }
+    assert_raises(ArgumentError, "text must be a string") { @title.text = 123 }
     @title.cell = @row.cells.first
     @title.text = "bob"
 
@@ -33,7 +33,7 @@ class TestTitle < Test::Unit::TestCase
   end
 
   def test_cell
-    assert_raise(ArgumentError, "cell must be a Cell") { @title.cell = "123" }
+    assert_raises(ArgumentError, "cell must be a Cell") { @title.cell = "123" }
     @title.cell = @row.cells.first
 
     assert_equal("one", @title.text)

--- a/test/drawing/tc_two_cell_anchor.rb
+++ b/test/drawing/tc_two_cell_anchor.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestTwoCellAnchor < Test::Unit::TestCase
+class TestTwoCellAnchor < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet
@@ -23,10 +23,10 @@ class TestTwoCellAnchor < Test::Unit::TestCase
   end
 
   def test_options
-    assert_raise(ArgumentError, 'invalid start_at') { @ws.add_chart Axlsx::Chart, start_at: "1" }
-    assert_raise(ArgumentError, 'invalid end_at') { @ws.add_chart Axlsx::Chart, start_at: [1, 2], end_at: ["a", 4] }
+    assert_raises(ArgumentError, 'invalid start_at') { @ws.add_chart Axlsx::Chart, start_at: "1" }
+    assert_raises(ArgumentError, 'invalid end_at') { @ws.add_chart Axlsx::Chart, start_at: [1, 2], end_at: ["a", 4] }
     # this is actually raised in the graphic frame
-    assert_raise(ArgumentError, 'invalid Chart') { @ws.add_chart Axlsx::TwoCellAnchor }
+    assert_raises(ArgumentError, 'invalid Chart') { @ws.add_chart Axlsx::TwoCellAnchor }
     a = @ws.add_chart Axlsx::Chart, start_at: [15, 35], end_at: [90, 45]
 
     assert_equal(15, a.graphic_frame.anchor.from.col)

--- a/test/drawing/tc_val_axis.rb
+++ b/test/drawing/tc_val_axis.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestValAxis < Test::Unit::TestCase
+class TestValAxis < Minitest::Test
   def setup
     @axis = Axlsx::ValAxis.new
   end
@@ -20,7 +20,7 @@ class TestValAxis < Test::Unit::TestCase
   end
 
   def test_crossBetween
-    assert_raise(ArgumentError, "requires valid crossBetween") { @axis.cross_between = :my_eyes }
-    assert_nothing_raised("accepts valid crossBetween") { @axis.cross_between = :midCat }
+    assert_raises(ArgumentError, "requires valid crossBetween") { @axis.cross_between = :my_eyes }
+    refute_raises { @axis.cross_between = :midCat }
   end
 end

--- a/test/drawing/tc_view_3D.rb
+++ b/test/drawing/tc_view_3D.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestView3D < Test::Unit::TestCase
+class TestView3D < Minitest::Test
   def setup
     @view = Axlsx::View3D.new
   end
@@ -16,37 +16,37 @@ class TestView3D < Test::Unit::TestCase
     assert_equal(5, v.rot_y)
     assert_equal("30%", v.h_percent)
     assert_equal("45%", v.depth_percent)
-    refute(v.r_ang_ax)
+    assert_false(v.r_ang_ax)
     assert_equal(10, v.perspective)
   end
 
   def test_rot_x
-    assert_raise(ArgumentError) { @view.rot_x = "bob" }
-    assert_nothing_raised { @view.rot_x = -90 }
+    assert_raises(ArgumentError) { @view.rot_x = "bob" }
+    refute_raises { @view.rot_x = -90 }
   end
 
   def test_rot_y
-    assert_raise(ArgumentError) { @view.rot_y = "bob" }
-    assert_nothing_raised { @view.rot_y = 90 }
+    assert_raises(ArgumentError) { @view.rot_y = "bob" }
+    refute_raises { @view.rot_y = 90 }
   end
 
   def test_h_percent
-    assert_raise(ArgumentError) { @view.h_percent = "bob" }
-    assert_nothing_raised { @view.h_percent = "500%" }
+    assert_raises(ArgumentError) { @view.h_percent = "bob" }
+    refute_raises { @view.h_percent = "500%" }
   end
 
   def test_depth_percent
-    assert_raise(ArgumentError) { @view.depth_percent = "bob" }
-    assert_nothing_raised { @view.depth_percent = "20%" }
+    assert_raises(ArgumentError) { @view.depth_percent = "bob" }
+    refute_raises { @view.depth_percent = "20%" }
   end
 
   def test_rAngAx
-    assert_raise(ArgumentError) { @view.rAngAx = "bob" }
-    assert_nothing_raised { @view.rAngAx = true }
+    assert_raises(ArgumentError) { @view.rAngAx = "bob" }
+    refute_raises { @view.rAngAx = true }
   end
 
   def test_perspective
-    assert_raise(ArgumentError) { @view.perspective = "bob" }
-    assert_nothing_raised { @view.perspective = 30 }
+    assert_raises(ArgumentError) { @view.perspective = "bob" }
+    refute_raises { @view.perspective = 30 }
   end
 end

--- a/test/drawing/tc_vml_drawing.rb
+++ b/test/drawing/tc_vml_drawing.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestVmlDrawing < Test::Unit::TestCase
+class TestVmlDrawing < Minitest::Test
   def setup
     p = Axlsx::Package.new
     wb = p.workbook
@@ -13,7 +13,7 @@ class TestVmlDrawing < Test::Unit::TestCase
   end
 
   def test_initialize
-    assert_raise(ArgumentError) { Axlsx::VmlDrawing.new }
+    assert_raises(ArgumentError) { Axlsx::VmlDrawing.new }
   end
 
   def test_pn

--- a/test/drawing/tc_vml_shape.rb
+++ b/test/drawing/tc_vml_shape.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestVmlShape < Test::Unit::TestCase
+class TestVmlShape < Minitest::Test
   def setup
     p = Axlsx::Package.new
     wb = p.workbook
@@ -13,7 +13,7 @@ class TestVmlShape < Test::Unit::TestCase
   end
 
   def test_initialize
-    assert_raise(ArgumentError) { Axlsx::VmlDrawing.new }
+    assert_raises(ArgumentError) { Axlsx::VmlDrawing.new }
   end
 
   def test_row
@@ -39,7 +39,7 @@ class TestVmlShape < Test::Unit::TestCase
     shape.left_column = 3
 
     assert_equal(3, shape.left_column)
-    assert_raise(ArgumentError) { shape.left_column = [] }
+    assert_raises(ArgumentError) { shape.left_column = [] }
   end
 
   def test_left_offset
@@ -47,7 +47,7 @@ class TestVmlShape < Test::Unit::TestCase
     shape.left_offset = 3
 
     assert_equal(3, shape.left_offset)
-    assert_raise(ArgumentError) { shape.left_offset = [] }
+    assert_raises(ArgumentError) { shape.left_offset = [] }
   end
 
   def test_right_column
@@ -55,7 +55,7 @@ class TestVmlShape < Test::Unit::TestCase
     shape.right_column = 3
 
     assert_equal(3, shape.right_column)
-    assert_raise(ArgumentError) { shape.right_column = [] }
+    assert_raises(ArgumentError) { shape.right_column = [] }
   end
 
   def test_right_offset
@@ -63,7 +63,7 @@ class TestVmlShape < Test::Unit::TestCase
     shape.right_offset = 3
 
     assert_equal(3, shape.right_offset)
-    assert_raise(ArgumentError) { shape.right_offset = [] }
+    assert_raises(ArgumentError) { shape.right_offset = [] }
   end
 
   def test_top_offset
@@ -71,7 +71,7 @@ class TestVmlShape < Test::Unit::TestCase
     shape.top_offset = 3
 
     assert_equal(3, shape.top_offset)
-    assert_raise(ArgumentError) { shape.top_offset = [] }
+    assert_raises(ArgumentError) { shape.top_offset = [] }
   end
 
   def test_bottom_offset
@@ -79,7 +79,7 @@ class TestVmlShape < Test::Unit::TestCase
     shape.bottom_offset = 3
 
     assert_equal(3, shape.bottom_offset)
-    assert_raise(ArgumentError) { shape.bottom_offset = [] }
+    assert_raises(ArgumentError) { shape.bottom_offset = [] }
   end
 
   def test_bottom_row
@@ -87,7 +87,7 @@ class TestVmlShape < Test::Unit::TestCase
     shape.bottom_row = 3
 
     assert_equal(3, shape.bottom_row)
-    assert_raise(ArgumentError) { shape.bottom_row = [] }
+    assert_raises(ArgumentError) { shape.bottom_row = [] }
   end
 
   def test_top_row
@@ -95,15 +95,15 @@ class TestVmlShape < Test::Unit::TestCase
     shape.top_row = 3
 
     assert_equal(3, shape.top_row)
-    assert_raise(ArgumentError) { shape.top_row = [] }
+    assert_raises(ArgumentError) { shape.top_row = [] }
   end
 
   def test_visible
     shape = @comments.first.vml_shape
     shape.visible = false
 
-    refute(shape.visible)
-    assert_raise(ArgumentError) { shape.visible = 'foo' }
+    assert_false(shape.visible)
+    assert_raises(ArgumentError) { shape.visible = 'foo' }
   end
 
   def test_to_xml_string

--- a/test/rels/tc_relationship.rb
+++ b/test/rels/tc_relationship.rb
@@ -2,12 +2,12 @@
 
 require 'tc_helper'
 
-class TestRelationships < Test::Unit::TestCase
+class TestRelationships < Minitest::Test
   def test_instances_with_different_attributes_have_unique_ids
     rel_1 = Axlsx::Relationship.new(Object.new, Axlsx::WORKSHEET_R, 'target')
     rel_2 = Axlsx::Relationship.new(Object.new, Axlsx::COMMENT_R, 'foobar')
 
-    assert_not_equal rel_1.Id, rel_2.Id
+    refute_equal rel_1.Id, rel_2.Id
   end
 
   def test_instances_with_same_attributes_share_id
@@ -23,7 +23,7 @@ class TestRelationships < Test::Unit::TestCase
     t2 = Thread.new { cache2 = Axlsx::Relationship.ids_cache }
     [t1, t2].each(&:join)
 
-    assert_not_same(cache1, cache2)
+    refute_same(cache1, cache2)
   end
 
   def test_target_is_only_considered_for_same_attributes_check_if_target_mode_is_external
@@ -36,18 +36,18 @@ class TestRelationships < Test::Unit::TestCase
     rel_3 = Axlsx::Relationship.new(source_obj, Axlsx::HYPERLINK_R, 'target', target_mode: :External)
     rel_4 = Axlsx::Relationship.new(source_obj, Axlsx::HYPERLINK_R, '../target', target_mode: :External)
 
-    assert_not_equal rel_3.Id, rel_4.Id
+    refute_equal rel_3.Id, rel_4.Id
   end
 
   def test_type
-    assert_raise(ArgumentError) { Axlsx::Relationship.new nil, 'type', 'target' }
-    assert_nothing_raised { Axlsx::Relationship.new nil, Axlsx::WORKSHEET_R, 'target' }
-    assert_nothing_raised { Axlsx::Relationship.new nil, Axlsx::COMMENT_R, 'target' }
+    assert_raises(ArgumentError) { Axlsx::Relationship.new nil, 'type', 'target' }
+    refute_raises { Axlsx::Relationship.new nil, Axlsx::WORKSHEET_R, 'target' }
+    refute_raises { Axlsx::Relationship.new nil, Axlsx::COMMENT_R, 'target' }
   end
 
   def test_target_mode
-    assert_raise(ArgumentError) { Axlsx::Relationship.new nil, 'type', 'target', target_mode: "FISH" }
-    assert_nothing_raised { Axlsx::Relationship.new(nil, Axlsx::WORKSHEET_R, 'target', target_mode: :External) }
+    assert_raises(ArgumentError) { Axlsx::Relationship.new nil, 'type', 'target', target_mode: "FISH" }
+    refute_raises { Axlsx::Relationship.new(nil, Axlsx::WORKSHEET_R, 'target', target_mode: :External) }
   end
 
   def test_ampersand_escaping_in_target

--- a/test/rels/tc_relationships.rb
+++ b/test/rels/tc_relationships.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestRelationships < Test::Unit::TestCase
+class TestRelationships < Minitest::Test
   def test_for
     source_obj_1 = Object.new
     source_obj_2 = Object.new

--- a/test/stylesheet/tc_border.rb
+++ b/test/stylesheet/tc_border.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestBorder < Test::Unit::TestCase
+class TestBorder < Minitest::Test
   def setup
     @b = Axlsx::Border.new
   end
@@ -17,24 +17,24 @@ class TestBorder < Test::Unit::TestCase
   end
 
   def test_diagonalUp
-    assert_raise(ArgumentError) { @b.diagonalUp = :red }
-    assert_nothing_raised { @b.diagonalUp = true }
+    assert_raises(ArgumentError) { @b.diagonalUp = :red }
+    refute_raises { @b.diagonalUp = true }
     assert(@b.diagonalUp)
   end
 
   def test_diagonalDown
-    assert_raise(ArgumentError) { @b.diagonalDown = :red }
-    assert_nothing_raised { @b.diagonalDown = true }
+    assert_raises(ArgumentError) { @b.diagonalDown = :red }
+    refute_raises { @b.diagonalDown = true }
     assert(@b.diagonalDown)
   end
 
   def test_outline
-    assert_raise(ArgumentError) { @b.outline = :red }
-    assert_nothing_raised { @b.outline = true }
+    assert_raises(ArgumentError) { @b.outline = :red }
+    refute_raises { @b.outline = true }
     assert(@b.outline)
   end
 
   def test_prs
-    assert_nothing_raised { @b.prs << Axlsx::BorderPr.new(name: :top, style: :thin, color: Axlsx::Color.new(rgb: "FF0000FF")) }
+    refute_raises { @b.prs << Axlsx::BorderPr.new(name: :top, style: :thin, color: Axlsx::Color.new(rgb: "FF0000FF")) }
   end
 end

--- a/test/stylesheet/tc_border_pr.rb
+++ b/test/stylesheet/tc_border_pr.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestBorderPr < Test::Unit::TestCase
+class TestBorderPr < Minitest::Test
   def setup
     @bpr = Axlsx::BorderPr.new
   end
@@ -16,20 +16,20 @@ class TestBorderPr < Test::Unit::TestCase
   end
 
   def test_color
-    assert_raise(ArgumentError) { @bpr.color = :red }
-    assert_nothing_raised { @bpr.color = Axlsx::Color.new rgb: "FF000000" }
+    assert_raises(ArgumentError) { @bpr.color = :red }
+    refute_raises { @bpr.color = Axlsx::Color.new rgb: "FF000000" }
     assert_kind_of(Axlsx::Color, @bpr.color)
   end
 
   def test_style
-    assert_raise(ArgumentError) { @bpr.style = :red }
-    assert_nothing_raised { @bpr.style = :thin }
+    assert_raises(ArgumentError) { @bpr.style = :red }
+    refute_raises { @bpr.style = :thin }
     assert_equal(:thin, @bpr.style)
   end
 
   def test_name
-    assert_raise(ArgumentError) { @bpr.name = :red }
-    assert_nothing_raised { @bpr.name = :top }
+    assert_raises(ArgumentError) { @bpr.name = :red }
+    refute_raises { @bpr.name = :top }
     assert_equal(:top, @bpr.name)
   end
 end

--- a/test/stylesheet/tc_cell_alignment.rb
+++ b/test/stylesheet/tc_cell_alignment.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestCellAlignment < Test::Unit::TestCase
+class TestCellAlignment < Minitest::Test
   def setup
     @item = Axlsx::CellAlignment.new
   end
@@ -28,56 +28,56 @@ class TestCellAlignment < Test::Unit::TestCase
   end
 
   def test_horizontal
-    assert_raise(ArgumentError) { @item.horizontal = :red }
-    assert_nothing_raised { @item.horizontal = :left }
+    assert_raises(ArgumentError) { @item.horizontal = :red }
+    refute_raises { @item.horizontal = :left }
     assert_equal(:left, @item.horizontal)
   end
 
   def test_vertical
-    assert_raise(ArgumentError) { @item.vertical = :red }
-    assert_nothing_raised { @item.vertical = :top }
+    assert_raises(ArgumentError) { @item.vertical = :red }
+    refute_raises { @item.vertical = :top }
     assert_equal(:top, @item.vertical)
   end
 
   def test_textRotation
-    assert_raise(ArgumentError) { @item.textRotation = -1 }
-    assert_nothing_raised { @item.textRotation = 5 }
+    assert_raises(ArgumentError) { @item.textRotation = -1 }
+    refute_raises { @item.textRotation = 5 }
     assert_equal(5, @item.textRotation)
   end
 
   def test_wrapText
-    assert_raise(ArgumentError) { @item.wrapText = -1 }
-    assert_nothing_raised { @item.wrapText = false }
-    refute(@item.wrapText)
+    assert_raises(ArgumentError) { @item.wrapText = -1 }
+    refute_raises { @item.wrapText = false }
+    assert_false(@item.wrapText)
   end
 
   def test_indent
-    assert_raise(ArgumentError) { @item.indent = -1 }
-    assert_nothing_raised { @item.indent = 5 }
+    assert_raises(ArgumentError) { @item.indent = -1 }
+    refute_raises { @item.indent = 5 }
     assert_equal(5, @item.indent)
   end
 
   def test_relativeIndent
-    assert_raise(ArgumentError) { @item.relativeIndent = :symbol }
-    assert_nothing_raised { @item.relativeIndent = 5 }
+    assert_raises(ArgumentError) { @item.relativeIndent = :symbol }
+    refute_raises { @item.relativeIndent = 5 }
     assert_equal(5, @item.relativeIndent)
   end
 
   def test_justifyLastLine
-    assert_raise(ArgumentError) { @item.justifyLastLine = -1 }
-    assert_nothing_raised { @item.justifyLastLine = true }
+    assert_raises(ArgumentError) { @item.justifyLastLine = -1 }
+    refute_raises { @item.justifyLastLine = true }
     assert(@item.justifyLastLine)
   end
 
   def test_shrinkToFit
-    assert_raise(ArgumentError) { @item.shrinkToFit = -1 }
-    assert_nothing_raised { @item.shrinkToFit = true }
+    assert_raises(ArgumentError) { @item.shrinkToFit = -1 }
+    refute_raises { @item.shrinkToFit = true }
     assert(@item.shrinkToFit)
   end
 
   def test_readingOrder
-    assert_raise(ArgumentError) { @item.readingOrder = -1 }
-    assert_nothing_raised { @item.readingOrder = 2 }
+    assert_raises(ArgumentError) { @item.readingOrder = -1 }
+    refute_raises { @item.readingOrder = 2 }
     assert_equal(2, @item.readingOrder)
   end
 end

--- a/test/stylesheet/tc_cell_protection.rb
+++ b/test/stylesheet/tc_cell_protection.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestCellProtection < Test::Unit::TestCase
+class TestCellProtection < Minitest::Test
   def setup
     @item = Axlsx::CellProtection.new
   end
@@ -15,14 +15,14 @@ class TestCellProtection < Test::Unit::TestCase
   end
 
   def test_hidden
-    assert_raise(ArgumentError) { @item.hidden = -1 }
-    assert_nothing_raised { @item.hidden = false }
-    refute(@item.hidden)
+    assert_raises(ArgumentError) { @item.hidden = -1 }
+    refute_raises { @item.hidden = false }
+    assert_false(@item.hidden)
   end
 
   def test_locked
-    assert_raise(ArgumentError) { @item.locked = -1 }
-    assert_nothing_raised { @item.locked = false }
-    refute(@item.locked)
+    assert_raises(ArgumentError) { @item.locked = -1 }
+    refute_raises { @item.locked = false }
+    assert_false(@item.locked)
   end
 end

--- a/test/stylesheet/tc_cell_style.rb
+++ b/test/stylesheet/tc_cell_style.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestCellStyle < Test::Unit::TestCase
+class TestCellStyle < Minitest::Test
   def setup
     @item = Axlsx::CellStyle.new
   end
@@ -19,38 +19,38 @@ class TestCellStyle < Test::Unit::TestCase
   end
 
   def test_name
-    assert_raise(ArgumentError) { @item.name = -1 }
-    assert_nothing_raised { @item.name = "stylin" }
+    assert_raises(ArgumentError) { @item.name = -1 }
+    refute_raises { @item.name = "stylin" }
     assert_equal("stylin", @item.name)
   end
 
   def test_xfId
-    assert_raise(ArgumentError) { @item.xfId = -1 }
-    assert_nothing_raised { @item.xfId = 5 }
+    assert_raises(ArgumentError) { @item.xfId = -1 }
+    refute_raises { @item.xfId = 5 }
     assert_equal(5, @item.xfId)
   end
 
   def test_builtinId
-    assert_raise(ArgumentError) { @item.builtinId = -1 }
-    assert_nothing_raised { @item.builtinId = 5 }
+    assert_raises(ArgumentError) { @item.builtinId = -1 }
+    refute_raises { @item.builtinId = 5 }
     assert_equal(5, @item.builtinId)
   end
 
   def test_iLevel
-    assert_raise(ArgumentError) { @item.iLevel = -1 }
-    assert_nothing_raised { @item.iLevel = 5 }
+    assert_raises(ArgumentError) { @item.iLevel = -1 }
+    refute_raises { @item.iLevel = 5 }
     assert_equal(5, @item.iLevel)
   end
 
   def test_hidden
-    assert_raise(ArgumentError) { @item.hidden = -1 }
-    assert_nothing_raised { @item.hidden = true }
+    assert_raises(ArgumentError) { @item.hidden = -1 }
+    refute_raises { @item.hidden = true }
     assert(@item.hidden)
   end
 
   def test_customBuiltin
-    assert_raise(ArgumentError) { @item.customBuiltin = -1 }
-    assert_nothing_raised { @item.customBuiltin = true }
+    assert_raises(ArgumentError) { @item.customBuiltin = -1 }
+    refute_raises { @item.customBuiltin = true }
     assert(@item.customBuiltin)
   end
 end

--- a/test/stylesheet/tc_color.rb
+++ b/test/stylesheet/tc_color.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestColor < Test::Unit::TestCase
+class TestColor < Minitest::Test
   def setup
     @item = Axlsx::Color.new
   end
@@ -16,14 +16,14 @@ class TestColor < Test::Unit::TestCase
   end
 
   def test_auto
-    assert_raise(ArgumentError) { @item.auto = -1 }
-    assert_nothing_raised { @item.auto = true }
+    assert_raises(ArgumentError) { @item.auto = -1 }
+    refute_raises { @item.auto = true }
     assert(@item.auto)
   end
 
   def test_rgb
-    assert_raise(ArgumentError) { @item.rgb = -1 }
-    assert_nothing_raised { @item.rgb = "FF00FF00" }
+    assert_raises(ArgumentError) { @item.rgb = -1 }
+    refute_raises { @item.rgb = "FF00FF00" }
     assert_equal("FF00FF00", @item.rgb)
   end
 
@@ -35,8 +35,8 @@ class TestColor < Test::Unit::TestCase
   end
 
   def test_tint
-    assert_raise(ArgumentError) { @item.tint = -1 }
-    assert_nothing_raised { @item.tint = -1.0 }
+    assert_raises(ArgumentError) { @item.tint = -1 }
+    refute_raises { @item.tint = -1.0 }
     assert_in_delta(@item.tint, -1.0)
   end
 end

--- a/test/stylesheet/tc_dxf.rb
+++ b/test/stylesheet/tc_dxf.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestDxf < Test::Unit::TestCase
+class TestDxf < Minitest::Test
   def setup
     @item = Axlsx::Dxf.new
     @styles = Axlsx::Styles.new
@@ -20,38 +20,38 @@ class TestDxf < Test::Unit::TestCase
   end
 
   def test_alignment
-    assert_raise(ArgumentError) { @item.alignment = -1.1 }
-    assert_nothing_raised { @item.alignment = Axlsx::CellAlignment.new }
+    assert_raises(ArgumentError) { @item.alignment = -1.1 }
+    refute_raises { @item.alignment = Axlsx::CellAlignment.new }
     assert_kind_of(Axlsx::CellAlignment, @item.alignment)
   end
 
   def test_protection
-    assert_raise(ArgumentError) { @item.protection = -1.1 }
-    assert_nothing_raised { @item.protection = Axlsx::CellProtection.new }
+    assert_raises(ArgumentError) { @item.protection = -1.1 }
+    refute_raises { @item.protection = Axlsx::CellProtection.new }
     assert_kind_of(Axlsx::CellProtection, @item.protection)
   end
 
   def test_numFmt
-    assert_raise(ArgumentError) { @item.numFmt = 1 }
-    assert_nothing_raised { @item.numFmt = Axlsx::NumFmt.new }
+    assert_raises(ArgumentError) { @item.numFmt = 1 }
+    refute_raises { @item.numFmt = Axlsx::NumFmt.new }
     assert_kind_of Axlsx::NumFmt, @item.numFmt
   end
 
   def test_fill
-    assert_raise(ArgumentError) { @item.fill = 1 }
-    assert_nothing_raised { @item.fill = Axlsx::Fill.new(Axlsx::PatternFill.new(patternType: :solid, fgColor: Axlsx::Color.new(rgb: "FF000000"))) }
+    assert_raises(ArgumentError) { @item.fill = 1 }
+    refute_raises { @item.fill = Axlsx::Fill.new(Axlsx::PatternFill.new(patternType: :solid, fgColor: Axlsx::Color.new(rgb: "FF000000"))) }
     assert_kind_of Axlsx::Fill, @item.fill
   end
 
   def test_font
-    assert_raise(ArgumentError) { @item.font = 1 }
-    assert_nothing_raised { @item.font = Axlsx::Font.new }
+    assert_raises(ArgumentError) { @item.font = 1 }
+    refute_raises { @item.font = Axlsx::Font.new }
     assert_kind_of Axlsx::Font, @item.font
   end
 
   def test_border
-    assert_raise(ArgumentError) { @item.border = 1 }
-    assert_nothing_raised { @item.border = Axlsx::Border.new }
+    assert_raises(ArgumentError) { @item.border = 1 }
+    refute_raises { @item.border = Axlsx::Border.new }
     assert_kind_of Axlsx::Border, @item.border
   end
 

--- a/test/stylesheet/tc_fill.rb
+++ b/test/stylesheet/tc_fill.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestFill < Test::Unit::TestCase
+class TestFill < Minitest::Test
   def setup
     @item = Axlsx::Fill.new Axlsx::PatternFill.new
   end
@@ -11,7 +11,7 @@ class TestFill < Test::Unit::TestCase
 
   def test_initialiation
     assert_kind_of(Axlsx::PatternFill, @item.fill_type)
-    assert_raise(ArgumentError) { Axlsx::Fill.new }
-    assert_nothing_raised { Axlsx::Fill.new(Axlsx::GradientFill.new) }
+    assert_raises(ArgumentError) { Axlsx::Fill.new }
+    refute_raises { Axlsx::Fill.new(Axlsx::GradientFill.new) }
   end
 end

--- a/test/stylesheet/tc_font.rb
+++ b/test/stylesheet/tc_font.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestFont < Test::Unit::TestCase
+class TestFont < Minitest::Test
   def setup
     @item = Axlsx::Font.new
   end
@@ -27,43 +27,43 @@ class TestFont < Test::Unit::TestCase
 
   # def name=(v) Axlsx::validate_string v; @name = v end
   def test_name
-    assert_raise(ArgumentError) { @item.name = 7 }
-    assert_nothing_raised { @item.name = "bob" }
+    assert_raises(ArgumentError) { @item.name = 7 }
+    refute_raises { @item.name = "bob" }
     assert_equal("bob", @item.name)
   end
 
   # def charset=(v) Axlsx::validate_unsigned_int v; @charset = v end
   def test_charset
-    assert_raise(ArgumentError) { @item.charset = -7 }
-    assert_nothing_raised { @item.charset = 5 }
+    assert_raises(ArgumentError) { @item.charset = -7 }
+    refute_raises { @item.charset = 5 }
     assert_equal(5, @item.charset)
   end
 
   # def family=(v) Axlsx::validate_unsigned_int v; @family = v end
   def test_family
-    assert_raise(ArgumentError) { @item.family = -7 }
-    assert_nothing_raised { @item.family = 5 }
+    assert_raises(ArgumentError) { @item.family = -7 }
+    refute_raises { @item.family = 5 }
     assert_equal(5, @item.family)
   end
 
   # def b=(v) Axlsx::validate_boolean v; @b = v end
   def test_b
-    assert_raise(ArgumentError) { @item.b = -7 }
-    assert_nothing_raised { @item.b = true }
+    assert_raises(ArgumentError) { @item.b = -7 }
+    refute_raises { @item.b = true }
     assert(@item.b)
   end
 
   # def i=(v) Axlsx::validate_boolean v; @i = v end
   def test_i
-    assert_raise(ArgumentError) { @item.i = -7 }
-    assert_nothing_raised { @item.i = true }
+    assert_raises(ArgumentError) { @item.i = -7 }
+    refute_raises { @item.i = true }
     assert(@item.i)
   end
 
   # def u=(v) Axlsx::validate_cell_u v; @u = v end
   def test_u
-    assert_raise(ArgumentError) { @item.u = -7 }
-    assert_nothing_raised { @item.u = :single }
+    assert_raises(ArgumentError) { @item.u = -7 }
+    refute_raises { @item.u = :single }
     assert_equal(:single, @item.u)
     doc = Nokogiri::XML(@item.to_xml_string)
 
@@ -72,60 +72,60 @@ class TestFont < Test::Unit::TestCase
 
   def test_u_backward_compatibility
     # backward compatibility for true
-    assert_nothing_raised { @item.u = true }
+    refute_raises { @item.u = true }
     assert_equal(:single, @item.u)
 
     # backward compatibility for false
-    assert_nothing_raised { @item.u = false }
+    refute_raises { @item.u = false }
     assert_equal(:none, @item.u)
   end
 
   # def strike=(v) Axlsx::validate_boolean v; @strike = v end
   def test_strike
-    assert_raise(ArgumentError) { @item.strike = -7 }
-    assert_nothing_raised { @item.strike = true }
+    assert_raises(ArgumentError) { @item.strike = -7 }
+    refute_raises { @item.strike = true }
     assert(@item.strike)
   end
 
   # def outline=(v) Axlsx::validate_boolean v; @outline = v end
   def test_outline
-    assert_raise(ArgumentError) { @item.outline = -7 }
-    assert_nothing_raised { @item.outline = true }
+    assert_raises(ArgumentError) { @item.outline = -7 }
+    refute_raises { @item.outline = true }
     assert(@item.outline)
   end
 
   # def shadow=(v) Axlsx::validate_boolean v; @shadow = v end
   def test_shadow
-    assert_raise(ArgumentError) { @item.shadow = -7 }
-    assert_nothing_raised { @item.shadow = true }
+    assert_raises(ArgumentError) { @item.shadow = -7 }
+    refute_raises { @item.shadow = true }
     assert(@item.shadow)
   end
 
   # def condense=(v) Axlsx::validate_boolean v; @condense = v end
   def test_condense
-    assert_raise(ArgumentError) { @item.condense = -7 }
-    assert_nothing_raised { @item.condense = true }
+    assert_raises(ArgumentError) { @item.condense = -7 }
+    refute_raises { @item.condense = true }
     assert(@item.condense)
   end
 
   # def extend=(v) Axlsx::validate_boolean v; @extend = v end
   def test_extend
-    assert_raise(ArgumentError) { @item.extend = -7 }
-    assert_nothing_raised { @item.extend = true }
+    assert_raises(ArgumentError) { @item.extend = -7 }
+    refute_raises { @item.extend = true }
     assert(@item.extend)
   end
 
   # def color=(v) DataTypeValidator.validate "Font.color", Color, v; @color=v end
   def test_color
-    assert_raise(ArgumentError) { @item.color = -7 }
-    assert_nothing_raised { @item.color = Axlsx::Color.new(rgb: "00000000") }
+    assert_raises(ArgumentError) { @item.color = -7 }
+    refute_raises { @item.color = Axlsx::Color.new(rgb: "00000000") }
     assert_kind_of(Axlsx::Color, @item.color)
   end
 
   # def sz=(v) Axlsx::validate_unsigned_int v; @sz=v end
   def test_sz
-    assert_raise(ArgumentError) { @item.sz = -7 }
-    assert_nothing_raised { @item.sz = 5 }
+    assert_raises(ArgumentError) { @item.sz = -7 }
+    refute_raises { @item.sz = 5 }
     assert_equal(5, @item.sz)
   end
 end

--- a/test/stylesheet/tc_gradient_fill.rb
+++ b/test/stylesheet/tc_gradient_fill.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestGradientFill < Test::Unit::TestCase
+class TestGradientFill < Minitest::Test
   def setup
     @item = Axlsx::GradientFill.new
   end
@@ -20,38 +20,38 @@ class TestGradientFill < Test::Unit::TestCase
   end
 
   def test_type
-    assert_raise(ArgumentError) { @item.type = 7 }
-    assert_nothing_raised { @item.type = :path }
+    assert_raises(ArgumentError) { @item.type = 7 }
+    refute_raises { @item.type = :path }
     assert_equal(:path, @item.type)
   end
 
   def test_degree
-    assert_raise(ArgumentError) { @item.degree = -7 }
-    assert_nothing_raised { @item.degree = 5.0 }
+    assert_raises(ArgumentError) { @item.degree = -7 }
+    refute_raises { @item.degree = 5.0 }
     assert_in_delta(@item.degree, 5.0)
   end
 
   def test_left
-    assert_raise(ArgumentError) { @item.left = -1.1 }
-    assert_nothing_raised { @item.left = 1.0 }
+    assert_raises(ArgumentError) { @item.left = -1.1 }
+    refute_raises { @item.left = 1.0 }
     assert_in_delta(@item.left, 1.0)
   end
 
   def test_right
-    assert_raise(ArgumentError) { @item.right = -1.1 }
-    assert_nothing_raised { @item.right = 0.5 }
+    assert_raises(ArgumentError) { @item.right = -1.1 }
+    refute_raises { @item.right = 0.5 }
     assert_in_delta(@item.right, 0.5)
   end
 
   def test_top
-    assert_raise(ArgumentError) { @item.top = -1.1 }
-    assert_nothing_raised { @item.top = 1.0 }
+    assert_raises(ArgumentError) { @item.top = -1.1 }
+    refute_raises { @item.top = 1.0 }
     assert_in_delta(@item.top, 1.0)
   end
 
   def test_bottom
-    assert_raise(ArgumentError) { @item.bottom = -1.1 }
-    assert_nothing_raised { @item.bottom = 0.0 }
+    assert_raises(ArgumentError) { @item.bottom = -1.1 }
+    refute_raises { @item.bottom = 0.0 }
     assert_in_delta(@item.bottom, 0.0)
   end
 

--- a/test/stylesheet/tc_gradient_stop.rb
+++ b/test/stylesheet/tc_gradient_stop.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestGradientStop < Test::Unit::TestCase
+class TestGradientStop < Minitest::Test
   def setup
     @item = Axlsx::GradientStop.new(Axlsx::Color.new(rgb: "FFFF0000"), 1.0)
   end
@@ -15,13 +15,13 @@ class TestGradientStop < Test::Unit::TestCase
   end
 
   def test_position
-    assert_raise(ArgumentError) { @item.position = -1.1 }
-    assert_nothing_raised { @item.position = 0.0 }
+    assert_raises(ArgumentError) { @item.position = -1.1 }
+    refute_raises { @item.position = 0.0 }
     assert_in_delta(@item.position, 0.0)
   end
 
   def test_color
-    assert_raise(ArgumentError) { @item.color = nil }
+    assert_raises(ArgumentError) { @item.color = nil }
     color = Axlsx::Color.new(rgb: "FF0000FF")
     @item.color = color
 

--- a/test/stylesheet/tc_num_fmt.rb
+++ b/test/stylesheet/tc_num_fmt.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestNumFmt < Test::Unit::TestCase
+class TestNumFmt < Minitest::Test
   def setup
     @item = Axlsx::NumFmt.new
   end
@@ -15,14 +15,14 @@ class TestNumFmt < Test::Unit::TestCase
   end
 
   def test_numFmtId
-    assert_raise(ArgumentError) { @item.numFmtId = -1.1 }
-    assert_nothing_raised { @item.numFmtId = 2 }
+    assert_raises(ArgumentError) { @item.numFmtId = -1.1 }
+    refute_raises { @item.numFmtId = 2 }
     assert_equal(2, @item.numFmtId)
   end
 
   def test_fomatCode
-    assert_raise(ArgumentError) { @item.formatCode = -1.1 }
-    assert_nothing_raised { @item.formatCode = "0" }
+    assert_raises(ArgumentError) { @item.formatCode = -1.1 }
+    refute_raises { @item.formatCode = "0" }
     assert_equal("0", @item.formatCode)
   end
 end

--- a/test/stylesheet/tc_pattern_fill.rb
+++ b/test/stylesheet/tc_pattern_fill.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestPatternFill < Test::Unit::TestCase
+class TestPatternFill < Minitest::Test
   def setup
     @item = Axlsx::PatternFill.new
   end
@@ -16,20 +16,20 @@ class TestPatternFill < Test::Unit::TestCase
   end
 
   def test_bgColor
-    assert_raise(ArgumentError) { @item.bgColor = -1.1 }
-    assert_nothing_raised { @item.bgColor = Axlsx::Color.new }
+    assert_raises(ArgumentError) { @item.bgColor = -1.1 }
+    refute_raises { @item.bgColor = Axlsx::Color.new }
     assert_equal("FF000000", @item.bgColor.rgb)
   end
 
   def test_fgColor
-    assert_raise(ArgumentError) { @item.fgColor = -1.1 }
-    assert_nothing_raised { @item.fgColor = Axlsx::Color.new }
+    assert_raises(ArgumentError) { @item.fgColor = -1.1 }
+    refute_raises { @item.fgColor = Axlsx::Color.new }
     assert_equal("FF000000", @item.fgColor.rgb)
   end
 
   def test_pattern_type
-    assert_raise(ArgumentError) { @item.patternType = -1.1 }
-    assert_nothing_raised { @item.patternType = :lightUp }
+    assert_raises(ArgumentError) { @item.patternType = -1.1 }
+    refute_raises { @item.patternType = :lightUp }
     assert_equal(:lightUp, @item.patternType)
   end
 

--- a/test/stylesheet/tc_styles.rb
+++ b/test/stylesheet/tc_styles.rb
@@ -3,7 +3,7 @@
 require 'tc_helper'
 require 'support/capture_warnings'
 
-class TestStyles < Test::Unit::TestCase
+class TestStyles < Minitest::Test
   include CaptureWarnings
 
   def setup
@@ -26,7 +26,7 @@ class TestStyles < Test::Unit::TestCase
 
     assert_equal(@styles.borders.size, border_count + 1)
     assert_equal("FFFF0000", @styles.borders.last.prs.last.color.rgb)
-    assert_raise(ArgumentError) { @styles.add_style border: { color: "FFFF0000" } }
+    assert_raises(ArgumentError) { @styles.add_style border: { color: "FFFF0000" } }
     assert_equal(4, @styles.borders.last.prs.size)
   end
 
@@ -88,9 +88,9 @@ class TestStyles < Test::Unit::TestCase
   end
 
   def test_parse_border_options_hash_required_keys
-    assert_raise(ArgumentError, "Require color key") { @styles.parse_border_options(border: { style: :thin }) }
-    assert_raise(ArgumentError, "Require style key") { @styles.parse_border_options(border: { color: "FF0d0d0d" }) }
-    assert_nothing_raised { @styles.parse_border_options(border: { style: :thin, color: "FF000000" }) }
+    assert_raises(ArgumentError, "Require color key") { @styles.parse_border_options(border: { style: :thin }) }
+    assert_raises(ArgumentError, "Require style key") { @styles.parse_border_options(border: { color: "FF0d0d0d" }) }
+    refute_raises { @styles.parse_border_options(border: { style: :thin, color: "FF000000" }) }
   end
 
   def test_parse_border_basic_options
@@ -127,7 +127,7 @@ class TestStyles < Test::Unit::TestCase
 
   def test_parse_border_options_integer_xf
     assert_equal(1, @styles.parse_border_options(border: 1))
-    assert_raise(ArgumentError, "unknown border index") { @styles.parse_border_options(border: 100) }
+    assert_raises(ArgumentError, "unknown border index") { @styles.parse_border_options(border: 100) }
   end
 
   def test_parse_border_options_integer_dxf
@@ -259,7 +259,7 @@ class TestStyles < Test::Unit::TestCase
     assert_equal(:left, xf.alignment.horizontal, "horizontal alignment applied")
     assert(xf.protection.hidden, "hidden protection set")
     assert(xf.protection.locked, "cell locking set")
-    assert_raise(ArgumentError, "should reject invalid borderId") { @styles.add_style border: 2 }
+    assert_raises(ArgumentError, "should reject invalid borderId") { @styles.add_style border: 2 }
 
     assert(xf.applyProtection, "protection applied")
     assert(xf.applyBorder, "border applied")
@@ -273,7 +273,7 @@ class TestStyles < Test::Unit::TestCase
 
     assert_equal(@styles.borders.size, border_count, "styles borders not affected")
     assert_equal("FFFF0000", @styles.dxfs.last.border.prs.last.color.rgb)
-    assert_raise(ArgumentError) { @styles.add_style border: { color: "FFFF0000" }, type: :dxf }
+    assert_raises(ArgumentError) { @styles.add_style border: { color: "FFFF0000" }, type: :dxf }
     assert_equal(4, @styles.borders.last.prs.size)
   end
 
@@ -301,7 +301,7 @@ class TestStyles < Test::Unit::TestCase
     assert_equal(:left, dxf.alignment.horizontal, "horizontal alignment applied")
     assert(dxf.protection.hidden, "hidden protection set")
     assert(dxf.protection.locked, "cell locking set")
-    assert_raise(ArgumentError, "should reject invalid borderId") { @styles.add_style border: 3 }
+    assert_raises(ArgumentError, "should reject invalid borderId") { @styles.add_style border: 3 }
   end
 
   def test_multiple_dxf
@@ -338,7 +338,7 @@ class TestStyles < Test::Unit::TestCase
   end
 
   def test_border_top_without_border_regression
-    ### https://github.com/axlsx-styler-gem/axlsx_styler/issues/31
+    # https://github.com/axlsx-styler-gem/axlsx_styler/issues/31
 
     borders = {
       top: { style: :double, color: '0000FF' },

--- a/test/stylesheet/tc_table_style.rb
+++ b/test/stylesheet/tc_table_style.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestTableStyle < Test::Unit::TestCase
+class TestTableStyle < Minitest::Test
   def setup
     @item = Axlsx::TableStyle.new "fisher"
   end
@@ -21,20 +21,20 @@ class TestTableStyle < Test::Unit::TestCase
   end
 
   def test_name
-    assert_raise(ArgumentError) { @item.name = -1.1 }
-    assert_nothing_raised { @item.name = "lovely table style" }
+    assert_raises(ArgumentError) { @item.name = -1.1 }
+    refute_raises { @item.name = "lovely table style" }
     assert_equal("lovely table style", @item.name)
   end
 
   def test_pivot
-    assert_raise(ArgumentError) { @item.pivot = -1.1 }
-    assert_nothing_raised { @item.pivot = true }
+    assert_raises(ArgumentError) { @item.pivot = -1.1 }
+    refute_raises { @item.pivot = true }
     assert(@item.pivot)
   end
 
   def test_table
-    assert_raise(ArgumentError) { @item.table = -1.1 }
-    assert_nothing_raised { @item.table = true }
+    assert_raises(ArgumentError) { @item.table = -1.1 }
+    refute_raises { @item.table = true }
     assert(@item.table)
   end
 

--- a/test/stylesheet/tc_table_style_element.rb
+++ b/test/stylesheet/tc_table_style_element.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestTableStyleElement < Test::Unit::TestCase
+class TestTableStyleElement < Minitest::Test
   def setup
     @item = Axlsx::TableStyleElement.new
   end
@@ -21,20 +21,20 @@ class TestTableStyleElement < Test::Unit::TestCase
   end
 
   def test_type
-    assert_raise(ArgumentError) { @item.type = -1.1 }
-    assert_nothing_raised { @item.type = :blankRow }
+    assert_raises(ArgumentError) { @item.type = -1.1 }
+    refute_raises { @item.type = :blankRow }
     assert_equal(:blankRow, @item.type)
   end
 
   def test_size
-    assert_raise(ArgumentError) { @item.size = -1.1 }
-    assert_nothing_raised { @item.size = 2 }
+    assert_raises(ArgumentError) { @item.size = -1.1 }
+    refute_raises { @item.size = 2 }
     assert_equal(2, @item.size)
   end
 
   def test_dxfId
-    assert_raise(ArgumentError) { @item.dxfId = -1.1 }
-    assert_nothing_raised { @item.dxfId = 7 }
+    assert_raises(ArgumentError) { @item.dxfId = -1.1 }
+    refute_raises { @item.dxfId = 7 }
     assert_equal(7, @item.dxfId)
   end
 

--- a/test/stylesheet/tc_table_styles.rb
+++ b/test/stylesheet/tc_table_styles.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestTableStyles < Test::Unit::TestCase
+class TestTableStyles < Minitest::Test
   def setup
     @item = Axlsx::TableStyles.new
   end
@@ -15,14 +15,14 @@ class TestTableStyles < Test::Unit::TestCase
   end
 
   def test_defaultTableStyle
-    assert_raise(ArgumentError) { @item.defaultTableStyle = -1.1 }
-    assert_nothing_raised { @item.defaultTableStyle = "anyones guess" }
+    assert_raises(ArgumentError) { @item.defaultTableStyle = -1.1 }
+    refute_raises { @item.defaultTableStyle = "anyones guess" }
     assert_equal("anyones guess", @item.defaultTableStyle)
   end
 
   def test_defaultPivotStyle
-    assert_raise(ArgumentError) { @item.defaultPivotStyle = -1.1 }
-    assert_nothing_raised { @item.defaultPivotStyle = "anyones guess" }
+    assert_raises(ArgumentError) { @item.defaultPivotStyle = -1.1 }
+    refute_raises { @item.defaultPivotStyle = "anyones guess" }
     assert_equal("anyones guess", @item.defaultPivotStyle)
   end
 end

--- a/test/stylesheet/tc_xf.rb
+++ b/test/stylesheet/tc_xf.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestXf < Test::Unit::TestCase
+class TestXf < Minitest::Test
   def setup
     @item = Axlsx::Xf.new
   end
@@ -28,92 +28,92 @@ class TestXf < Test::Unit::TestCase
   end
 
   def test_alignment
-    assert_raise(ArgumentError) { @item.alignment = -1.1 }
-    assert_nothing_raised { @item.alignment = Axlsx::CellAlignment.new }
+    assert_raises(ArgumentError) { @item.alignment = -1.1 }
+    refute_raises { @item.alignment = Axlsx::CellAlignment.new }
     assert_kind_of(Axlsx::CellAlignment, @item.alignment)
   end
 
   def test_protection
-    assert_raise(ArgumentError) { @item.protection = -1.1 }
-    assert_nothing_raised { @item.protection = Axlsx::CellProtection.new }
+    assert_raises(ArgumentError) { @item.protection = -1.1 }
+    refute_raises { @item.protection = Axlsx::CellProtection.new }
     assert_kind_of(Axlsx::CellProtection, @item.protection)
   end
 
   def test_numFmtId
-    assert_raise(ArgumentError) { @item.numFmtId = -1.1 }
-    assert_nothing_raised { @item.numFmtId = 0 }
+    assert_raises(ArgumentError) { @item.numFmtId = -1.1 }
+    refute_raises { @item.numFmtId = 0 }
     assert_equal(0, @item.numFmtId)
   end
 
   def test_fillId
-    assert_raise(ArgumentError) { @item.fillId = -1.1 }
-    assert_nothing_raised { @item.fillId = 0 }
+    assert_raises(ArgumentError) { @item.fillId = -1.1 }
+    refute_raises { @item.fillId = 0 }
     assert_equal(0, @item.fillId)
   end
 
   def test_fontId
-    assert_raise(ArgumentError) { @item.fontId = -1.1 }
-    assert_nothing_raised { @item.fontId = 0 }
+    assert_raises(ArgumentError) { @item.fontId = -1.1 }
+    refute_raises { @item.fontId = 0 }
     assert_equal(0, @item.fontId)
   end
 
   def test_borderId
-    assert_raise(ArgumentError) { @item.borderId = -1.1 }
-    assert_nothing_raised { @item.borderId = 0 }
+    assert_raises(ArgumentError) { @item.borderId = -1.1 }
+    refute_raises { @item.borderId = 0 }
     assert_equal(0, @item.borderId)
   end
 
   def test_xfId
-    assert_raise(ArgumentError) { @item.xfId = -1.1 }
-    assert_nothing_raised { @item.xfId = 0 }
+    assert_raises(ArgumentError) { @item.xfId = -1.1 }
+    refute_raises { @item.xfId = 0 }
     assert_equal(0, @item.xfId)
   end
 
   def test_quotePrefix
-    assert_raise(ArgumentError) { @item.quotePrefix = -1.1 }
-    assert_nothing_raised { @item.quotePrefix = false }
-    refute(@item.quotePrefix)
+    assert_raises(ArgumentError) { @item.quotePrefix = -1.1 }
+    refute_raises { @item.quotePrefix = false }
+    assert_false(@item.quotePrefix)
   end
 
   def test_pivotButton
-    assert_raise(ArgumentError) { @item.pivotButton = -1.1 }
-    assert_nothing_raised { @item.pivotButton = false }
-    refute(@item.pivotButton)
+    assert_raises(ArgumentError) { @item.pivotButton = -1.1 }
+    refute_raises { @item.pivotButton = false }
+    assert_false(@item.pivotButton)
   end
 
   def test_applyNumberFormat
-    assert_raise(ArgumentError) { @item.applyNumberFormat = -1.1 }
-    assert_nothing_raised { @item.applyNumberFormat = false }
-    refute(@item.applyNumberFormat)
+    assert_raises(ArgumentError) { @item.applyNumberFormat = -1.1 }
+    refute_raises { @item.applyNumberFormat = false }
+    assert_false(@item.applyNumberFormat)
   end
 
   def test_applyFont
-    assert_raise(ArgumentError) { @item.applyFont = -1.1 }
-    assert_nothing_raised { @item.applyFont = false }
-    refute(@item.applyFont)
+    assert_raises(ArgumentError) { @item.applyFont = -1.1 }
+    refute_raises { @item.applyFont = false }
+    assert_false(@item.applyFont)
   end
 
   def test_applyFill
-    assert_raise(ArgumentError) { @item.applyFill = -1.1 }
-    assert_nothing_raised { @item.applyFill = false }
-    refute(@item.applyFill)
+    assert_raises(ArgumentError) { @item.applyFill = -1.1 }
+    refute_raises { @item.applyFill = false }
+    assert_false(@item.applyFill)
   end
 
   def test_applyBorder
-    assert_raise(ArgumentError) { @item.applyBorder = -1.1 }
-    assert_nothing_raised { @item.applyBorder = false }
-    refute(@item.applyBorder)
+    assert_raises(ArgumentError) { @item.applyBorder = -1.1 }
+    refute_raises { @item.applyBorder = false }
+    assert_false(@item.applyBorder)
   end
 
   def test_applyAlignment
-    assert_raise(ArgumentError) { @item.applyAlignment = -1.1 }
-    assert_nothing_raised { @item.applyAlignment = false }
-    refute(@item.applyAlignment)
+    assert_raises(ArgumentError) { @item.applyAlignment = -1.1 }
+    refute_raises { @item.applyAlignment = false }
+    assert_false(@item.applyAlignment)
   end
 
   def test_applyProtection
-    assert_raise(ArgumentError) { @item.applyProtection = -1.1 }
-    assert_nothing_raised { @item.applyProtection = false }
-    refute(@item.applyProtection)
+    assert_raises(ArgumentError) { @item.applyProtection = -1.1 }
+    refute_raises { @item.applyProtection = false }
+    assert_false(@item.applyProtection)
   end
 end

--- a/test/tc_axlsx.rb
+++ b/test/tc_axlsx.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestAxlsx < Test::Unit::TestCase
+class TestAxlsx < Minitest::Test
   # rubocop:disable Layout/HashAlignment
   def setup_wide
     @wide_test_points = {
@@ -23,7 +23,7 @@ class TestAxlsx < Test::Unit::TestCase
   end
 
   def test_do_not_trust_input_by_default
-    refute Axlsx.trust_input
+    assert_false Axlsx.trust_input
   end
 
   def test_trust_input_can_be_set_to_true
@@ -173,7 +173,7 @@ class TestAxlsx < Test::Unit::TestCase
 
     Axlsx.escape_formulas = false
 
-    refute Axlsx.escape_formulas
+    assert_false Axlsx.escape_formulas
   ensure
     Axlsx.instance_variable_set(:@escape_formulas, nil)
   end

--- a/test/tc_helper.rb
+++ b/test/tc_helper.rb
@@ -7,7 +7,21 @@ SimpleCov.start do
   add_filter "/vendor/"
 end
 
-require 'test/unit'
-require "timecop"
-require 'webmock/test_unit'
-require "axlsx"
+require 'minitest/autorun'
+require 'timecop'
+require 'webmock/minitest'
+require 'axlsx'
+
+module Minitest
+  class Test
+    def assert_false(value)
+      assert_equal(false, value)
+    end
+
+    def refute_raises
+      yield
+    rescue StandardError => e
+      raise Minitest::Assertion, "Expected no exception, but raised: #{e.class.name} with message '#{e.message}'"
+    end
+  end
+end

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -3,7 +3,7 @@
 require 'tc_helper'
 require 'support/capture_warnings'
 
-class TestPackage < Test::Unit::TestCase
+class TestPackage < Minitest::Test
   include CaptureWarnings
 
   def setup
@@ -97,23 +97,23 @@ class TestPackage < Test::Unit::TestCase
   def test_use_autowidth
     @package.use_autowidth = false
 
-    refute(@package.workbook.use_autowidth)
+    assert_false(@package.workbook.use_autowidth)
   end
 
   def test_core_accessor
     assert_equal(@package.core, Axlsx.instance_values_for(@package)["core"])
-    assert_raise(NoMethodError) { @package.core = nil }
+    assert_raises(NoMethodError) { @package.core = nil }
   end
 
   def test_app_accessor
     assert_equal(@package.app, Axlsx.instance_values_for(@package)["app"])
-    assert_raise(NoMethodError) { @package.app = nil }
+    assert_raises(NoMethodError) { @package.app = nil }
   end
 
   def test_use_shared_strings
     assert_nil(@package.use_shared_strings)
-    assert_raise(ArgumentError) { @package.use_shared_strings 9 }
-    assert_nothing_raised { @package.use_shared_strings = true }
+    assert_raises(ArgumentError) { @package.use_shared_strings 9 }
+    refute_raises { @package.use_shared_strings = true }
     assert_equal(@package.use_shared_strings, @package.workbook.use_shared_strings)
   end
 
@@ -354,6 +354,6 @@ class TestPackage < Test::Unit::TestCase
 
   def test_encrypt
     # this is no where near close to ready yet
-    refute(@package.encrypt('your_mom.xlsxl', 'has a password'))
+    assert_false(@package.encrypt('your_mom.xlsxl', 'has a password'))
   end
 end

--- a/test/util/tc_mime_type_utils.rb
+++ b/test/util/tc_mime_type_utils.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestMimeTypeUtils < Test::Unit::TestCase
+class TestMimeTypeUtils < Minitest::Test
   def setup
     stub_request(:get, 'https://example.com/sample-image.png')
       .to_return(body: File.new('examples/sample.png'), status: 200)
@@ -19,6 +19,6 @@ class TestMimeTypeUtils < Test::Unit::TestCase
   end
 
   def test_escape_uri
-    assert_raise(URI::InvalidURIError) { Axlsx::MimeTypeUtils.get_mime_type_from_uri('| ls') }
+    assert_raises(URI::InvalidURIError) { Axlsx::MimeTypeUtils.get_mime_type_from_uri('| ls') }
   end
 end

--- a/test/util/tc_serialized_attributes.rb
+++ b/test/util/tc_serialized_attributes.rb
@@ -10,7 +10,7 @@ class Funk
   attr_accessor :camel_symbol, :boolean, :integer
 end
 
-class TestSeralizedAttributes < Test::Unit::TestCase
+class TestSeralizedAttributes < Minitest::Test
   def setup
     @object = Funk.new
   end

--- a/test/util/tc_simple_typed_list.rb
+++ b/test/util/tc_simple_typed_list.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestSimpleTypedList < Test::Unit::TestCase
+class TestSimpleTypedList < Minitest::Test
   def setup
     @list = Axlsx::SimpleTypedList.new Integer
   end
@@ -10,24 +10,24 @@ class TestSimpleTypedList < Test::Unit::TestCase
   def teardown; end
 
   def test_type_is_a_class_or_array_of_class
-    assert_nothing_raised { Axlsx::SimpleTypedList.new Integer }
-    assert_nothing_raised { Axlsx::SimpleTypedList.new [Integer, String] }
-    assert_raise(ArgumentError) { Axlsx::SimpleTypedList.new }
-    assert_raise(ArgumentError) { Axlsx::SimpleTypedList.new "1" }
-    assert_raise(ArgumentError) { Axlsx::SimpleTypedList.new [Integer, "Class"] }
+    refute_raises { Axlsx::SimpleTypedList.new Integer }
+    refute_raises { Axlsx::SimpleTypedList.new [Integer, String] }
+    assert_raises(ArgumentError) { Axlsx::SimpleTypedList.new }
+    assert_raises(ArgumentError) { Axlsx::SimpleTypedList.new "1" }
+    assert_raises(ArgumentError) { Axlsx::SimpleTypedList.new [Integer, "Class"] }
   end
 
   def test_indexed_based_assignment
     # should not allow nil assignment
-    assert_raise(ArgumentError) { @list[0] = nil }
-    assert_raise(ArgumentError) { @list[0] = "1" }
-    assert_nothing_raised { @list[0] = 1 }
+    assert_raises(ArgumentError) { @list[0] = nil }
+    assert_raises(ArgumentError) { @list[0] = "1" }
+    refute_raises { @list[0] = 1 }
   end
 
   def test_concat_assignment
-    assert_raise(ArgumentError) { @list << nil }
-    assert_raise(ArgumentError) { @list << "1" }
-    assert_nothing_raised { @list << 1 }
+    assert_raises(ArgumentError) { @list << nil }
+    assert_raises(ArgumentError) { @list << "1" }
+    refute_raises { @list << 1 }
   end
 
   def test_concat_should_return_index
@@ -55,18 +55,18 @@ class TestSimpleTypedList < Test::Unit::TestCase
     @list.push 3
     @list.lock
 
-    assert_raise(ArgumentError) { @list.delete 1  }
-    assert_raise(ArgumentError) { @list.delete_at 1 }
-    assert_raise(ArgumentError) { @list.delete_at 2 }
-    assert_raise(ArgumentError) { @list.insert(1, 3) }
-    assert_raise(ArgumentError) { @list[1] = 3 }
+    assert_raises(ArgumentError) { @list.delete 1  }
+    assert_raises(ArgumentError) { @list.delete_at 1 }
+    assert_raises(ArgumentError) { @list.delete_at 2 }
+    assert_raises(ArgumentError) { @list.insert(1, 3) }
+    assert_raises(ArgumentError) { @list[1] = 3 }
 
     @list.push 4
-    assert_nothing_raised { @list.delete_at 3 }
+    refute_raises { @list.delete_at 3 }
     @list.unlock
     # ignore garbage
-    assert_nothing_raised { @list.delete 0 }
-    assert_nothing_raised { @list.delete 9 }
+    refute_raises { @list.delete 0 }
+    refute_raises { @list.delete 9 }
   end
 
   def test_delete
@@ -95,7 +95,7 @@ class TestSimpleTypedList < Test::Unit::TestCase
   end
 
   def test_insert
-    assert_raise(ArgumentError) { @list << nil }
+    assert_raises(ArgumentError) { @list << nil }
 
     assert_equal(1, @list.insert(0, 1))
     assert_equal(2, @list.insert(1, 2))
@@ -105,7 +105,7 @@ class TestSimpleTypedList < Test::Unit::TestCase
   end
 
   def test_setter
-    assert_raise(ArgumentError) { @list[0] = nil }
+    assert_raises(ArgumentError) { @list[0] = nil }
 
     assert_equal(1, @list[0] = 1)
     assert_equal(2, @list[1] = 2)

--- a/test/util/tc_validators.rb
+++ b/test/util/tc_validators.rb
@@ -2,212 +2,212 @@
 
 require 'tc_helper'
 
-class TestValidators < Test::Unit::TestCase
+class TestValidators < Minitest::Test
   def setup; end
 
   def teardown; end
 
   def test_validators
     # unsigned_int
-    assert_nothing_raised { Axlsx.validate_unsigned_int 1 }
-    assert_nothing_raised { Axlsx.validate_unsigned_int(+1) }
-    assert_raise(ArgumentError) { Axlsx.validate_unsigned_int(-1) }
-    assert_raise(ArgumentError) { Axlsx.validate_unsigned_int('1') }
+    refute_raises { Axlsx.validate_unsigned_int 1 }
+    refute_raises { Axlsx.validate_unsigned_int(+1) }
+    assert_raises(ArgumentError) { Axlsx.validate_unsigned_int(-1) }
+    assert_raises(ArgumentError) { Axlsx.validate_unsigned_int('1') }
 
     # int
-    assert_nothing_raised { Axlsx.validate_int(1) }
-    assert_nothing_raised { Axlsx.validate_int(-1) }
-    assert_raise(ArgumentError) { Axlsx.validate_int('a') }
-    assert_raise(ArgumentError) { Axlsx.validate_int(Array) }
+    refute_raises { Axlsx.validate_int(1) }
+    refute_raises { Axlsx.validate_int(-1) }
+    assert_raises(ArgumentError) { Axlsx.validate_int('a') }
+    assert_raises(ArgumentError) { Axlsx.validate_int(Array) }
 
     # boolean (as 0 or 1, :true, :false, true, false, or "true," "false")
     [0, 1, :true, :false, true, false, "true", "false"].each do |v|
-      assert_nothing_raised { Axlsx.validate_boolean v }
+      refute_raises { Axlsx.validate_boolean v }
     end
-    assert_raise(ArgumentError) { Axlsx.validate_boolean 2 }
+    assert_raises(ArgumentError) { Axlsx.validate_boolean 2 }
 
     # string
-    assert_nothing_raised { Axlsx.validate_string "1" }
-    assert_raise(ArgumentError) { Axlsx.validate_string 2 }
-    assert_raise(ArgumentError) { Axlsx.validate_string false }
+    refute_raises { Axlsx.validate_string "1" }
+    assert_raises(ArgumentError) { Axlsx.validate_string 2 }
+    assert_raises(ArgumentError) { Axlsx.validate_string false }
 
     # float
-    assert_nothing_raised { Axlsx.validate_float 1.0 }
-    assert_raise(ArgumentError) { Axlsx.validate_float 2 }
-    assert_raise(ArgumentError) { Axlsx.validate_float false }
+    refute_raises { Axlsx.validate_float 1.0 }
+    assert_raises(ArgumentError) { Axlsx.validate_float 2 }
+    assert_raises(ArgumentError) { Axlsx.validate_float false }
 
     # pattern_type
-    assert_nothing_raised { Axlsx.validate_pattern_type :none }
-    assert_raise(ArgumentError) { Axlsx.validate_pattern_type "none" }
-    assert_raise(ArgumentError) { Axlsx.validate_pattern_type "crazy_pattern" }
-    assert_raise(ArgumentError) { Axlsx.validate_pattern_type false }
+    refute_raises { Axlsx.validate_pattern_type :none }
+    assert_raises(ArgumentError) { Axlsx.validate_pattern_type "none" }
+    assert_raises(ArgumentError) { Axlsx.validate_pattern_type "crazy_pattern" }
+    assert_raises(ArgumentError) { Axlsx.validate_pattern_type false }
 
     # gradient_type
-    assert_nothing_raised { Axlsx.validate_gradient_type :path }
-    assert_raise(ArgumentError) { Axlsx.validate_gradient_type nil }
-    assert_raise(ArgumentError) { Axlsx.validate_gradient_type "fractal" }
-    assert_raise(ArgumentError) { Axlsx.validate_gradient_type false }
+    refute_raises { Axlsx.validate_gradient_type :path }
+    assert_raises(ArgumentError) { Axlsx.validate_gradient_type nil }
+    assert_raises(ArgumentError) { Axlsx.validate_gradient_type "fractal" }
+    assert_raises(ArgumentError) { Axlsx.validate_gradient_type false }
 
     # horizontal alignment
-    assert_nothing_raised { Axlsx.validate_horizontal_alignment :general }
-    assert_raise(ArgumentError) { Axlsx.validate_horizontal_alignment nil }
-    assert_raise(ArgumentError) { Axlsx.validate_horizontal_alignment "wavy" }
-    assert_raise(ArgumentError) { Axlsx.validate_horizontal_alignment false }
+    refute_raises { Axlsx.validate_horizontal_alignment :general }
+    assert_raises(ArgumentError) { Axlsx.validate_horizontal_alignment nil }
+    assert_raises(ArgumentError) { Axlsx.validate_horizontal_alignment "wavy" }
+    assert_raises(ArgumentError) { Axlsx.validate_horizontal_alignment false }
 
     # vertical alignment
-    assert_nothing_raised { Axlsx.validate_vertical_alignment :top }
-    assert_raise(ArgumentError) { Axlsx.validate_vertical_alignment nil }
-    assert_raise(ArgumentError) { Axlsx.validate_vertical_alignment "dynamic" }
-    assert_raise(ArgumentError) { Axlsx.validate_vertical_alignment false }
+    refute_raises { Axlsx.validate_vertical_alignment :top }
+    assert_raises(ArgumentError) { Axlsx.validate_vertical_alignment nil }
+    assert_raises(ArgumentError) { Axlsx.validate_vertical_alignment "dynamic" }
+    assert_raises(ArgumentError) { Axlsx.validate_vertical_alignment false }
 
     # contentType
-    assert_nothing_raised { Axlsx.validate_content_type Axlsx::WORKBOOK_CT }
-    assert_raise(ArgumentError) { Axlsx.validate_content_type nil }
-    assert_raise(ArgumentError) { Axlsx.validate_content_type "http://some.url" }
-    assert_raise(ArgumentError) { Axlsx.validate_content_type false }
+    refute_raises { Axlsx.validate_content_type Axlsx::WORKBOOK_CT }
+    assert_raises(ArgumentError) { Axlsx.validate_content_type nil }
+    assert_raises(ArgumentError) { Axlsx.validate_content_type "http://some.url" }
+    assert_raises(ArgumentError) { Axlsx.validate_content_type false }
 
     # relationshipType
-    assert_nothing_raised { Axlsx.validate_relationship_type Axlsx::WORKBOOK_R }
-    assert_raise(ArgumentError) { Axlsx.validate_relationship_type nil }
-    assert_raise(ArgumentError) { Axlsx.validate_relationship_type "http://some.url" }
-    assert_raise(ArgumentError) { Axlsx.validate_relationship_type false }
+    refute_raises { Axlsx.validate_relationship_type Axlsx::WORKBOOK_R }
+    assert_raises(ArgumentError) { Axlsx.validate_relationship_type nil }
+    assert_raises(ArgumentError) { Axlsx.validate_relationship_type "http://some.url" }
+    assert_raises(ArgumentError) { Axlsx.validate_relationship_type false }
 
     # number_with_unit
-    assert_nothing_raised { Axlsx.validate_number_with_unit "210mm" }
-    assert_nothing_raised { Axlsx.validate_number_with_unit "8.5in" }
-    assert_nothing_raised { Axlsx.validate_number_with_unit "29.7cm" }
-    assert_nothing_raised { Axlsx.validate_number_with_unit "120pt" }
-    assert_nothing_raised { Axlsx.validate_number_with_unit "0pc" }
-    assert_nothing_raised { Axlsx.validate_number_with_unit "12.34pi" }
-    assert_raise(ArgumentError) { Axlsx.validate_number_with_unit nil }
-    assert_raise(ArgumentError) { Axlsx.validate_number_with_unit "210" }
-    assert_raise(ArgumentError) { Axlsx.validate_number_with_unit 210 }
-    assert_raise(ArgumentError) { Axlsx.validate_number_with_unit "mm" }
-    assert_raise(ArgumentError) { Axlsx.validate_number_with_unit "-29cm" }
+    refute_raises { Axlsx.validate_number_with_unit "210mm" }
+    refute_raises { Axlsx.validate_number_with_unit "8.5in" }
+    refute_raises { Axlsx.validate_number_with_unit "29.7cm" }
+    refute_raises { Axlsx.validate_number_with_unit "120pt" }
+    refute_raises { Axlsx.validate_number_with_unit "0pc" }
+    refute_raises { Axlsx.validate_number_with_unit "12.34pi" }
+    assert_raises(ArgumentError) { Axlsx.validate_number_with_unit nil }
+    assert_raises(ArgumentError) { Axlsx.validate_number_with_unit "210" }
+    assert_raises(ArgumentError) { Axlsx.validate_number_with_unit 210 }
+    assert_raises(ArgumentError) { Axlsx.validate_number_with_unit "mm" }
+    assert_raises(ArgumentError) { Axlsx.validate_number_with_unit "-29cm" }
 
     # scale_10_400
-    assert_nothing_raised { Axlsx.validate_scale_10_400 10 }
-    assert_nothing_raised { Axlsx.validate_scale_10_400 100 }
-    assert_nothing_raised { Axlsx.validate_scale_10_400 400 }
-    assert_raise(ArgumentError) { Axlsx.validate_scale_10_400 9 }
-    assert_raise(ArgumentError) { Axlsx.validate_scale_10_400 10.0 }
-    assert_raise(ArgumentError) { Axlsx.validate_scale_10_400 400.1 }
-    assert_raise(ArgumentError) { Axlsx.validate_scale_10_400 "99" }
+    refute_raises { Axlsx.validate_scale_10_400 10 }
+    refute_raises { Axlsx.validate_scale_10_400 100 }
+    refute_raises { Axlsx.validate_scale_10_400 400 }
+    assert_raises(ArgumentError) { Axlsx.validate_scale_10_400 9 }
+    assert_raises(ArgumentError) { Axlsx.validate_scale_10_400 10.0 }
+    assert_raises(ArgumentError) { Axlsx.validate_scale_10_400 400.1 }
+    assert_raises(ArgumentError) { Axlsx.validate_scale_10_400 "99" }
 
     # scale_0_10_400
-    assert_nothing_raised { Axlsx.validate_scale_0_10_400 0 }
-    assert_nothing_raised { Axlsx.validate_scale_0_10_400 10 }
-    assert_nothing_raised { Axlsx.validate_scale_0_10_400 100 }
-    assert_nothing_raised { Axlsx.validate_scale_0_10_400 400 }
-    assert_raise(ArgumentError) { Axlsx.validate_scale_0_10_400 9 }
-    assert_raise(ArgumentError) { Axlsx.validate_scale_0_10_400 10.0 }
-    assert_raise(ArgumentError) { Axlsx.validate_scale_0_10_400 400.1 }
-    assert_raise(ArgumentError) { Axlsx.validate_scale_0_10_400 "99" }
+    refute_raises { Axlsx.validate_scale_0_10_400 0 }
+    refute_raises { Axlsx.validate_scale_0_10_400 10 }
+    refute_raises { Axlsx.validate_scale_0_10_400 100 }
+    refute_raises { Axlsx.validate_scale_0_10_400 400 }
+    assert_raises(ArgumentError) { Axlsx.validate_scale_0_10_400 9 }
+    assert_raises(ArgumentError) { Axlsx.validate_scale_0_10_400 10.0 }
+    assert_raises(ArgumentError) { Axlsx.validate_scale_0_10_400 400.1 }
+    assert_raises(ArgumentError) { Axlsx.validate_scale_0_10_400 "99" }
 
     # page_orientation
-    assert_nothing_raised { Axlsx.validate_page_orientation :default }
-    assert_nothing_raised { Axlsx.validate_page_orientation :landscape }
-    assert_nothing_raised { Axlsx.validate_page_orientation :portrait }
-    assert_raise(ArgumentError) { Axlsx.validate_page_orientation nil }
-    assert_raise(ArgumentError) { Axlsx.validate_page_orientation 1 }
-    assert_raise(ArgumentError) { Axlsx.validate_page_orientation "landscape" }
+    refute_raises { Axlsx.validate_page_orientation :default }
+    refute_raises { Axlsx.validate_page_orientation :landscape }
+    refute_raises { Axlsx.validate_page_orientation :portrait }
+    assert_raises(ArgumentError) { Axlsx.validate_page_orientation nil }
+    assert_raises(ArgumentError) { Axlsx.validate_page_orientation 1 }
+    assert_raises(ArgumentError) { Axlsx.validate_page_orientation "landscape" }
 
     # data_validation_error_style
     [:information, :stop, :warning].each do |sym|
-      assert_nothing_raised { Axlsx.validate_data_validation_error_style sym }
+      refute_raises { Axlsx.validate_data_validation_error_style sym }
     end
-    assert_raise(ArgumentError) { Axlsx.validate_data_validation_error_style :other_symbol }
-    assert_raise(ArgumentError) { Axlsx.validate_data_validation_error_style 'warning' }
-    assert_raise(ArgumentError) { Axlsx.validate_data_validation_error_style 0 }
+    assert_raises(ArgumentError) { Axlsx.validate_data_validation_error_style :other_symbol }
+    assert_raises(ArgumentError) { Axlsx.validate_data_validation_error_style 'warning' }
+    assert_raises(ArgumentError) { Axlsx.validate_data_validation_error_style 0 }
 
     # data_validation_operator
     [:lessThan, :lessThanOrEqual, :equal, :notEqual, :greaterThanOrEqual, :greaterThan, :between, :notBetween].each do |sym|
-      assert_nothing_raised { Axlsx.validate_data_validation_operator sym }
+      refute_raises { Axlsx.validate_data_validation_operator sym }
     end
-    assert_raise(ArgumentError) { Axlsx.validate_data_validation_error_style :other_symbol }
-    assert_raise(ArgumentError) { Axlsx.validate_data_validation_error_style 'lessThan' }
-    assert_raise(ArgumentError) { Axlsx.validate_data_validation_error_style 0 }
+    assert_raises(ArgumentError) { Axlsx.validate_data_validation_error_style :other_symbol }
+    assert_raises(ArgumentError) { Axlsx.validate_data_validation_error_style 'lessThan' }
+    assert_raises(ArgumentError) { Axlsx.validate_data_validation_error_style 0 }
 
     # data_validation_type
     [:custom, :data, :decimal, :list, :none, :textLength, :date, :time, :whole].each do |sym|
-      assert_nothing_raised { Axlsx.validate_data_validation_type sym }
+      refute_raises { Axlsx.validate_data_validation_type sym }
     end
-    assert_raise(ArgumentError) { Axlsx.validate_data_validation_error_style :other_symbol }
-    assert_raise(ArgumentError) { Axlsx.validate_data_validation_error_style 'decimal' }
-    assert_raise(ArgumentError) { Axlsx.validate_data_validation_error_style 0 }
+    assert_raises(ArgumentError) { Axlsx.validate_data_validation_error_style :other_symbol }
+    assert_raises(ArgumentError) { Axlsx.validate_data_validation_error_style 'decimal' }
+    assert_raises(ArgumentError) { Axlsx.validate_data_validation_error_style 0 }
 
     # sheet_view_type
     [:normal, :page_break_preview, :page_layout].each do |sym|
-      assert_nothing_raised { Axlsx.validate_sheet_view_type sym }
+      refute_raises { Axlsx.validate_sheet_view_type sym }
     end
-    assert_raise(ArgumentError) { Axlsx.validate_data_validation_error_style :other_symbol }
-    assert_raise(ArgumentError) { Axlsx.validate_data_validation_error_style 'page_layout' }
-    assert_raise(ArgumentError) { Axlsx.validate_data_validation_error_style 0 }
+    assert_raises(ArgumentError) { Axlsx.validate_data_validation_error_style :other_symbol }
+    assert_raises(ArgumentError) { Axlsx.validate_data_validation_error_style 'page_layout' }
+    assert_raises(ArgumentError) { Axlsx.validate_data_validation_error_style 0 }
 
     # active_pane_type
     [:bottom_left, :bottom_right, :top_left, :top_right].each do |sym|
-      assert_nothing_raised { Axlsx.validate_pane_type sym }
+      refute_raises { Axlsx.validate_pane_type sym }
     end
-    assert_raise(ArgumentError) { Axlsx.validate_pane_type :other_symbol }
-    assert_raise(ArgumentError) { Axlsx.validate_pane_type 'bottom_left' }
-    assert_raise(ArgumentError) { Axlsx.validate_pane_type 0 }
+    assert_raises(ArgumentError) { Axlsx.validate_pane_type :other_symbol }
+    assert_raises(ArgumentError) { Axlsx.validate_pane_type 'bottom_left' }
+    assert_raises(ArgumentError) { Axlsx.validate_pane_type 0 }
 
     # split_state_type
     [:frozen, :frozen_split, :split].each do |sym|
-      assert_nothing_raised { Axlsx.validate_split_state_type sym }
+      refute_raises { Axlsx.validate_split_state_type sym }
     end
-    assert_raise(ArgumentError) { Axlsx.validate_split_state_type :other_symbol }
-    assert_raise(ArgumentError) { Axlsx.validate_split_state_type 'frozen_split' }
-    assert_raise(ArgumentError) { Axlsx.validate_split_state_type 0 }
+    assert_raises(ArgumentError) { Axlsx.validate_split_state_type :other_symbol }
+    assert_raises(ArgumentError) { Axlsx.validate_split_state_type 'frozen_split' }
+    assert_raises(ArgumentError) { Axlsx.validate_split_state_type 0 }
 
     # display_blanks_as
     [:gap, :span, :zero].each do |sym|
-      assert_nothing_raised { Axlsx.validate_display_blanks_as sym }
+      refute_raises { Axlsx.validate_display_blanks_as sym }
     end
-    assert_raise(ArgumentError) { Axlsx.validate_display_blanks_as :other_symbol }
-    assert_raise(ArgumentError) { Axlsx.validate_display_blanks_as 'other_blank' }
-    assert_raise(ArgumentError) { Axlsx.validate_display_blanks_as 0 }
+    assert_raises(ArgumentError) { Axlsx.validate_display_blanks_as :other_symbol }
+    assert_raises(ArgumentError) { Axlsx.validate_display_blanks_as 'other_blank' }
+    assert_raises(ArgumentError) { Axlsx.validate_display_blanks_as 0 }
 
     # view_visibility
     [:visible, :hidden, :very_hidden].each do |sym|
-      assert_nothing_raised { Axlsx.validate_view_visibility sym }
+      refute_raises { Axlsx.validate_view_visibility sym }
     end
-    assert_raise(ArgumentError) { Axlsx.validate_view_visibility :other_symbol }
-    assert_raise(ArgumentError) { Axlsx.validate_view_visibility 'other_visibility' }
-    assert_raise(ArgumentError) { Axlsx.validate_view_visibility 0 }
+    assert_raises(ArgumentError) { Axlsx.validate_view_visibility :other_symbol }
+    assert_raises(ArgumentError) { Axlsx.validate_view_visibility 'other_visibility' }
+    assert_raises(ArgumentError) { Axlsx.validate_view_visibility 0 }
 
     # marker_symbol
     [:default, :circle, :dash, :diamond, :dot, :picture, :plus, :square, :star, :triangle, :x].each do |sym|
-      assert_nothing_raised { Axlsx.validate_marker_symbol sym }
+      refute_raises { Axlsx.validate_marker_symbol sym }
     end
-    assert_raise(ArgumentError) { Axlsx.validate_marker_symbol :other_symbol }
-    assert_raise(ArgumentError) { Axlsx.validate_marker_symbol 'other_marker' }
-    assert_raise(ArgumentError) { Axlsx.validate_marker_symbol 0 }
+    assert_raises(ArgumentError) { Axlsx.validate_marker_symbol :other_symbol }
+    assert_raises(ArgumentError) { Axlsx.validate_marker_symbol 'other_marker' }
+    assert_raises(ArgumentError) { Axlsx.validate_marker_symbol 0 }
   end
 
   def test_validate_integerish
-    assert_raise(ArgumentError) { Axlsx.validate_integerish Axlsx }
-    [1, 1.4, "a"].each { |test_value| assert_nothing_raised { Axlsx.validate_integerish test_value } }
+    assert_raises(ArgumentError) { Axlsx.validate_integerish Axlsx }
+    [1, 1.4, "a"].each { |test_value| refute_raises { Axlsx.validate_integerish test_value } }
   end
 
   def test_validate_family
-    assert_raise(ArgumentError) { Axlsx.validate_family 0 }
+    assert_raises(ArgumentError) { Axlsx.validate_family 0 }
     (1..5).each do |item|
-      assert_nothing_raised { Axlsx.validate_family item }
+      refute_raises { Axlsx.validate_family item }
     end
   end
 
   def test_validate_u
-    assert_raise(ArgumentError) { Axlsx.validate_cell_u :hoge }
+    assert_raises(ArgumentError) { Axlsx.validate_cell_u :hoge }
     [:none, :single, :double, :singleAccounting, :doubleAccounting].each do |sym|
-      assert_nothing_raised { Axlsx.validate_cell_u sym }
+      refute_raises { Axlsx.validate_cell_u sym }
     end
   end
 
   def test_range_validation
     # exclusive
-    assert_raise(ArgumentError) { Axlsx::RangeValidator.validate('foo', 1, 10, 10, false) }
+    assert_raises(ArgumentError) { Axlsx::RangeValidator.validate('foo', 1, 10, 10, false) }
     # inclusive by default
-    assert_nothing_raised { Axlsx::RangeValidator.validate('foo', 1, 10, 10) }
+    refute_raises { Axlsx::RangeValidator.validate('foo', 1, 10, 10) }
   end
 end

--- a/test/workbook/tc_defined_name.rb
+++ b/test/workbook/tc_defined_name.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestDefinedNames < Test::Unit::TestCase
+class TestDefinedNames < Minitest::Test
   def setup
     @dn = Axlsx::DefinedName.new('Sheet1!A1:A1')
   end
@@ -13,21 +13,21 @@ class TestDefinedNames < Test::Unit::TestCase
 
   def test_string_attributes
     %w(short_cut_key status_bar help description custom_menu comment).each do |attr|
-      assert_raise(ArgumentError, 'only strings allowed in string attributes') { @dn.send(:"#{attr}=", 1) }
-      assert_nothing_raised { @dn.send(:"#{attr}=", '_xlnm.Sheet_Title') }
+      assert_raises(ArgumentError, 'only strings allowed in string attributes') { @dn.send(:"#{attr}=", 1) }
+      refute_raises { @dn.send(:"#{attr}=", '_xlnm.Sheet_Title') }
     end
   end
 
   def test_boolean_attributes
     %w(workbook_parameter publish_to_server xlm vb_proceedure function hidden).each do |attr|
-      assert_raise(ArgumentError, 'only booleanish allowed in string attributes') { @dn.send(:"#{attr}=", 'foo') }
-      assert_nothing_raised { @dn.send(:"#{attr}=", 1) }
+      assert_raises(ArgumentError, 'only booleanish allowed in string attributes') { @dn.send(:"#{attr}=", 'foo') }
+      refute_raises { @dn.send(:"#{attr}=", 1) }
     end
   end
 
   def test_local_sheet_id
-    assert_raise(ArgumentError, 'local_sheet_id must be an unsigned int') { @dn.local_sheet_id = -1 }
-    assert_nothing_raised { @dn.local_sheet_id = 1 }
+    assert_raises(ArgumentError, 'local_sheet_id must be an unsigned int') { @dn.local_sheet_id = -1 }
+    refute_raises { @dn.local_sheet_id = 1 }
   end
 
   def test_do_not_camelcase_value_for_name
@@ -39,7 +39,7 @@ class TestDefinedNames < Test::Unit::TestCase
   end
 
   def test_to_xml_string
-    assert_raise(ArgumentError, 'name is required for serialization') { @dn.to_xml_string }
+    assert_raises(ArgumentError, 'name is required for serialization') { @dn.to_xml_string }
     @dn.name = '_xlnm.Print_Titles'
     @dn.hidden = true
     doc = Nokogiri::XML(@dn.to_xml_string)

--- a/test/workbook/tc_shared_strings_table.rb
+++ b/test/workbook/tc_shared_strings_table.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestSharedStringsTable < Test::Unit::TestCase
+class TestSharedStringsTable < Minitest::Test
   def setup
     @p = Axlsx::Package.new use_shared_strings: true
 
@@ -52,9 +52,9 @@ class TestSharedStringsTable < Test::Unit::TestCase
     assert @p.workbook.shared_strings.unique_cells.key?(nasties)
 
     # test that none of the control characters are in the XML output for shared strings
-    assert_no_match(/#{Axlsx::CONTROL_CHARS}/o, @p.workbook.shared_strings.to_xml_string)
+    refute_match(/#{Axlsx::CONTROL_CHARS}/o, @p.workbook.shared_strings.to_xml_string)
 
     # assert that the shared string was normalized to remove the control characters
-    assert_not_nil @p.workbook.shared_strings.to_xml_string.index("helloworld")
+    refute_nil @p.workbook.shared_strings.to_xml_string.index("helloworld")
   end
 end

--- a/test/workbook/tc_workbook.rb
+++ b/test/workbook/tc_workbook.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestWorkbook < Test::Unit::TestCase
+class TestWorkbook < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @wb = p.workbook
@@ -27,20 +27,20 @@ class TestWorkbook < Test::Unit::TestCase
     @wb.xml_space = :default
 
     assert_equal(:default, @wb.xml_space)
-    assert_raise(ArgumentError) { @wb.xml_space = :none }
+    assert_raises(ArgumentError) { @wb.xml_space = :none }
   end
 
   def test_no_autowidth
     assert(@wb.use_autowidth)
-    assert_raise(ArgumentError) { @wb.use_autowidth = 0.1 }
-    assert_nothing_raised { @wb.use_autowidth = false }
-    refute(@wb.use_autowidth)
+    assert_raises(ArgumentError) { @wb.use_autowidth = 0.1 }
+    refute_raises { @wb.use_autowidth = false }
+    assert_false(@wb.use_autowidth)
   end
 
   def test_is_reversed
     assert_nil(@wb.is_reversed)
-    assert_raise(ArgumentError) { @wb.is_reversed = 0.1 }
-    assert_nothing_raised { @wb.is_reversed = true }
+    assert_raises(ArgumentError) { @wb.is_reversed = 0.1 }
+    refute_raises { @wb.is_reversed = true }
     assert(@wb.use_autowidth)
   end
 
@@ -54,7 +54,7 @@ class TestWorkbook < Test::Unit::TestCase
   end
 
   def test_worksheet_empty_name
-    assert_raise(ArgumentError) { @wb.add_worksheet(name: '') }
+    assert_raises(ArgumentError) { @wb.add_worksheet(name: '') }
   end
 
   def test_date1904
@@ -81,8 +81,8 @@ class TestWorkbook < Test::Unit::TestCase
 
   def test_shared_strings
     assert_nil(@wb.use_shared_strings)
-    assert_raise(ArgumentError) { @wb.use_shared_strings = 'bpb' }
-    assert_nothing_raised { @wb.use_shared_strings = :true }
+    assert_raises(ArgumentError) { @wb.use_shared_strings = 'bpb' }
+    refute_raises { @wb.use_shared_strings = :true }
   end
 
   def test_add_worksheet
@@ -134,7 +134,7 @@ class TestWorkbook < Test::Unit::TestCase
     ws = @wb.add_worksheet name: 'fish'
     ws.add_row [1, 2, 3]
     ws.add_row [4, 5, 6]
-    assert_raise(ArgumentError, "no sheet name part") { @wb["A1:C2"] }
+    assert_raises(ArgumentError, "no sheet name part") { @wb["A1:C2"] }
     assert_equal(6, @wb['fish!A1:C2'].size)
   end
 

--- a/test/workbook/tc_workbook_view.rb
+++ b/test/workbook/tc_workbook_view.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestWorkbookView < Test::Unit::TestCase
+class TestWorkbookView < Minitest::Test
   def setup
     @options = { visibility: :hidden, minimized: true, show_horizontal_scroll: true, show_vertical_scroll: true,
                  show_sheet_tabs: true, tab_ratio: 750, first_sheet: 0, active_tab: 1, x_window: 500, y_window: 400,
@@ -18,23 +18,23 @@ class TestWorkbookView < Test::Unit::TestCase
 
   def test_boolean_attribute_validation
     %w(minimized show_horizontal_scroll show_vertical_scroll show_sheet_tabs auto_filter_date_grouping).each do |attr|
-      assert_raise(ArgumentError, 'only booleanish allowed in boolean attributes') { @book_view.send(:"#{attr}=", "banana") }
-      assert_nothing_raised { @book_view.send(:"#{attr}=", false) }
+      assert_raises(ArgumentError, 'only booleanish allowed in boolean attributes') { @book_view.send(:"#{attr}=", "banana") }
+      refute_raises { @book_view.send(:"#{attr}=", false) }
     end
   end
 
   def test_integer_attribute_validation
     %w(tab_ratio first_sheet active_tab x_window y_window window_width window_height).each do |attr|
-      assert_raise(ArgumentError, 'only integer allowed in integer attributes') { @book_view.send(:"#{attr}=", "b") }
-      assert_nothing_raised { @book_view.send(:"#{attr}=", 7) }
+      assert_raises(ArgumentError, 'only integer allowed in integer attributes') { @book_view.send(:"#{attr}=", "b") }
+      refute_raises { @book_view.send(:"#{attr}=", 7) }
     end
   end
 
   def test_visibility_attribute_validation
-    assert_raise(ArgumentError) { @book_view.visibility = :foobar }
-    assert_nothing_raised { @book_view.visibility = :hidden }
-    assert_nothing_raised { @book_view.visibility = :very_hidden }
-    assert_nothing_raised { @book_view.visibility = :visible }
+    assert_raises(ArgumentError) { @book_view.visibility = :foobar }
+    refute_raises { @book_view.visibility = :hidden }
+    refute_raises { @book_view.visibility = :very_hidden }
+    refute_raises { @book_view.visibility = :visible }
   end
 
   def test_to_xml_string

--- a/test/workbook/worksheet/auto_filter/tc_auto_filter.rb
+++ b/test/workbook/worksheet/auto_filter/tc_auto_filter.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestAutoFilter < Test::Unit::TestCase
+class TestAutoFilter < Minitest::Test
   def setup
     ws = Axlsx::Package.new.workbook.add_worksheet
     3.times { |index| ws.add_row [1 * index, 2 * index, 3 * index] }

--- a/test/workbook/worksheet/auto_filter/tc_filter_column.rb
+++ b/test/workbook/worksheet/auto_filter/tc_filter_column.rb
@@ -2,16 +2,16 @@
 
 require 'tc_helper'
 
-class TestFilterColumn < Test::Unit::TestCase
+class TestFilterColumn < Minitest::Test
   def setup
     @filter_column = Axlsx::FilterColumn.new(0, :filters, filter_items: [200])
   end
 
   def test_initialize_col_id
-    assert_raise ArgumentError do
+    assert_raises ArgumentError do
       Axlsx::FilterColumn.new(0, :bobs_house_of_filter)
     end
-    assert_raise ArgumentError do
+    assert_raises ArgumentError do
       Axlsx::FilterColumn.new(:penut, :filters)
     end
   end
@@ -40,30 +40,30 @@ class TestFilterColumn < Test::Unit::TestCase
   end
 
   def test_default_hidden_button
-    refute @filter_column.hidden_button
+    assert_false @filter_column.hidden_button
   end
 
   def test_show_button
-    assert_raise ArgumentError do
+    assert_raises ArgumentError do
       @filter_column.show_button = :foo
     end
-    assert_nothing_raised { @filter_column.show_button = false }
-    refute @filter_column.show_button
+    refute_raises { @filter_column.show_button = false }
+    assert_false @filter_column.show_button
   end
 
   def test_hidden_button
-    assert_raise ArgumentError do
+    assert_raises ArgumentError do
       @filter_column.hidden_button = :hoge
     end
-    assert_nothing_raised { @filter_column.hidden_button = true }
+    refute_raises { @filter_column.hidden_button = true }
     assert @filter_column.hidden_button
   end
 
   def test_col_id=
-    assert_raise ArgumentError do
+    assert_raises ArgumentError do
       @filter_column.col_id = :bar
     end
-    assert_nothing_raised { @filter_column.col_id = 7 }
+    refute_raises { @filter_column.col_id = 7 }
   end
 
   def test_to_xml_string

--- a/test/workbook/worksheet/auto_filter/tc_filters.rb
+++ b/test/workbook/worksheet/auto_filter/tc_filters.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestFilters < Test::Unit::TestCase
+class TestFilters < Minitest::Test
   def setup
     @filters = Axlsx::Filters.new(filter_items: [1, 'a'],
                                   date_group_items: [{ date_time_grouping: :year, year: 2011, month: 11, day: 11, hour: 0, minute: 0, second: 0 }],
@@ -11,14 +11,14 @@ class TestFilters < Test::Unit::TestCase
 
   def test_blank
     assert @filters.blank
-    assert_raise(ArgumentError) { @filters.blank = :only_if_you_want_it }
+    assert_raises(ArgumentError) { @filters.blank = :only_if_you_want_it }
     @filters.blank = true
 
     assert @filters.blank
   end
 
   def test_calendar_type
-    assert_raise(ArgumentError) { @filters.calendar_type = 'monkey calendar' }
+    assert_raises(ArgumentError) { @filters.calendar_type = 'monkey calendar' }
     @filters.calendar_type = 'japan'
 
     assert_equal('japan', @filters.calendar_type)
@@ -40,7 +40,7 @@ class TestFilters < Test::Unit::TestCase
       'a'
     end
 
-    refute @filters.apply(keeper)
+    assert_false @filters.apply(keeper)
   end
 
   def test_apply_is_true_for_non_matching_values

--- a/test/workbook/worksheet/auto_filter/tc_sort_condition.rb
+++ b/test/workbook/worksheet/auto_filter/tc_sort_condition.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestSortCondition < Test::Unit::TestCase
+class TestSortCondition < Minitest::Test
   def setup
     ws = Axlsx::Package.new.workbook.add_worksheet
     ws.add_row ['first', 'second', 'third']

--- a/test/workbook/worksheet/auto_filter/tc_sort_state.rb
+++ b/test/workbook/worksheet/auto_filter/tc_sort_state.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestSortState < Test::Unit::TestCase
+class TestSortState < Minitest::Test
   def setup
     ws = Axlsx::Package.new.workbook.add_worksheet
     ws.add_row ['first', 'second', 'third']

--- a/test/workbook/worksheet/tc_border_creator.rb
+++ b/test/workbook/worksheet/tc_border_creator.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestBorderCreator < Test::Unit::TestCase
+class TestBorderCreator < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     @wb = @p.workbook

--- a/test/workbook/worksheet/tc_break.rb
+++ b/test/workbook/worksheet/tc_break.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestBreak < Test::Unit::TestCase
+class TestBreak < Minitest::Test
   def setup
     @break = Axlsx::Break.new(id: 1, min: 1, max: 10, man: true, pt: false)
   end
@@ -36,7 +36,7 @@ class TestBreak < Test::Unit::TestCase
   end
 
   def test_pt
-    refute(@break.pt)
+    assert_false(@break.pt)
     assert_raises ArgumentError do
       Axlsx::Break.new(pt: -1)
     end

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestCell < Test::Unit::TestCase
+class TestCell < Minitest::Test
   def setup
     p = Axlsx::Package.new
     p.use_shared_strings = true
@@ -99,14 +99,14 @@ class TestCell < Test::Unit::TestCase
   end
 
   def test_style
-    assert_raise(ArgumentError, "must reject invalid style indexes") { @c.style = @c.row.worksheet.workbook.styles.cellXfs.size }
-    assert_nothing_raised("must allow valid style index changes") { @c.style = 1 }
+    assert_raises(ArgumentError, "must reject invalid style indexes") { @c.style = @c.row.worksheet.workbook.styles.cellXfs.size }
+    refute_raises { @c.style = 1 }
     assert_equal(1, @c.style)
   end
 
   def test_type
-    assert_raise(ArgumentError, "type must be :string, :integer, :float, :date, :time, :boolean") { @c.type = :array }
-    assert_nothing_raised("type can be changed") { @c.type = :string }
+    assert_raises(ArgumentError, "type must be :string, :integer, :float, :date, :time, :boolean") { @c.type = :array }
+    refute_raises { @c.type = :string }
     assert_equal("1.0", @c.value, "changing type casts the value")
     assert_equal(:float, @row.add_cell(1.0 / (10**7)).type, 'properly identify exponential floats as float type')
     assert_equal(:time, @row.add_cell(Time.now).type, 'time should be time')
@@ -115,8 +115,8 @@ class TestCell < Test::Unit::TestCase
   end
 
   def test_value
-    assert_raise(ArgumentError, "type must be :string, :integer, :float, :date, :time, :boolean") { @c.type = :array }
-    assert_nothing_raised("type can be changed") { @c.type = :string }
+    assert_raises(ArgumentError, "type must be :string, :integer, :float, :date, :time, :boolean") { @c.type = :array }
+    refute_raises { @c.type = :string }
     assert_equal("1.0", @c.value, "changing type casts the value")
   end
 
@@ -215,63 +215,63 @@ class TestCell < Test::Unit::TestCase
   end
 
   def test_color
-    assert_raise(ArgumentError) { @c.color = -1.1 }
-    assert_nothing_raised { @c.color = "FF00FF00" }
+    assert_raises(ArgumentError) { @c.color = -1.1 }
+    refute_raises { @c.color = "FF00FF00" }
     assert_equal("FF00FF00", @c.color.rgb)
   end
 
   def test_scheme
-    assert_raise(ArgumentError) { @c.scheme = -1.1 }
-    assert_nothing_raised { @c.scheme = :major }
+    assert_raises(ArgumentError) { @c.scheme = -1.1 }
+    refute_raises { @c.scheme = :major }
     assert_equal(:major, @c.scheme)
   end
 
   def test_vertAlign
-    assert_raise(ArgumentError) { @c.vertAlign = -1.1 }
-    assert_nothing_raised { @c.vertAlign = :baseline }
+    assert_raises(ArgumentError) { @c.vertAlign = -1.1 }
+    refute_raises { @c.vertAlign = :baseline }
     assert_equal(:baseline, @c.vertAlign)
   end
 
   def test_sz
-    assert_raise(ArgumentError) { @c.sz = -1.1 }
-    assert_nothing_raised { @c.sz = 12 }
+    assert_raises(ArgumentError) { @c.sz = -1.1 }
+    refute_raises { @c.sz = 12 }
     assert_equal(12, @c.sz)
   end
 
   def test_extend
-    assert_raise(ArgumentError) { @c.extend = -1.1 }
-    assert_nothing_raised { @c.extend = false }
-    refute(@c.extend)
+    assert_raises(ArgumentError) { @c.extend = -1.1 }
+    refute_raises { @c.extend = false }
+    assert_false(@c.extend)
   end
 
   def test_condense
-    assert_raise(ArgumentError) { @c.condense = -1.1 }
-    assert_nothing_raised { @c.condense = false }
-    refute(@c.condense)
+    assert_raises(ArgumentError) { @c.condense = -1.1 }
+    refute_raises { @c.condense = false }
+    assert_false(@c.condense)
   end
 
   def test_shadow
-    assert_raise(ArgumentError) { @c.shadow = -1.1 }
-    assert_nothing_raised { @c.shadow = false }
-    refute(@c.shadow)
+    assert_raises(ArgumentError) { @c.shadow = -1.1 }
+    refute_raises { @c.shadow = false }
+    assert_false(@c.shadow)
   end
 
   def test_outline
-    assert_raise(ArgumentError) { @c.outline = -1.1 }
-    assert_nothing_raised { @c.outline = false }
-    refute(@c.outline)
+    assert_raises(ArgumentError) { @c.outline = -1.1 }
+    refute_raises { @c.outline = false }
+    assert_false(@c.outline)
   end
 
   def test_strike
-    assert_raise(ArgumentError) { @c.strike = -1.1 }
-    assert_nothing_raised { @c.strike = false }
-    refute(@c.strike)
+    assert_raises(ArgumentError) { @c.strike = -1.1 }
+    refute_raises { @c.strike = false }
+    assert_false(@c.strike)
   end
 
   def test_u
     @c.type = :string
-    assert_raise(ArgumentError) { @c.u = -1.1 }
-    assert_nothing_raised { @c.u = :single }
+    assert_raises(ArgumentError) { @c.u = -1.1 }
+    refute_raises { @c.u = :single }
     assert_equal(:single, @c.u)
     doc = Nokogiri::XML(@c.to_xml_string(1, 1))
 
@@ -279,33 +279,33 @@ class TestCell < Test::Unit::TestCase
   end
 
   def test_i
-    assert_raise(ArgumentError) { @c.i = -1.1 }
-    assert_nothing_raised { @c.i = false }
-    refute(@c.i)
+    assert_raises(ArgumentError) { @c.i = -1.1 }
+    refute_raises { @c.i = false }
+    assert_false(@c.i)
   end
 
   def test_rFont
-    assert_raise(ArgumentError) { @c.font_name = -1.1 }
-    assert_nothing_raised { @c.font_name = "Arial" }
+    assert_raises(ArgumentError) { @c.font_name = -1.1 }
+    refute_raises { @c.font_name = "Arial" }
     assert_equal("Arial", @c.font_name)
   end
 
   def test_charset
-    assert_raise(ArgumentError) { @c.charset = -1.1 }
-    assert_nothing_raised { @c.charset = 1 }
+    assert_raises(ArgumentError) { @c.charset = -1.1 }
+    refute_raises { @c.charset = 1 }
     assert_equal(1, @c.charset)
   end
 
   def test_family
-    assert_raise(ArgumentError) { @c.family = -1.1 }
-    assert_nothing_raised { @c.family = 5 }
+    assert_raises(ArgumentError) { @c.family = -1.1 }
+    refute_raises { @c.family = 5 }
     assert_equal(5, @c.family)
   end
 
   def test_b
-    assert_raise(ArgumentError) { @c.b = -1.1 }
-    assert_nothing_raised { @c.b = false }
-    refute(@c.b)
+    assert_raises(ArgumentError) { @c.b = -1.1 }
+    refute_raises { @c.b = false }
+    assert_false(@c.b)
   end
 
   def test_merge_with_string
@@ -333,7 +333,7 @@ class TestCell < Test::Unit::TestCase
   end
 
   def test_ssti
-    assert_raise(ArgumentError, "ssti must be an unsigned integer!") { @c.send(:ssti=, -1) }
+    assert_raises(ArgumentError, "ssti must be an unsigned integer!") { @c.send(:ssti=, -1) }
     @c.send :ssti=, 1
 
     assert_equal(1, @c.ssti)

--- a/test/workbook/worksheet/tc_cfvo.rb
+++ b/test/workbook/worksheet/tc_cfvo.rb
@@ -2,27 +2,27 @@
 
 require 'tc_helper'
 
-class TestCfvo < Test::Unit::TestCase
+class TestCfvo < Minitest::Test
   def setup
     @cfvo = Axlsx::Cfvo.new(val: "0", type: :min)
   end
 
   def test_val
-    assert_nothing_raised { @cfvo.val = "abc" }
+    refute_raises { @cfvo.val = "abc" }
     assert_equal("abc", @cfvo.val)
   end
 
   def test_type
-    assert_raise(ArgumentError) { @cfvo.type = :invalid_type }
-    assert_nothing_raised { @cfvo.type = :max }
+    assert_raises(ArgumentError) { @cfvo.type = :invalid_type }
+    refute_raises { @cfvo.type = :max }
     assert_equal(:max, @cfvo.type)
   end
 
   def test_gte
-    assert_raise(ArgumentError) { @cfvo.gte = :bob }
+    assert_raises(ArgumentError) { @cfvo.gte = :bob }
     assert(@cfvo.gte)
-    assert_nothing_raised { @cfvo.gte = false }
-    refute(@cfvo.gte)
+    refute_raises { @cfvo.gte = false }
+    assert_false(@cfvo.gte)
   end
 
   def test_to_xml_string

--- a/test/workbook/worksheet/tc_col.rb
+++ b/test/workbook/worksheet/tc_col.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestCol < Test::Unit::TestCase
+class TestCol < Minitest::Test
   def setup
     @col = Axlsx::Col.new 1, 1
   end
@@ -16,14 +16,14 @@ class TestCol < Test::Unit::TestCase
   end
 
   def test_min_max_required
-    assert_raise(ArgumentError, 'min and max must be specified when creating a new column') { Axlsx::Col.new }
-    assert_raise(ArgumentError, 'min and max must be specified when creating a new column') { Axlsx::Col.new nil, nil }
-    assert_nothing_raised { Axlsx::Col.new 1, 1 }
+    assert_raises(ArgumentError, 'min and max must be specified when creating a new column') { Axlsx::Col.new }
+    assert_raises(ArgumentError, 'min and max must be specified when creating a new column') { Axlsx::Col.new nil, nil }
+    refute_raises { Axlsx::Col.new 1, 1 }
   end
 
   def test_bestFit
     assert_nil(@col.bestFit)
-    assert_raise(NoMethodError, 'bestFit is read only') { @col.bestFit = 'bob' }
+    assert_raises(NoMethodError, 'bestFit is read only') { @col.bestFit = 'bob' }
     @col.width = 1.999
 
     assert(@col.bestFit, 'bestFit should be true when width has been set')
@@ -31,14 +31,14 @@ class TestCol < Test::Unit::TestCase
 
   def test_collapsed
     assert_nil(@col.collapsed)
-    assert_raise(ArgumentError, 'collapsed must be boolean(ish)') { @col.collapsed = 'bob' }
-    assert_nothing_raised('collapsed must be boolean(ish)') { @col.collapsed = true }
+    assert_raises(ArgumentError, 'collapsed must be boolean(ish)') { @col.collapsed = 'bob' }
+    refute_raises { @col.collapsed = true }
   end
 
   def test_customWidth
     assert_nil(@col.customWidth)
     @col.width = 3
-    assert_raise(NoMethodError, 'customWidth is read only') { @col.customWidth = 3 }
+    assert_raises(NoMethodError, 'customWidth is read only') { @col.customWidth = 3 }
     assert(@col.customWidth, 'customWidth is true when width is set')
   end
 
@@ -62,21 +62,21 @@ class TestCol < Test::Unit::TestCase
 
   def test_hidden
     assert_nil(@col.hidden)
-    assert_raise(ArgumentError, 'hidden must be boolean(ish)') { @col.hidden = 'bob' }
-    assert_nothing_raised(ArgumentError, 'hidden must be boolean(ish)') { @col.hidden = true }
+    assert_raises(ArgumentError, 'hidden must be boolean(ish)') { @col.hidden = 'bob' }
+    refute_raises { @col.hidden = true }
   end
 
   def test_outlineLevel
     assert_nil(@col.outlineLevel)
-    assert_raise(ArgumentError, 'outline level cannot be negative') { @col.outlineLevel = -1 }
-    assert_raise(ArgumentError, 'outline level cannot be greater than 7') { @col.outlineLevel = 8 }
-    assert_nothing_raised('can set outlineLevel') { @col.outlineLevel = 1 }
+    assert_raises(ArgumentError, 'outline level cannot be negative') { @col.outlineLevel = -1 }
+    assert_raises(ArgumentError, 'outline level cannot be greater than 7') { @col.outlineLevel = 8 }
+    refute_raises { @col.outlineLevel = 1 }
   end
 
   def test_phonetic
     assert_nil(@col.phonetic)
-    assert_raise(ArgumentError, 'phonetic must be boolean(ish)') { @col.phonetic = 'bob' }
-    assert_nothing_raised(ArgumentError, 'phonetic must be boolean(ish)') { @col.phonetic = true }
+    assert_raises(ArgumentError, 'phonetic must be boolean(ish)') { @col.phonetic = 'bob' }
+    refute_raises { @col.phonetic = true }
   end
 
   def test_to_xml_string

--- a/test/workbook/worksheet/tc_color_scale.rb
+++ b/test/workbook/worksheet/tc_color_scale.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestColorScale < Test::Unit::TestCase
+class TestColorScale < Minitest::Test
   def setup
     @color_scale = Axlsx::ColorScale.new
   end
@@ -52,7 +52,7 @@ class TestColorScale < Test::Unit::TestCase
 
   def test_delete_at
     @color_scale.add type: :max, val: 5, color: "FFDEDEDE"
-    assert_nothing_raised { @color_scale.delete_at 2 }
+    refute_raises { @color_scale.delete_at 2 }
     assert_equal(2, @color_scale.value_objects.size)
     assert_equal(2, @color_scale.colors.size)
   end

--- a/test/workbook/worksheet/tc_comment.rb
+++ b/test/workbook/worksheet/tc_comment.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestComment < Test::Unit::TestCase
+class TestComment < Minitest::Test
   def setup
     p = Axlsx::Package.new
     wb = p.workbook
@@ -12,7 +12,7 @@ class TestComment < Test::Unit::TestCase
   end
 
   def test_initailize
-    assert_raise(ArgumentError) { Axlsx::Comment.new }
+    assert_raises(ArgumentError) { Axlsx::Comment.new }
   end
 
   def test_author
@@ -31,7 +31,7 @@ class TestComment < Test::Unit::TestCase
   end
 
   def test_visible
-    refute(@c1.visible)
+    assert_false(@c1.visible)
     assert(@c2.visible)
   end
 

--- a/test/workbook/worksheet/tc_comments.rb
+++ b/test/workbook/worksheet/tc_comments.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestComments < Test::Unit::TestCase
+class TestComments < Minitest::Test
   def setup
     p = Axlsx::Package.new
     wb = p.workbook
@@ -12,17 +12,17 @@ class TestComments < Test::Unit::TestCase
   end
 
   def test_initialize
-    assert_raise(ArgumentError) { Axlsx::Comments.new }
+    assert_raises(ArgumentError) { Axlsx::Comments.new }
     assert_kind_of(Axlsx::VmlDrawing, @ws.comments.vml_drawing)
   end
 
   def test_add_comment
     assert_equal(2, @ws.comments.size)
-    assert_raise(ArgumentError) { @ws.comments.add_comment }
-    assert_raise(ArgumentError) { @ws.comments.add_comment(text: 'Yes We Can', ref: 'A1') }
-    assert_raise(ArgumentError) { @ws.comments.add_comment(author: 'bob', ref: 'A1') }
-    assert_raise(ArgumentError) { @ws.comments.add_comment(author: 'bob', text: 'Yes We Can') }
-    assert_nothing_raised { @ws.comments.add_comment(author: 'bob', text: 'Yes We Can', ref: 'A1') }
+    assert_raises(ArgumentError) { @ws.comments.add_comment }
+    assert_raises(ArgumentError) { @ws.comments.add_comment(text: 'Yes We Can', ref: 'A1') }
+    assert_raises(ArgumentError) { @ws.comments.add_comment(author: 'bob', ref: 'A1') }
+    assert_raises(ArgumentError) { @ws.comments.add_comment(author: 'bob', text: 'Yes We Can') }
+    refute_raises { @ws.comments.add_comment(author: 'bob', text: 'Yes We Can', ref: 'A1') }
     assert_equal(3, @ws.comments.size)
   end
 

--- a/test/workbook/worksheet/tc_conditional_formatting.rb
+++ b/test/workbook/worksheet/tc_conditional_formatting.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestConditionalFormatting < Test::Unit::TestCase
+class TestConditionalFormatting < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet name: "hmmm"
@@ -149,86 +149,86 @@ class TestConditionalFormatting < Test::Unit::TestCase
   end
 
   def test_sqref
-    assert_raise(ArgumentError) { @cf.sqref = 10 }
-    assert_nothing_raised { @cf.sqref = "A1:A1" }
+    assert_raises(ArgumentError) { @cf.sqref = 10 }
+    refute_raises { @cf.sqref = "A1:A1" }
     assert_equal("A1:A1", @cf.sqref)
   end
 
   def test_type
-    assert_raise(ArgumentError) { @cfr.type = "illegal" }
-    assert_nothing_raised { @cfr.type = :containsBlanks }
+    assert_raises(ArgumentError) { @cfr.type = "illegal" }
+    refute_raises { @cfr.type = :containsBlanks }
     assert_equal(:containsBlanks, @cfr.type)
   end
 
   def test_above_average
-    assert_raise(ArgumentError) { @cfr.aboveAverage = "illegal" }
-    assert_nothing_raised { @cfr.aboveAverage = true }
+    assert_raises(ArgumentError) { @cfr.aboveAverage = "illegal" }
+    refute_raises { @cfr.aboveAverage = true }
     assert(@cfr.aboveAverage)
   end
 
   def test_equal_average
-    assert_raise(ArgumentError) { @cfr.equalAverage = "illegal" }
-    assert_nothing_raised { @cfr.equalAverage = true }
+    assert_raises(ArgumentError) { @cfr.equalAverage = "illegal" }
+    refute_raises { @cfr.equalAverage = true }
     assert(@cfr.equalAverage)
   end
 
   def test_bottom
-    assert_raise(ArgumentError) { @cfr.bottom = "illegal" }
-    assert_nothing_raised { @cfr.bottom = true }
+    assert_raises(ArgumentError) { @cfr.bottom = "illegal" }
+    refute_raises { @cfr.bottom = true }
     assert(@cfr.bottom)
   end
 
   def test_operator
-    assert_raise(ArgumentError) { @cfr.operator = "cellIs" }
-    assert_nothing_raised { @cfr.operator = :notBetween }
+    assert_raises(ArgumentError) { @cfr.operator = "cellIs" }
+    refute_raises { @cfr.operator = :notBetween }
     assert_equal(:notBetween, @cfr.operator)
   end
 
   def test_dxf_id
-    assert_raise(ArgumentError) { @cfr.dxfId = "illegal" }
-    assert_nothing_raised { @cfr.dxfId = 1 }
+    assert_raises(ArgumentError) { @cfr.dxfId = "illegal" }
+    refute_raises { @cfr.dxfId = 1 }
     assert_equal(1, @cfr.dxfId)
   end
 
   def test_priority
-    assert_raise(ArgumentError) { @cfr.priority = -1.0 }
-    assert_nothing_raised { @cfr.priority = 1 }
+    assert_raises(ArgumentError) { @cfr.priority = -1.0 }
+    refute_raises { @cfr.priority = 1 }
     assert_equal(1, @cfr.priority)
   end
 
   def test_text
-    assert_raise(ArgumentError) { @cfr.text = 1.0 }
-    assert_nothing_raised { @cfr.text = "testing" }
+    assert_raises(ArgumentError) { @cfr.text = 1.0 }
+    refute_raises { @cfr.text = "testing" }
     assert_equal("testing", @cfr.text)
   end
 
   def test_percent
-    assert_raise(ArgumentError) { @cfr.percent = "10%" } # WRONG!
-    assert_nothing_raised { @cfr.percent = true }
+    assert_raises(ArgumentError) { @cfr.percent = "10%" } # WRONG!
+    refute_raises { @cfr.percent = true }
     assert(@cfr.percent)
   end
 
   def test_rank
-    assert_raise(ArgumentError) { @cfr.rank = -1 }
-    assert_nothing_raised { @cfr.rank = 1 }
+    assert_raises(ArgumentError) { @cfr.rank = -1 }
+    refute_raises { @cfr.rank = 1 }
     assert_equal(1, @cfr.rank)
   end
 
   def test_std_dev
-    assert_raise(ArgumentError) { @cfr.stdDev = -1 }
-    assert_nothing_raised { @cfr.stdDev = 1 }
+    assert_raises(ArgumentError) { @cfr.stdDev = -1 }
+    refute_raises { @cfr.stdDev = 1 }
     assert_equal(1, @cfr.stdDev)
   end
 
   def test_stop_if_true
-    assert_raise(ArgumentError) { @cfr.stopIfTrue = "illegal" }
-    assert_nothing_raised { @cfr.stopIfTrue = false }
-    refute(@cfr.stopIfTrue)
+    assert_raises(ArgumentError) { @cfr.stopIfTrue = "illegal" }
+    refute_raises { @cfr.stopIfTrue = false }
+    assert_false(@cfr.stopIfTrue)
   end
 
   def test_time_period
-    assert_raise(ArgumentError) { @cfr.timePeriod = "illegal" }
-    assert_nothing_raised { @cfr.timePeriod = :today }
+    assert_raises(ArgumentError) { @cfr.timePeriod = "illegal" }
+    refute_raises { @cfr.timePeriod = :today }
     assert_equal(:today, @cfr.timePeriod)
   end
 end

--- a/test/workbook/worksheet/tc_data_bar.rb
+++ b/test/workbook/worksheet/tc_data_bar.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestDataBar < Test::Unit::TestCase
+class TestDataBar < Minitest::Test
   def setup
     @data_bar = Axlsx::DataBar.new color: "FF638EC6"
   end
@@ -21,21 +21,21 @@ class TestDataBar < Test::Unit::TestCase
   end
 
   def test_minLength
-    assert_raise(ArgumentError) { @data_bar.minLength = :invalid_type }
-    assert_nothing_raised { @data_bar.minLength = 0 }
+    assert_raises(ArgumentError) { @data_bar.minLength = :invalid_type }
+    refute_raises { @data_bar.minLength = 0 }
     assert_equal(0, @data_bar.minLength)
   end
 
   def test_maxLength
-    assert_raise(ArgumentError) { @data_bar.maxLength = :invalid_type }
-    assert_nothing_raised { @data_bar.maxLength = 0 }
+    assert_raises(ArgumentError) { @data_bar.maxLength = :invalid_type }
+    refute_raises { @data_bar.maxLength = 0 }
     assert_equal(0, @data_bar.maxLength)
   end
 
   def test_showValue
-    assert_raise(ArgumentError) { @data_bar.showValue = :invalid_type }
-    assert_nothing_raised { @data_bar.showValue = false }
-    refute(@data_bar.showValue)
+    assert_raises(ArgumentError) { @data_bar.showValue = :invalid_type }
+    refute_raises { @data_bar.showValue = false }
+    assert_false(@data_bar.showValue)
   end
 
   def test_to_xml_string

--- a/test/workbook/worksheet/tc_data_validation.rb
+++ b/test/workbook/worksheet/tc_data_validation.rb
@@ -3,7 +3,7 @@
 require 'tc_helper'
 require 'support/capture_warnings'
 
-class TestDataValidation < Test::Unit::TestCase
+class TestDataValidation < Minitest::Test
   include CaptureWarnings
 
   def setup
@@ -47,84 +47,84 @@ class TestDataValidation < Test::Unit::TestCase
 
   def test_boolean_attribute_validation
     @boolean_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be boolean") { @dv.send(:"#{key}=", 'A') }
-      assert_nothing_raised { @dv.send(:"#{key}=", value) }
+      assert_raises(ArgumentError, "#{key} must be boolean") { @dv.send(:"#{key}=", 'A') }
+      refute_raises { @dv.send(:"#{key}=", value) }
     end
   end
 
   def test_string_attribute_validation
     @string_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be string") { @dv.send(:"#{key}=", :symbol) }
-      assert_nothing_raised { @dv.send(:"#{key}=", value) }
+      assert_raises(ArgumentError, "#{key} must be string") { @dv.send(:"#{key}=", :symbol) }
+      refute_raises { @dv.send(:"#{key}=", value) }
     end
   end
 
   def test_symbol_attribute_validation
     @symbol_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be symbol") { @dv.send(:"#{key}=", "foo") }
-      assert_nothing_raised { @dv.send(:"#{key}=", value) }
+      assert_raises(ArgumentError, "#{key} must be symbol") { @dv.send(:"#{key}=", "foo") }
+      refute_raises { @dv.send(:"#{key}=", value) }
     end
   end
 
   def test_formula1
-    assert_raise(ArgumentError) { @dv.formula1 = 10 }
-    assert_nothing_raised { @dv.formula1 = "=SUM(A1:A1)" }
+    assert_raises(ArgumentError) { @dv.formula1 = 10 }
+    refute_raises { @dv.formula1 = "=SUM(A1:A1)" }
     assert_equal("=SUM(A1:A1)", @dv.formula1)
   end
 
   def test_formula2
-    assert_raise(ArgumentError) { @dv.formula2 = 10 }
-    assert_nothing_raised { @dv.formula2 = "=SUM(A1:A1)" }
+    assert_raises(ArgumentError) { @dv.formula2 = 10 }
+    refute_raises { @dv.formula2 = "=SUM(A1:A1)" }
     assert_equal("=SUM(A1:A1)", @dv.formula2)
   end
 
   def test_allowBlank
-    assert_raise(ArgumentError) { @dv.allowBlank = "foo´" }
-    assert_nothing_raised { @dv.allowBlank = false }
-    refute(@dv.allowBlank)
+    assert_raises(ArgumentError) { @dv.allowBlank = "foo´" }
+    refute_raises { @dv.allowBlank = false }
+    assert_false(@dv.allowBlank)
   end
 
   def test_error
-    assert_raise(ArgumentError) { @dv.error = :symbol }
-    assert_nothing_raised { @dv.error = "This is a error message" }
+    assert_raises(ArgumentError) { @dv.error = :symbol }
+    refute_raises { @dv.error = "This is a error message" }
     assert_equal("This is a error message", @dv.error)
   end
 
   def test_errorStyle
-    assert_raise(ArgumentError) { @dv.errorStyle = "foo" }
-    assert_nothing_raised { @dv.errorStyle = :information }
+    assert_raises(ArgumentError) { @dv.errorStyle = "foo" }
+    refute_raises { @dv.errorStyle = :information }
     assert_equal(:information, @dv.errorStyle)
   end
 
   def test_errorTitle
-    assert_raise(ArgumentError) { @dv.errorTitle = :symbol }
-    assert_nothing_raised { @dv.errorTitle = "This is the error title" }
+    assert_raises(ArgumentError) { @dv.errorTitle = :symbol }
+    refute_raises { @dv.errorTitle = "This is the error title" }
     assert_equal("This is the error title", @dv.errorTitle)
   end
 
   def test_operator
-    assert_raise(ArgumentError) { @dv.operator = "foo" }
-    assert_nothing_raised { @dv.operator = :greaterThan }
+    assert_raises(ArgumentError) { @dv.operator = "foo" }
+    refute_raises { @dv.operator = :greaterThan }
     assert_equal(:greaterThan, @dv.operator)
   end
 
   def test_prompt
-    assert_raise(ArgumentError) { @dv.prompt = :symbol }
-    assert_nothing_raised { @dv.prompt = "This is a prompt message" }
+    assert_raises(ArgumentError) { @dv.prompt = :symbol }
+    refute_raises { @dv.prompt = "This is a prompt message" }
     assert_equal("This is a prompt message", @dv.prompt)
   end
 
   def test_promptTitle
-    assert_raise(ArgumentError) { @dv.promptTitle = :symbol }
-    assert_nothing_raised { @dv.promptTitle = "This is the prompt title" }
+    assert_raises(ArgumentError) { @dv.promptTitle = :symbol }
+    refute_raises { @dv.promptTitle = "This is the prompt title" }
     assert_equal("This is the prompt title", @dv.promptTitle)
   end
 
   def test_showDropDown
     warnings = capture_warnings do
-      assert_raise(ArgumentError) { @dv.showDropDown = "foo´" }
-      assert_nothing_raised { @dv.showDropDown = false }
-      refute(@dv.showDropDown)
+      assert_raises(ArgumentError) { @dv.showDropDown = "foo´" }
+      refute_raises { @dv.showDropDown = false }
+      assert_false(@dv.showDropDown)
     end
 
     assert_equal 2, warnings.size
@@ -132,34 +132,34 @@ class TestDataValidation < Test::Unit::TestCase
   end
 
   def test_hideDropDown
-    assert_raise(ArgumentError) { @dv.hideDropDown = "foo´" }
-    assert_nothing_raised { @dv.hideDropDown = false }
-    refute(@dv.hideDropDown)
+    assert_raises(ArgumentError) { @dv.hideDropDown = "foo´" }
+    refute_raises { @dv.hideDropDown = false }
+    assert_false(@dv.hideDropDown)
     # As hideDropdown is just an alias for showDropDown, we should test the original value too
-    refute(@dv.showDropDown)
+    assert_false(@dv.showDropDown)
   end
 
   def test_showErrorMessage
-    assert_raise(ArgumentError) { @dv.showErrorMessage = "foo´" }
-    assert_nothing_raised { @dv.showErrorMessage = false }
-    refute(@dv.showErrorMessage)
+    assert_raises(ArgumentError) { @dv.showErrorMessage = "foo´" }
+    refute_raises { @dv.showErrorMessage = false }
+    assert_false(@dv.showErrorMessage)
   end
 
   def test_showInputMessage
-    assert_raise(ArgumentError) { @dv.showInputMessage = "foo´" }
-    assert_nothing_raised { @dv.showInputMessage = false }
-    refute(@dv.showInputMessage)
+    assert_raises(ArgumentError) { @dv.showInputMessage = "foo´" }
+    refute_raises { @dv.showInputMessage = false }
+    assert_false(@dv.showInputMessage)
   end
 
   def test_sqref
-    assert_raise(ArgumentError) { @dv.sqref = 10 }
-    assert_nothing_raised { @dv.sqref = "A1:A1" }
+    assert_raises(ArgumentError) { @dv.sqref = 10 }
+    refute_raises { @dv.sqref = "A1:A1" }
     assert_equal("A1:A1", @dv.sqref)
   end
 
   def test_type
-    assert_raise(ArgumentError) { @dv.type = "foo" }
-    assert_nothing_raised { @dv.type = :list }
+    assert_raises(ArgumentError) { @dv.type = "foo" }
+    refute_raises { @dv.type = :list }
     assert_equal(:list, @dv.type)
   end
 

--- a/test/workbook/worksheet/tc_date_time_converter.rb
+++ b/test/workbook/worksheet/tc_date_time_converter.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestDateTimeConverter < Test::Unit::TestCase
+class TestDateTimeConverter < Minitest::Test
   def setup
     @margin_of_error = 0.000_001
   end

--- a/test/workbook/worksheet/tc_header_footer.rb
+++ b/test/workbook/worksheet/tc_header_footer.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestHeaderFooter < Test::Unit::TestCase
+class TestHeaderFooter < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     ws = @p.workbook.add_worksheet name: 'test'
@@ -54,15 +54,15 @@ class TestHeaderFooter < Test::Unit::TestCase
 
   def test_string_attributes
     %w(odd_header odd_footer even_header even_footer first_header first_footer).each do |attr|
-      assert_raise(ArgumentError, 'only strings allowed in string attributes') { @hf.send(:"#{attr}=", 1) }
-      assert_nothing_raised { @hf.send(:"#{attr}=", 'test_string') }
+      assert_raises(ArgumentError, 'only strings allowed in string attributes') { @hf.send(:"#{attr}=", 1) }
+      refute_raises { @hf.send(:"#{attr}=", 'test_string') }
     end
   end
 
   def test_boolean_attributes
     %w(different_first different_odd_even).each do |attr|
-      assert_raise(ArgumentError, 'only booleanish allowed in string attributes') { @hf.send(:"#{attr}=", 'foo') }
-      assert_nothing_raised { @hf.send(:"#{attr}=", 1) }
+      assert_raises(ArgumentError, 'only booleanish allowed in string attributes') { @hf.send(:"#{attr}=", 'foo') }
+      refute_raises { @hf.send(:"#{attr}=", 1) }
     end
   end
 

--- a/test/workbook/worksheet/tc_icon_set.rb
+++ b/test/workbook/worksheet/tc_icon_set.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestIconSet < Test::Unit::TestCase
+class TestIconSet < Minitest::Test
   def setup
     @icon_set = Axlsx::IconSet.new
   end
@@ -10,39 +10,39 @@ class TestIconSet < Test::Unit::TestCase
   def test_defaults
     assert_equal("3TrafficLights1", @icon_set.iconSet)
     assert(@icon_set.percent)
-    refute(@icon_set.reverse)
+    assert_false(@icon_set.reverse)
     assert(@icon_set.showValue)
     assert_equal([0, 33, 67], @icon_set.interpolationPoints)
   end
 
   def test_icon_set
-    assert_raise(ArgumentError) { @icon_set.iconSet = "invalid_value" }
-    assert_nothing_raised { @icon_set.iconSet = "5Rating" }
+    assert_raises(ArgumentError) { @icon_set.iconSet = "invalid_value" }
+    refute_raises { @icon_set.iconSet = "5Rating" }
     assert_equal("5Rating", @icon_set.iconSet)
   end
 
   def test_interpolation_points
-    assert_raise(ArgumentError) { @icon_set.interpolationPoints = ["invalid_value"] }
-    assert_nothing_raised { @icon_set.interpolationPoints = [0, 60, 80] }
+    assert_raises(ArgumentError) { @icon_set.interpolationPoints = ["invalid_value"] }
+    refute_raises { @icon_set.interpolationPoints = [0, 60, 80] }
     assert_equal([0, 60, 80], @icon_set.interpolationPoints)
   end
 
   def test_percent
-    assert_raise(ArgumentError) { @icon_set.percent = :invalid_type }
-    assert_nothing_raised { @icon_set.percent = false }
-    refute(@icon_set.percent)
+    assert_raises(ArgumentError) { @icon_set.percent = :invalid_type }
+    refute_raises { @icon_set.percent = false }
+    assert_false(@icon_set.percent)
   end
 
   def test_showValue
-    assert_raise(ArgumentError) { @icon_set.showValue = :invalid_type }
-    assert_nothing_raised { @icon_set.showValue = false }
-    refute(@icon_set.showValue)
+    assert_raises(ArgumentError) { @icon_set.showValue = :invalid_type }
+    refute_raises { @icon_set.showValue = false }
+    assert_false(@icon_set.showValue)
   end
 
   def test_reverse
-    assert_raise(ArgumentError) { @icon_set.reverse = :invalid_type }
-    assert_nothing_raised { @icon_set.reverse = false }
-    refute(@icon_set.reverse)
+    assert_raises(ArgumentError) { @icon_set.reverse = :invalid_type }
+    refute_raises { @icon_set.reverse = false }
+    assert_false(@icon_set.reverse)
   end
 
   def test_to_xml_string

--- a/test/workbook/worksheet/tc_outline_pr.rb
+++ b/test/workbook/worksheet/tc_outline_pr.rb
@@ -2,13 +2,13 @@
 
 require 'tc_helper'
 
-class TestOutlinePr < Test::Unit::TestCase
+class TestOutlinePr < Minitest::Test
   def setup
     @outline_pr = Axlsx::OutlinePr.new(summary_below: false, summary_right: true, apply_styles: false)
   end
 
   def test_summary_below
-    refute @outline_pr.summary_below
+    assert_false @outline_pr.summary_below
   end
 
   def test_summary_right
@@ -16,6 +16,6 @@ class TestOutlinePr < Test::Unit::TestCase
   end
 
   def test_apply_styles
-    refute @outline_pr.apply_styles
+    assert_false @outline_pr.apply_styles
   end
 end

--- a/test/workbook/worksheet/tc_page_margins.rb
+++ b/test/workbook/worksheet/tc_page_margins.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestPageMargins < Test::Unit::TestCase
+class TestPageMargins < Minitest::Test
   def setup
     p = Axlsx::Package.new
     ws = p.workbook.add_worksheet name: "hmmm"
@@ -64,38 +64,38 @@ class TestPageMargins < Test::Unit::TestCase
   end
 
   def test_left
-    assert_raise(ArgumentError) { @pm.left = -1.2 }
-    assert_nothing_raised { @pm.left = 1.5 }
+    assert_raises(ArgumentError) { @pm.left = -1.2 }
+    refute_raises { @pm.left = 1.5 }
     assert_in_delta(@pm.left, 1.5)
   end
 
   def test_right
-    assert_raise(ArgumentError) { @pm.right = -1.2 }
-    assert_nothing_raised { @pm.right = 1.5 }
+    assert_raises(ArgumentError) { @pm.right = -1.2 }
+    refute_raises { @pm.right = 1.5 }
     assert_in_delta(@pm.right, 1.5)
   end
 
   def test_top
-    assert_raise(ArgumentError) { @pm.top = -1.2 }
-    assert_nothing_raised { @pm.top = 1.5 }
+    assert_raises(ArgumentError) { @pm.top = -1.2 }
+    refute_raises { @pm.top = 1.5 }
     assert_in_delta(@pm.top, 1.5)
   end
 
   def test_bottom
-    assert_raise(ArgumentError) { @pm.bottom = -1.2 }
-    assert_nothing_raised { @pm.bottom = 1.5 }
+    assert_raises(ArgumentError) { @pm.bottom = -1.2 }
+    refute_raises { @pm.bottom = 1.5 }
     assert_in_delta(@pm.bottom, 1.5)
   end
 
   def test_header
-    assert_raise(ArgumentError) { @pm.header = -1.2 }
-    assert_nothing_raised { @pm.header = 1.5 }
+    assert_raises(ArgumentError) { @pm.header = -1.2 }
+    refute_raises { @pm.header = 1.5 }
     assert_in_delta(@pm.header, 1.5)
   end
 
   def test_footer
-    assert_raise(ArgumentError) { @pm.footer = -1.2 }
-    assert_nothing_raised { @pm.footer = 1.5 }
+    assert_raises(ArgumentError) { @pm.footer = -1.2 }
+    refute_raises { @pm.footer = 1.5 }
     assert_in_delta(@pm.footer, 1.5)
   end
 end

--- a/test/workbook/worksheet/tc_page_set_up_pr.rb
+++ b/test/workbook/worksheet/tc_page_set_up_pr.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestPageSetUpPr < Test::Unit::TestCase
+class TestPageSetUpPr < Minitest::Test
   def setup
     @page_setup_pr = Axlsx::PageSetUpPr.new(fit_to_page: true, auto_page_breaks: true)
   end

--- a/test/workbook/worksheet/tc_page_setup.rb
+++ b/test/workbook/worksheet/tc_page_setup.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestPageSetup < Test::Unit::TestCase
+class TestPageSetup < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     ws = @p.workbook.add_worksheet name: "hmmm"
@@ -48,8 +48,8 @@ class TestPageSetup < Test::Unit::TestCase
   end
 
   def test_paper_size
-    assert_raise(ArgumentError) { @ps.paper_size = 119 }
-    assert_nothing_raised {  @ps.paper_size = 10 }
+    assert_raises(ArgumentError) { @ps.paper_size = 119 }
+    refute_raises { @ps.paper_size = 10 }
   end
 
   def test_set_some_values
@@ -102,38 +102,38 @@ class TestPageSetup < Test::Unit::TestCase
   end
 
   def test_fit_to_height
-    assert_raise(ArgumentError) { @ps.fit_to_height = 1.5 }
-    assert_nothing_raised { @ps.fit_to_height = 2 }
+    assert_raises(ArgumentError) { @ps.fit_to_height = 1.5 }
+    refute_raises { @ps.fit_to_height = 2 }
     assert_equal(2, @ps.fit_to_height)
   end
 
   def test_fit_to_width
-    assert_raise(ArgumentError) { @ps.fit_to_width = false }
-    assert_nothing_raised { @ps.fit_to_width = 1 }
+    assert_raises(ArgumentError) { @ps.fit_to_width = false }
+    refute_raises { @ps.fit_to_width = 1 }
     assert_equal(1, @ps.fit_to_width)
   end
 
   def test_orientation
-    assert_raise(ArgumentError) { @ps.orientation = "" }
-    assert_nothing_raised { @ps.orientation = :default }
+    assert_raises(ArgumentError) { @ps.orientation = "" }
+    refute_raises { @ps.orientation = :default }
     assert_equal(:default, @ps.orientation)
   end
 
   def test_paper_height
-    assert_raise(ArgumentError) { @ps.paper_height = 99 }
-    assert_nothing_raised { @ps.paper_height = "11in" }
+    assert_raises(ArgumentError) { @ps.paper_height = 99 }
+    refute_raises { @ps.paper_height = "11in" }
     assert_equal("11in", @ps.paper_height)
   end
 
   def test_paper_width
-    assert_raise(ArgumentError) { @ps.paper_width = "22" }
-    assert_nothing_raised { @ps.paper_width = "29.7cm" }
+    assert_raises(ArgumentError) { @ps.paper_width = "22" }
+    refute_raises { @ps.paper_width = "29.7cm" }
     assert_equal("29.7cm", @ps.paper_width)
   end
 
   def test_scale
-    assert_raise(ArgumentError) { @ps.scale = 50.5 }
-    assert_nothing_raised { @ps.scale = 99 }
+    assert_raises(ArgumentError) { @ps.scale = 50.5 }
+    refute_raises { @ps.scale = 99 }
     assert_equal(99, @ps.scale)
   end
 
@@ -147,6 +147,6 @@ class TestPageSetup < Test::Unit::TestCase
     fits = @ps.fit_to height: 7, width: 2
 
     assert_equal([2, 7], fits)
-    assert_raise(ArgumentError) { puts @ps.fit_to(width: true) }
+    assert_raises(ArgumentError) { puts @ps.fit_to(width: true) }
   end
 end

--- a/test/workbook/worksheet/tc_pane.rb
+++ b/test/workbook/worksheet/tc_pane.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestPane < Test::Unit::TestCase
+class TestPane < Minitest::Test
   def setup
     # inverse defaults for booleans
     @nil_options = { active_pane: :bottom_left, state: :frozen, top_left_cell: 'A2' }
@@ -12,32 +12,32 @@ class TestPane < Test::Unit::TestCase
   end
 
   def test_active_pane
-    assert_raise(ArgumentError) { @pane.active_pane = "10" }
-    assert_nothing_raised { @pane.active_pane = :top_left }
+    assert_raises(ArgumentError) { @pane.active_pane = "10" }
+    refute_raises { @pane.active_pane = :top_left }
     assert_equal("topLeft", @pane.active_pane)
   end
 
   def test_state
-    assert_raise(ArgumentError) { @pane.state = "foo" }
-    assert_nothing_raised { @pane.state = :frozen_split }
+    assert_raises(ArgumentError) { @pane.state = "foo" }
+    refute_raises { @pane.state = :frozen_split }
     assert_equal("frozenSplit", @pane.state)
   end
 
   def test_x_split
-    assert_raise(ArgumentError) { @pane.x_split = "foo´" }
-    assert_nothing_raised { @pane.x_split = 200 }
+    assert_raises(ArgumentError) { @pane.x_split = "foo´" }
+    refute_raises { @pane.x_split = 200 }
     assert_equal(200, @pane.x_split)
   end
 
   def test_y_split
-    assert_raise(ArgumentError) { @pane.y_split = 'foo' }
-    assert_nothing_raised { @pane.y_split = 300 }
+    assert_raises(ArgumentError) { @pane.y_split = 'foo' }
+    refute_raises { @pane.y_split = 300 }
     assert_equal(300, @pane.y_split)
   end
 
   def test_top_left_cell
-    assert_raise(ArgumentError) { @pane.top_left_cell = :cell }
-    assert_nothing_raised { @pane.top_left_cell = "A2" }
+    assert_raises(ArgumentError) { @pane.top_left_cell = :cell }
+    refute_raises { @pane.top_left_cell = "A2" }
     assert_equal("A2", @pane.top_left_cell)
   end
 

--- a/test/workbook/worksheet/tc_pivot_table.rb
+++ b/test/workbook/worksheet/tc_pivot_table.rb
@@ -10,7 +10,7 @@ def shared_test_pivot_table_xml_validity(pivot_table)
   assert_empty(errors)
 end
 
-class TestPivotTable < Test::Unit::TestCase
+class TestPivotTable < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet
@@ -173,7 +173,7 @@ class TestPivotTable < Test::Unit::TestCase
   end
 
   def test_pivot_table_with_more_than_one_data_row
-    ### https://github.com/caxlsx/caxlsx/issues/110
+    # https://github.com/caxlsx/caxlsx/issues/110
 
     pivot_table = @ws.add_pivot_table('G5:G6', 'A1:E5') do |pt|
       pt.rows = ["Date", "Name"]
@@ -203,7 +203,7 @@ class TestPivotTable < Test::Unit::TestCase
   end
 
   def test_pivot_table_with_only_one_data_row
-    ### https://github.com/caxlsx/caxlsx/issues/110
+    # https://github.com/caxlsx/caxlsx/issues/110
 
     pivot_table = @ws.add_pivot_table('G5:G6', 'A1:E5') do |pt|
       pt.rows = ["Date", "Name"]

--- a/test/workbook/worksheet/tc_pivot_table_cache_definition.rb
+++ b/test/workbook/worksheet/tc_pivot_table_cache_definition.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestPivotTableCacheDefinition < Test::Unit::TestCase
+class TestPivotTableCacheDefinition < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet

--- a/test/workbook/worksheet/tc_print_options.rb
+++ b/test/workbook/worksheet/tc_print_options.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestPrintOptions < Test::Unit::TestCase
+class TestPrintOptions < Minitest::Test
   def setup
     p = Axlsx::Package.new
     ws = p.workbook.add_worksheet name: "hmmm"
@@ -10,10 +10,10 @@ class TestPrintOptions < Test::Unit::TestCase
   end
 
   def test_initialize
-    refute(@po.grid_lines)
-    refute(@po.headings)
-    refute(@po.horizontal_centered)
-    refute(@po.vertical_centered)
+    assert_false(@po.grid_lines)
+    assert_false(@po.headings)
+    assert_false(@po.horizontal_centered)
+    assert_false(@po.vertical_centered)
   end
 
   def test_initialize_with_options
@@ -39,8 +39,8 @@ class TestPrintOptions < Test::Unit::TestCase
 
     assert(@po.grid_lines)
     assert(@po.headings)
-    refute(@po.horizontal_centered)
-    refute(@po.vertical_centered)
+    assert_false(@po.horizontal_centered)
+    assert_false(@po.vertical_centered)
   end
 
   def test_to_xml
@@ -51,26 +51,26 @@ class TestPrintOptions < Test::Unit::TestCase
   end
 
   def test_grid_lines
-    assert_raise(ArgumentError) { @po.grid_lines = 99 }
-    assert_nothing_raised { @po.grid_lines = true }
+    assert_raises(ArgumentError) { @po.grid_lines = 99 }
+    refute_raises { @po.grid_lines = true }
     assert(@po.grid_lines)
   end
 
   def test_headings
-    assert_raise(ArgumentError) { @po.headings = 99 }
-    assert_nothing_raised { @po.headings = true }
+    assert_raises(ArgumentError) { @po.headings = 99 }
+    refute_raises { @po.headings = true }
     assert(@po.headings)
   end
 
   def test_horizontal_centered
-    assert_raise(ArgumentError) { @po.horizontal_centered = 99 }
-    assert_nothing_raised { @po.horizontal_centered = true }
+    assert_raises(ArgumentError) { @po.horizontal_centered = 99 }
+    refute_raises { @po.horizontal_centered = true }
     assert(@po.horizontal_centered)
   end
 
   def test_vertical_centered
-    assert_raise(ArgumentError) { @po.vertical_centered = 99 }
-    assert_nothing_raised { @po.vertical_centered = true }
+    assert_raises(ArgumentError) { @po.vertical_centered = 99 }
+    refute_raises { @po.vertical_centered = true }
     assert(@po.vertical_centered)
   end
 end

--- a/test/workbook/worksheet/tc_protected_range.rb
+++ b/test/workbook/worksheet/tc_protected_range.rb
@@ -2,14 +2,14 @@
 
 require 'tc_helper'
 
-class TestProtectedRange < Test::Unit::TestCase
+class TestProtectedRange < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     @ws = @p.workbook.add_worksheet { |sheet| sheet.add_row [1, 2, 3, 4, 5, 6, 7, 8, 9] }
   end
 
   def test_initialize_options
-    assert_nothing_raised { Axlsx::ProtectedRange.new(sqref: 'A1:B1', name: "only bob") }
+    refute_raises { Axlsx::ProtectedRange.new(sqref: 'A1:B1', name: "only bob") }
   end
 
   def test_range

--- a/test/workbook/worksheet/tc_rich_text.rb
+++ b/test/workbook/worksheet/tc_rich_text.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class RichText < Test::Unit::TestCase
+class RichText < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet name: "hmmmz"
@@ -33,10 +33,10 @@ class RichText < Test::Unit::TestCase
     runs = @rt.runs
 
     assert_equal(27, runs.length)
-    refute(runs.first.b)
+    assert_false(runs.first.b)
     assert(runs.first.i)
     assert(runs[1].b)
-    refute(runs[1].i)
+    assert_false(runs[1].i)
   end
 
   def test_implicit_richtext

--- a/test/workbook/worksheet/tc_rich_text_run.rb
+++ b/test/workbook/worksheet/tc_rich_text_run.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class RichTextRun < Test::Unit::TestCase
+class RichTextRun < Minitest::Test
   def setup
     @p = Axlsx::Package.new
     @ws = @p.workbook.add_worksheet name: "hmmmz"
@@ -19,7 +19,7 @@ class RichTextRun < Test::Unit::TestCase
   def test_initialize
     assert_equal('hihihi', @rtr.value)
     assert(@rtr.b)
-    refute(@rtr.i)
+    assert_false(@rtr.i)
   end
 
   def test_font_size_with_custom_style_and_no_sz
@@ -56,63 +56,63 @@ class RichTextRun < Test::Unit::TestCase
   end
 
   def test_color
-    assert_raise(ArgumentError) { @rtr.color = -1.1 }
-    assert_nothing_raised { @rtr.color = "FF00FF00" }
+    assert_raises(ArgumentError) { @rtr.color = -1.1 }
+    refute_raises { @rtr.color = "FF00FF00" }
     assert_equal("FF00FF00", @rtr.color.rgb)
   end
 
   def test_scheme
-    assert_raise(ArgumentError) { @rtr.scheme = -1.1 }
-    assert_nothing_raised { @rtr.scheme = :major }
+    assert_raises(ArgumentError) { @rtr.scheme = -1.1 }
+    refute_raises { @rtr.scheme = :major }
     assert_equal(:major, @rtr.scheme)
   end
 
   def test_vertAlign
-    assert_raise(ArgumentError) { @rtr.vertAlign = -1.1 }
-    assert_nothing_raised { @rtr.vertAlign = :baseline }
+    assert_raises(ArgumentError) { @rtr.vertAlign = -1.1 }
+    refute_raises { @rtr.vertAlign = :baseline }
     assert_equal(:baseline, @rtr.vertAlign)
   end
 
   def test_sz
-    assert_raise(ArgumentError) { @rtr.sz = -1.1 }
-    assert_nothing_raised { @rtr.sz = 12 }
+    assert_raises(ArgumentError) { @rtr.sz = -1.1 }
+    refute_raises { @rtr.sz = 12 }
     assert_equal(12, @rtr.sz)
   end
 
   def test_extend
-    assert_raise(ArgumentError) { @rtr.extend = -1.1 }
-    assert_nothing_raised { @rtr.extend = false }
-    refute(@rtr.extend)
+    assert_raises(ArgumentError) { @rtr.extend = -1.1 }
+    refute_raises { @rtr.extend = false }
+    assert_false(@rtr.extend)
   end
 
   def test_condense
-    assert_raise(ArgumentError) { @rtr.condense = -1.1 }
-    assert_nothing_raised { @rtr.condense = false }
-    refute(@rtr.condense)
+    assert_raises(ArgumentError) { @rtr.condense = -1.1 }
+    refute_raises { @rtr.condense = false }
+    assert_false(@rtr.condense)
   end
 
   def test_shadow
-    assert_raise(ArgumentError) { @rtr.shadow = -1.1 }
-    assert_nothing_raised { @rtr.shadow = false }
-    refute(@rtr.shadow)
+    assert_raises(ArgumentError) { @rtr.shadow = -1.1 }
+    refute_raises { @rtr.shadow = false }
+    assert_false(@rtr.shadow)
   end
 
   def test_outline
-    assert_raise(ArgumentError) { @rtr.outline = -1.1 }
-    assert_nothing_raised { @rtr.outline = false }
-    refute(@rtr.outline)
+    assert_raises(ArgumentError) { @rtr.outline = -1.1 }
+    refute_raises { @rtr.outline = false }
+    assert_false(@rtr.outline)
   end
 
   def test_strike
-    assert_raise(ArgumentError) { @rtr.strike = -1.1 }
-    assert_nothing_raised { @rtr.strike = false }
-    refute(@rtr.strike)
+    assert_raises(ArgumentError) { @rtr.strike = -1.1 }
+    refute_raises { @rtr.strike = false }
+    assert_false(@rtr.strike)
   end
 
   def test_u
     @c.type = :string
-    assert_raise(ArgumentError) { @c.u = -1.1 }
-    assert_nothing_raised { @c.u = :single }
+    assert_raises(ArgumentError) { @c.u = -1.1 }
+    refute_raises { @c.u = :single }
     assert_equal(:single, @c.u)
     doc = Nokogiri::XML(@c.to_xml_string(1, 1))
 
@@ -120,33 +120,33 @@ class RichTextRun < Test::Unit::TestCase
   end
 
   def test_i
-    assert_raise(ArgumentError) { @c.i = -1.1 }
-    assert_nothing_raised { @c.i = false }
-    refute(@c.i)
+    assert_raises(ArgumentError) { @c.i = -1.1 }
+    refute_raises { @c.i = false }
+    assert_false(@c.i)
   end
 
   def test_rFont
-    assert_raise(ArgumentError) { @c.font_name = -1.1 }
-    assert_nothing_raised { @c.font_name = "Arial" }
+    assert_raises(ArgumentError) { @c.font_name = -1.1 }
+    refute_raises { @c.font_name = "Arial" }
     assert_equal("Arial", @c.font_name)
   end
 
   def test_charset
-    assert_raise(ArgumentError) { @c.charset = -1.1 }
-    assert_nothing_raised { @c.charset = 1 }
+    assert_raises(ArgumentError) { @c.charset = -1.1 }
+    refute_raises { @c.charset = 1 }
     assert_equal(1, @c.charset)
   end
 
   def test_family
-    assert_raise(ArgumentError) { @rtr.family = 0 }
-    assert_nothing_raised { @rtr.family = 1 }
+    assert_raises(ArgumentError) { @rtr.family = 0 }
+    refute_raises { @rtr.family = 1 }
     assert_equal(1, @rtr.family)
   end
 
   def test_b
-    assert_raise(ArgumentError) { @c.b = -1.1 }
-    assert_nothing_raised { @c.b = false }
-    refute(@c.b)
+    assert_raises(ArgumentError) { @c.b = -1.1 }
+    refute_raises { @c.b = false }
+    assert_false(@c.b)
   end
 
   def test_multiline_autowidth

--- a/test/workbook/worksheet/tc_row.rb
+++ b/test/workbook/worksheet/tc_row.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestRow < Test::Unit::TestCase
+class TestRow < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet name: "hmmm"
@@ -106,7 +106,7 @@ class TestRow < Test::Unit::TestCase
     @ws.add_row row, escape_formulas: [true, false, true]
 
     assert(@ws.rows.last.cells.first.escape_formulas)
-    refute(@ws.rows.last.cells[1].escape_formulas)
+    assert_false(@ws.rows.last.cells[1].escape_formulas)
     assert(@ws.rows.last.cells[2].escape_formulas)
   end
 
@@ -117,32 +117,32 @@ class TestRow < Test::Unit::TestCase
   end
 
   def test_height
-    assert_raise(ArgumentError) { @row.height = -3 }
-    assert_nothing_raised { @row.height = 15 }
+    assert_raises(ArgumentError) { @row.height = -3 }
+    refute_raises { @row.height = 15 }
     assert_equal(15, @row.height)
   end
 
   def test_ph
-    assert_raise(ArgumentError) { @row.ph = -3 }
-    assert_nothing_raised { @row.ph = true }
+    assert_raises(ArgumentError) { @row.ph = -3 }
+    refute_raises { @row.ph = true }
     assert(@row.ph)
   end
 
   def test_hidden
-    assert_raise(ArgumentError) { @row.hidden = -3 }
-    assert_nothing_raised { @row.hidden = true }
+    assert_raises(ArgumentError) { @row.hidden = -3 }
+    refute_raises { @row.hidden = true }
     assert(@row.hidden)
   end
 
   def test_collapsed
-    assert_raise(ArgumentError) { @row.collapsed = -3 }
-    assert_nothing_raised { @row.collapsed = true }
+    assert_raises(ArgumentError) { @row.collapsed = -3 }
+    refute_raises { @row.collapsed = true }
     assert(@row.collapsed)
   end
 
   def test_outlineLevel
-    assert_raise(ArgumentError) { @row.outlineLevel = -3 }
-    assert_nothing_raised { @row.outlineLevel = 2 }
+    assert_raises(ArgumentError) { @row.outlineLevel = -3 }
+    refute_raises { @row.outlineLevel = 2 }
     assert_equal(2, @row.outlineLevel)
   end
 
@@ -178,7 +178,11 @@ class TestRow < Test::Unit::TestCase
     r = @ws.add_row(values, offset: offset, style: 1)
     r.cells.each_with_index do |c, index|
       assert_equal(c.style, index < offset ? 0 : 1)
-      assert_equal(c.value, index < offset ? nil : values[index - offset])
+      if index < offset
+        assert_nil(c.value)
+      else
+        assert_equal(c.value, values[index - offset])
+      end
     end
   end
 
@@ -189,7 +193,11 @@ class TestRow < Test::Unit::TestCase
     r = @ws.add_row(values, offset: offset, style: styles)
     r.cells.each_with_index do |c, index|
       assert_equal(c.style, index < offset ? 0 : styles[index - offset])
-      assert_equal(c.value, index < offset ? nil : values[index - offset])
+      if index < offset
+        assert_nil(c.value)
+      else
+        assert_equal(c.value, values[index - offset])
+      end
     end
   end
 

--- a/test/workbook/worksheet/tc_selection.rb
+++ b/test/workbook/worksheet/tc_selection.rb
@@ -2,33 +2,33 @@
 
 require 'tc_helper'
 
-class TestSelection < Test::Unit::TestCase
+class TestSelection < Minitest::Test
   def setup
     @options = { active_cell: 'A2', active_cell_id: 1, pane: :top_left, sqref: 'A2' }
     @selection = Axlsx::Selection.new(@options)
   end
 
   def test_active_cell
-    assert_raise(ArgumentError) { @selection.active_cell = :active_cell }
-    assert_nothing_raised { @selection.active_cell = "F5" }
+    assert_raises(ArgumentError) { @selection.active_cell = :active_cell }
+    refute_raises { @selection.active_cell = "F5" }
     assert_equal("F5", @selection.active_cell)
   end
 
   def test_active_cell_id
-    assert_raise(ArgumentError) { @selection.active_cell_id = "foo" }
-    assert_nothing_raised { @selection.active_cell_id = 11 }
+    assert_raises(ArgumentError) { @selection.active_cell_id = "foo" }
+    refute_raises { @selection.active_cell_id = 11 }
     assert_equal(11, @selection.active_cell_id)
   end
 
   def test_pane
-    assert_raise(ArgumentError) { @selection.pane = "foo´" }
-    assert_nothing_raised { @selection.pane = :bottom_right }
+    assert_raises(ArgumentError) { @selection.pane = "foo´" }
+    refute_raises { @selection.pane = :bottom_right }
     assert_equal("bottomRight", @selection.pane)
   end
 
   def test_sqref
-    assert_raise(ArgumentError) { @selection.sqref = :sqref }
-    assert_nothing_raised { @selection.sqref = "G32" }
+    assert_raises(ArgumentError) { @selection.sqref = :sqref }
+    refute_raises { @selection.sqref = "G32" }
     assert_equal("G32", @selection.sqref)
   end
 

--- a/test/workbook/worksheet/tc_sheet_calc_pr.rb
+++ b/test/workbook/worksheet/tc_sheet_calc_pr.rb
@@ -2,13 +2,13 @@
 
 require 'tc_helper'
 
-class TestSheetCalcPr < Test::Unit::TestCase
+class TestSheetCalcPr < Minitest::Test
   def setup
     @sheet_calc_pr = Axlsx::SheetCalcPr.new(full_calc_on_load: false)
   end
 
   def test_full_calc_on_load
-    refute @sheet_calc_pr.full_calc_on_load
+    assert_false @sheet_calc_pr.full_calc_on_load
     assert Axlsx::SheetCalcPr.new.full_calc_on_load
   end
 

--- a/test/workbook/worksheet/tc_sheet_format_pr.rb
+++ b/test/workbook/worksheet/tc_sheet_format_pr.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestSheetFormatPr < Test::Unit::TestCase
+class TestSheetFormatPr < Minitest::Test
   def setup
     @options = {
       base_col_width: 5,
@@ -32,48 +32,48 @@ class TestSheetFormatPr < Test::Unit::TestCase
   end
 
   def test_base_col_width
-    assert_raise(ArgumentError) { @sheet_format_pr.base_col_width = :foo }
-    assert_nothing_raised { @sheet_format_pr.base_col_width = 1 }
+    assert_raises(ArgumentError) { @sheet_format_pr.base_col_width = :foo }
+    refute_raises { @sheet_format_pr.base_col_width = 1 }
   end
 
   def test_outline_level_row
-    assert_raise(ArgumentError) { @sheet_format_pr.outline_level_row = :foo }
-    assert_nothing_raised { @sheet_format_pr.outline_level_row = 1 }
+    assert_raises(ArgumentError) { @sheet_format_pr.outline_level_row = :foo }
+    refute_raises { @sheet_format_pr.outline_level_row = 1 }
   end
 
   def test_outline_level_col
-    assert_raise(ArgumentError) { @sheet_format_pr.outline_level_col = :foo }
-    assert_nothing_raised { @sheet_format_pr.outline_level_col = 1 }
+    assert_raises(ArgumentError) { @sheet_format_pr.outline_level_col = :foo }
+    refute_raises { @sheet_format_pr.outline_level_col = 1 }
   end
 
   def test_default_row_height
-    assert_raise(ArgumentError) { @sheet_format_pr.default_row_height = :foo }
-    assert_nothing_raised { @sheet_format_pr.default_row_height = 1.0 }
+    assert_raises(ArgumentError) { @sheet_format_pr.default_row_height = :foo }
+    refute_raises { @sheet_format_pr.default_row_height = 1.0 }
   end
 
   def test_default_col_width
-    assert_raise(ArgumentError) { @sheet_format_pr.default_col_width = :foo }
-    assert_nothing_raised { @sheet_format_pr.default_col_width = 1.0 }
+    assert_raises(ArgumentError) { @sheet_format_pr.default_col_width = :foo }
+    refute_raises { @sheet_format_pr.default_col_width = 1.0 }
   end
 
   def test_custom_height
-    assert_raise(ArgumentError) { @sheet_format_pr.custom_height = :foo }
-    assert_nothing_raised { @sheet_format_pr.custom_height = true }
+    assert_raises(ArgumentError) { @sheet_format_pr.custom_height = :foo }
+    refute_raises { @sheet_format_pr.custom_height = true }
   end
 
   def test_zero_height
-    assert_raise(ArgumentError) { @sheet_format_pr.zero_height = :foo }
-    assert_nothing_raised { @sheet_format_pr.zero_height = true }
+    assert_raises(ArgumentError) { @sheet_format_pr.zero_height = :foo }
+    refute_raises { @sheet_format_pr.zero_height = true }
   end
 
   def test_thick_top
-    assert_raise(ArgumentError) { @sheet_format_pr.thick_top = :foo }
-    assert_nothing_raised { @sheet_format_pr.thick_top = true }
+    assert_raises(ArgumentError) { @sheet_format_pr.thick_top = :foo }
+    refute_raises { @sheet_format_pr.thick_top = true }
   end
 
   def test_thick_bottom
-    assert_raise(ArgumentError) { @sheet_format_pr.thick_bottom = :foo }
-    assert_nothing_raised { @sheet_format_pr.thick_bottom = true }
+    assert_raises(ArgumentError) { @sheet_format_pr.thick_bottom = :foo }
+    refute_raises { @sheet_format_pr.thick_bottom = true }
   end
 
   def test_to_xml_string

--- a/test/workbook/worksheet/tc_sheet_pr.rb
+++ b/test/workbook/worksheet/tc_sheet_pr.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestSheetPr < Test::Unit::TestCase
+class TestSheetPr < Minitest::Test
   def setup
     worksheet = Axlsx::Package.new.workbook.add_worksheet
     @options = {

--- a/test/workbook/worksheet/tc_sheet_protection.rb
+++ b/test/workbook/worksheet/tc_sheet_protection.rb
@@ -22,7 +22,7 @@ require 'tc_helper'
 # <xsd:attribute name="password" type="xsd:string" use="optional" default="nil"/>
 # </xsd:complexType>
 
-class TestSheetProtection < Test::Unit::TestCase
+class TestSheetProtection < Minitest::Test
   def setup
     # inverse defaults
     @boolean_options = { sheet: false, objects: true, scenarios: true, format_cells: false,
@@ -47,8 +47,8 @@ class TestSheetProtection < Test::Unit::TestCase
 
   def test_boolean_attribute_validation
     @boolean_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be boolean") { @sp.send(:"#{key}=", 'A') }
-      assert_nothing_raised { @sp.send(:"#{key}=", value) }
+      assert_raises(ArgumentError, "#{key} must be boolean") { @sp.send(:"#{key}=", 'A') }
+      refute_raises { @sp.send(:"#{key}=", value) }
     end
   end
 

--- a/test/workbook/worksheet/tc_sheet_view.rb
+++ b/test/workbook/worksheet/tc_sheet_view.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestSheetView < Test::Unit::TestCase
+class TestSheetView < Minitest::Test
   def setup
     # inverse defaults for booleans
     @boolean_options = { right_to_left: true, show_formulas: true, show_outline_symbols: false,
@@ -47,143 +47,143 @@ class TestSheetView < Test::Unit::TestCase
 
   def test_boolean_attribute_validation
     @boolean_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be boolean") { @sv.send(:"#{key}=", 'A') }
-      assert_nothing_raised { @sv.send(:"#{key}=", value) }
+      assert_raises(ArgumentError, "#{key} must be boolean") { @sv.send(:"#{key}=", 'A') }
+      refute_raises { @sv.send(:"#{key}=", value) }
     end
   end
 
   def test_string_attribute_validation
     @string_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be string") { @sv.send(:"#{key}=", :symbol) }
-      assert_nothing_raised { @sv.send(:"#{key}=", value) }
+      assert_raises(ArgumentError, "#{key} must be string") { @sv.send(:"#{key}=", :symbol) }
+      refute_raises { @sv.send(:"#{key}=", value) }
     end
   end
 
   def test_symbol_attribute_validation
     @symbol_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be symbol") { @sv.send(:"#{key}=", "foo") }
-      assert_nothing_raised { @sv.send(:"#{key}=", value) }
+      assert_raises(ArgumentError, "#{key} must be symbol") { @sv.send(:"#{key}=", "foo") }
+      refute_raises { @sv.send(:"#{key}=", value) }
     end
   end
 
   def test_integer_attribute_validation
     @integer_options.each do |key, value|
-      assert_raise(ArgumentError, "#{key} must be integer") { @sv.send(:"#{key}=", "foo") }
-      assert_nothing_raised { @sv.send(:"#{key}=", value) }
+      assert_raises(ArgumentError, "#{key} must be integer") { @sv.send(:"#{key}=", "foo") }
+      refute_raises { @sv.send(:"#{key}=", value) }
     end
   end
 
   def test_color_id
-    assert_raise(ArgumentError) { @sv.color_id = "10" }
-    assert_nothing_raised { @sv.color_id = 2 }
+    assert_raises(ArgumentError) { @sv.color_id = "10" }
+    refute_raises { @sv.color_id = 2 }
     assert_equal(2, @sv.color_id)
   end
 
   def test_default_grid_color
-    assert_raise(ArgumentError) { @sv.default_grid_color = "foo" }
-    assert_nothing_raised { @sv.default_grid_color = false }
-    refute(@sv.default_grid_color)
+    assert_raises(ArgumentError) { @sv.default_grid_color = "foo" }
+    refute_raises { @sv.default_grid_color = false }
+    assert_false(@sv.default_grid_color)
   end
 
   def test_right_to_left
-    assert_raise(ArgumentError) { @sv.right_to_left = "foo´" }
-    assert_nothing_raised { @sv.right_to_left = true }
+    assert_raises(ArgumentError) { @sv.right_to_left = "foo´" }
+    refute_raises { @sv.right_to_left = true }
     assert(@sv.right_to_left)
   end
 
   def test_show_formulas
-    assert_raise(ArgumentError) { @sv.show_formulas = 'foo' }
-    assert_nothing_raised { @sv.show_formulas = false }
-    refute(@sv.show_formulas)
+    assert_raises(ArgumentError) { @sv.show_formulas = 'foo' }
+    refute_raises { @sv.show_formulas = false }
+    assert_false(@sv.show_formulas)
   end
 
   def test_show_grid_lines
-    assert_raise(ArgumentError) { @sv.show_grid_lines = "foo" }
-    assert_nothing_raised { @sv.show_grid_lines = false }
-    refute(@sv.show_grid_lines)
+    assert_raises(ArgumentError) { @sv.show_grid_lines = "foo" }
+    refute_raises { @sv.show_grid_lines = false }
+    assert_false(@sv.show_grid_lines)
   end
 
   def test_show_outline_symbols
-    assert_raise(ArgumentError) { @sv.show_outline_symbols = 'foo' }
-    assert_nothing_raised { @sv.show_outline_symbols = true }
+    assert_raises(ArgumentError) { @sv.show_outline_symbols = 'foo' }
+    refute_raises { @sv.show_outline_symbols = true }
     assert(@sv.show_outline_symbols)
   end
 
   def test_show_row_col_headers
-    assert_raise(ArgumentError) { @sv.show_row_col_headers = "foo" }
-    assert_nothing_raised { @sv.show_row_col_headers = false }
-    refute(@sv.show_row_col_headers)
+    assert_raises(ArgumentError) { @sv.show_row_col_headers = "foo" }
+    refute_raises { @sv.show_row_col_headers = false }
+    assert_false(@sv.show_row_col_headers)
   end
 
   def test_show_ruler
-    assert_raise(ArgumentError) { @sv.show_ruler = 'foo' }
-    assert_nothing_raised { @sv.show_ruler = false }
-    refute(@sv.show_ruler)
+    assert_raises(ArgumentError) { @sv.show_ruler = 'foo' }
+    refute_raises { @sv.show_ruler = false }
+    assert_false(@sv.show_ruler)
   end
 
   def test_show_white_space
-    assert_raise(ArgumentError) { @sv.show_white_space = 'foo' }
-    assert_nothing_raised { @sv.show_white_space = false }
-    refute(@sv.show_white_space)
+    assert_raises(ArgumentError) { @sv.show_white_space = 'foo' }
+    refute_raises { @sv.show_white_space = false }
+    assert_false(@sv.show_white_space)
   end
 
   def test_show_zeros
-    assert_raise(ArgumentError) { @sv.show_zeros = "foo" }
-    assert_nothing_raised { @sv.show_zeros = false }
-    refute(@sv.show_zeros)
+    assert_raises(ArgumentError) { @sv.show_zeros = "foo" }
+    refute_raises { @sv.show_zeros = false }
+    assert_false(@sv.show_zeros)
   end
 
   def test_tab_selected
-    assert_raise(ArgumentError) { @sv.tab_selected = "foo" }
-    assert_nothing_raised { @sv.tab_selected = false }
-    refute(@sv.tab_selected)
+    assert_raises(ArgumentError) { @sv.tab_selected = "foo" }
+    refute_raises { @sv.tab_selected = false }
+    assert_false(@sv.tab_selected)
   end
 
   def test_top_left_cell
-    assert_raise(ArgumentError) { @sv.top_left_cell = :cell_adress }
-    assert_nothing_raised { @sv.top_left_cell = "A2" }
+    assert_raises(ArgumentError) { @sv.top_left_cell = :cell_adress }
+    refute_raises { @sv.top_left_cell = "A2" }
     assert_equal("A2", @sv.top_left_cell)
   end
 
   def test_view
-    assert_raise(ArgumentError) { @sv.view = 'view' }
-    assert_nothing_raised { @sv.view = :page_break_preview }
+    assert_raises(ArgumentError) { @sv.view = 'view' }
+    refute_raises { @sv.view = :page_break_preview }
     assert_equal(:page_break_preview, @sv.view)
   end
 
   def test_window_protection
-    assert_raise(ArgumentError) { @sv.window_protection = "foo" }
-    assert_nothing_raised { @sv.window_protection = false }
-    refute(@sv.window_protection)
+    assert_raises(ArgumentError) { @sv.window_protection = "foo" }
+    refute_raises { @sv.window_protection = false }
+    assert_false(@sv.window_protection)
   end
 
   def test_workbook_view_id
-    assert_raise(ArgumentError) { @sv.workbook_view_id = "1" }
-    assert_nothing_raised { @sv.workbook_view_id = 1 }
+    assert_raises(ArgumentError) { @sv.workbook_view_id = "1" }
+    refute_raises { @sv.workbook_view_id = 1 }
     assert_equal(1, @sv.workbook_view_id)
   end
 
   def test_zoom_scale
-    assert_raise(ArgumentError) { @sv.zoom_scale = "50" }
-    assert_nothing_raised { @sv.zoom_scale = 50 }
+    assert_raises(ArgumentError) { @sv.zoom_scale = "50" }
+    refute_raises { @sv.zoom_scale = 50 }
     assert_equal(50, @sv.zoom_scale)
   end
 
   def test_zoom_scale_normal
-    assert_raise(ArgumentError) { @sv.zoom_scale_normal = "50" }
-    assert_nothing_raised { @sv.zoom_scale_normal = 50 }
+    assert_raises(ArgumentError) { @sv.zoom_scale_normal = "50" }
+    refute_raises { @sv.zoom_scale_normal = 50 }
     assert_equal(50, @sv.zoom_scale_normal)
   end
 
   def test_zoom_scale_page_layout_view
-    assert_raise(ArgumentError) { @sv.zoom_scale_page_layout_view = "50" }
-    assert_nothing_raised { @sv.zoom_scale_page_layout_view = 50 }
+    assert_raises(ArgumentError) { @sv.zoom_scale_page_layout_view = "50" }
+    refute_raises { @sv.zoom_scale_page_layout_view = 50 }
     assert_equal(50, @sv.zoom_scale_page_layout_view)
   end
 
   def test_zoom_scale_sheet_layout_view
-    assert_raise(ArgumentError) { @sv.zoom_scale_sheet_layout_view = "50" }
-    assert_nothing_raised { @sv.zoom_scale_sheet_layout_view = 50 }
+    assert_raises(ArgumentError) { @sv.zoom_scale_sheet_layout_view = "50" }
+    refute_raises { @sv.zoom_scale_sheet_layout_view = 50 }
     assert_equal(50, @sv.zoom_scale_sheet_layout_view)
   end
 

--- a/test/workbook/worksheet/tc_table.rb
+++ b/test/workbook/worksheet/tc_table.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestTable < Test::Unit::TestCase
+class TestTable < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet

--- a/test/workbook/worksheet/tc_table_style_info.rb
+++ b/test/workbook/worksheet/tc_table_style_info.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestTableStyleInfo < Test::Unit::TestCase
+class TestTableStyleInfo < Minitest::Test
   def setup
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet
@@ -28,7 +28,7 @@ class TestTableStyleInfo < Test::Unit::TestCase
   def test_boolean_properties
     table_style = Axlsx::TableStyleInfo.new
     @options.each_key do |key|
-      assert_nothing_raised { table_style.send(:"#{key.to_sym}=", true) }
+      refute_raises { table_style.send(:"#{key.to_sym}=", true) }
       assert_raises(ArgumentError) { table_style.send(key.to_sym, 'foo') }
     end
   end

--- a/test/workbook/worksheet/tc_worksheet_hyperlink.rb
+++ b/test/workbook/worksheet/tc_worksheet_hyperlink.rb
@@ -2,7 +2,7 @@
 
 require 'tc_helper'
 
-class TestWorksheetHyperlink < Test::Unit::TestCase
+class TestWorksheetHyperlink < Minitest::Test
   def setup
     p = Axlsx::Package.new
     wb = p.workbook
@@ -12,7 +12,7 @@ class TestWorksheetHyperlink < Test::Unit::TestCase
   end
 
   def test_initailize
-    assert_raise(ArgumentError) { Axlsx::WorksheetHyperlink.new }
+    assert_raises(ArgumentError) { Axlsx::WorksheetHyperlink.new }
   end
 
   def test_location


### PR DESCRIPTION
Time to modernize. This is a pretty straightforward conversion, and I shimmed two method which don't natively exist in Minitest, but let's keep them for clarity:
- `assert_false` (not the same as `refute`, which allows any falsey value)
- `refute_raises`

There are no changes to lib (non-test) code.