### PR TITLE
Use a single merge instead of merge chain

### DIFF
--- a/lib/axlsx/stylesheet/styles.rb
+++ b/lib/axlsx/stylesheet/styles.rb
@@ -245,7 +245,7 @@ module Axlsx
 
         font_defaults = { name: @fonts.first.name, sz: @fonts.first.sz, family: @fonts.first.family }
 
-        raw_style = { type: :xf }.merge(font_defaults).merge(options)
+        raw_style = { type: :xf }.merge(font_defaults, options)
 
         if raw_style[:format_code]
           raw_style.delete(:num_fmt)

--- a/test/workbook/worksheet/tc_data_validation.rb
+++ b/test/workbook/worksheet/tc_data_validation.rb
@@ -16,7 +16,7 @@ class TestDataValidation < Minitest::Test
     @string_options = { formula1: 'foo', formula2: 'foo', error: 'foo', errorTitle: 'foo', prompt: 'foo', promptTitle: 'foo', sqref: 'foo' }
     @symbol_options = { errorStyle: :warning, operator: :lessThan, type: :whole }
 
-    @options = @boolean_options.merge(@nil_options).merge(@type_option).merge(@error_style_option)
+    @options = @boolean_options.merge(@nil_options, @type_option, @error_style_option)
 
     @dv = Axlsx::DataValidation.new(@options)
   end

--- a/test/workbook/worksheet/tc_sheet_view.rb
+++ b/test/workbook/worksheet/tc_sheet_view.rb
@@ -13,10 +13,10 @@ class TestSheetView < Minitest::Test
     @int_0 = { zoom_scale_normal: 100, zoom_scale_page_layout_view: 100, zoom_scale_sheet_layout_view: 100, workbook_view_id: 2 }
     @int_100 = { zoom_scale: 10 }
 
-    @integer_options = { color_id: 2, workbook_view_id: 2 }.merge(@int_0).merge(@int_100)
+    @integer_options = { color_id: 2, workbook_view_id: 2 }.merge(@int_0, @int_100)
     @string_options = { top_left_cell: 'A2' }
 
-    @options = @boolean_options.merge(@boolean_options).merge(@symbol_options).merge(@nil_options).merge(@int_0).merge(@int_100)
+    @options = @boolean_options.merge(@boolean_options, @symbol_options, @nil_options, @int_0, @int_100)
 
     @sv = Axlsx::SheetView.new(@options)
   end


### PR DESCRIPTION
Starting from Ruby 2.6, it is possible to pass multiple hashes to `Hash#merge`

Ref: https://ruby-doc.org/core-2.6/Hash.html#method-i-merge


Ruby 2.6 on M1 Pro

```
Comparison:
         merge(X, Y):  4287524.9 i/s
   merge(X).merge(Y):  2785848.9 i/s - 1.54x  (± 0.00) slower

Comparison:
         merge(X, Y):        232 allocated
   merge(X).merge(Y):        464 allocated - 2.00x more
```

Ref: rubocop/rubocop-performance#447

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).