### PR TITLE
Fix typos in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ CHANGELOG
   - [PR #186](https://github.com/caxlsx/caxlsx/pull/186) - `escape_formulas` should handle all [OWASP-designated formula prefixes](https://owasp.org/www-community/attacks/CSV_Injection).
   - Fix bug when calling `worksheet.add_border("A1:B2", nil)`
   - Change `BorderCreator#initialize` arguments handling
-  - Fix `add_border` to work with singluar cell refs
+  - Fix `add_border` to work with singular cell refs
   - [PR #196](https://github.com/caxlsx/caxlsx/pull/196) - Fix tab color reassignment
   - Add support for remote image source in `Pic` using External Relationship (supported in Excel documents)
 
@@ -167,7 +167,7 @@ CHANGELOG
     and charts to the same worksheet drawing.
   - Added outline_level_rows and outline_level_columns to worksheet to simplify setting up outlining in the worksheet.
   - Added support for pivot tables
-  - Added support for descrete border edge styles
+  - Added support for discrete border edge styles
   - Improved validation of sheet names
   - Added support for formula value caching so that iOS and OSX preview can show the proper values. See Cell.add_row and the formula_values option.
 
@@ -199,7 +199,7 @@ CHANGELOG
     from the initial master.
 
 - **September.8.12**: 1.2.3
-  - enhance exponential float/bigdecimal values rendering as strings intead
+  - enhance exponential float/bigdecimal values rendering as strings instead
     of 'numbers' in excel.
   - added support for :none option on chart axis labels
   - added support for paper_size option on worksheet.page_setup
@@ -233,14 +233,14 @@ CHANGELOG
    - added in interop requirements so that charts are properly exported
      to PDF from Libra Office
    - various readability improvements and work standardizing attribute
-     names to snake_case. Aliases are provided for backward compatiblity
+     names to snake_case. Aliases are provided for backward compatibility
 
 - **June.11.12**: 1.1.7
    - fix chart rendering issue when label offset is specified as a
      percentage in serialization and ensure that formula are not stored
 in value caches
    - fix bug that causes repair warnings when using a text only title reference.
-   - Add title property to axis so you can lable the x/y/series axis for
+   - Add title property to axis so you can label the x/y/series axis for
      charts.
    - Add sheet views with panes
 
@@ -250,14 +250,14 @@ in value caches
    - added support for two cell anchors for images
    - test coverage now back up to 100%
    - bugfix for merge cell sorting algorithm
-   - added fit_to method for page_setup to simplify managing witdh/height
+   - added fit_to method for page_setup to simplify managing width/height
    - added ph (phonetics) and s (style) attributes for row.
    - resolved all warnings generating from this gem.
    - improved comment relationship management for multiple comments
 
 - **May.13.12**: 1.1.5
    - MOAR print options! You can now specify paper size, orientation,
-     fit to width, page margings and gridlines for printing.
+     fit to width, page margins and gridlines for printing.
    - Support for adding comments to your worksheets
    - bugfix for applying style to empty cells
    - bugfix for parsing formula with multiple '='
@@ -332,7 +332,7 @@ in value caches
 
 - **January.6.12**: 1.0.15
    https://github.com/randym/axlsx/compare/1.0.14...1.0.15
-   - Bug fix add_style specified number formats must be explicity applied for libraOffice
+   - Bug fix add_style specified number formats must be explicitly applied for libraOffice
    - performance improvements from ochko when creating cells with options.
    - Bug fix setting types=>[:n] when adding a row incorrectly determines the cell type to be string as the value is null during creation.
    - Release in preparation for password protection merge
@@ -364,7 +364,7 @@ in value caches
 - **October.30.11**: 1.0.10
   - Updating gemspec to lower gem version requirements.
   - Added row.style assignation for updating the cell style for an entire row
-  - Added col_style method to worksheet upate a the style for a column of cells
+  - Added col_style method to worksheet update a the style for a column of cells
   - Added cols for an easy reference to columns in a worksheet.
   - prep for pre release of acts_as_xlsx gem
   - added in travis.ci configuration and build status
@@ -379,14 +379,14 @@ in value caches
   - Added support for images (jpg, gif, png) in worksheets.
 
 - **October.23.11**: 1.0.7 released
-  - Added support for 3D options when creating a new chart. This lets you set the persective, rotation and other 3D attributes when using worksheet.add_chart
+  - Added support for 3D options when creating a new chart. This lets you set the perspective, rotation and other 3D attributes when using worksheet.add_chart
   - Updated serialization write test to verify write permissions and warn if it cannot run the test due to permission restrcitions.
   - updated rake to include build, genoc and deploy tasks.
   - rebuilt documentation.
   - moved version constant to its own file
   - fixed bug in SerAxis that was requiring tickLblSkip and tickMarkSkip to be boolean. Should be unsigned int.
   - Review and improve docs
-  - rebuild of anchor positioning to remove some spagetti code. Chart now supports a start_at and end_at method that accept an arrar for col/row positioning. See example6 for an example. You can still pass :start_at and :end_at options to worksheet.add_chart.
+  - rebuild of anchor positioning to remove some spaghetti code. Chart now supports a start_at and end_at method that accept an arrar for col/row positioning. See example6 for an example. You can still pass :start_at and :end_at options to worksheet.add_chart.
   - Refactored cat and val axis data to keep series serialization a bit more DRY
 
 - **October.22.11**: 1.0.6
@@ -406,7 +406,7 @@ in value caches
   - BugFix: shape attribute for bar chart is now properly serialized
   - BugFix: date1904 property now properly set for charts
   - Added style property to charts
-  - Removed serialization write test as it most commonly fails when run from the gem's intalled directory
+  - Removed serialization write test as it most commonly fails when run from the gem's installed directory
 
 - **October.21.11**: 1.0.4
   - altered package to accept a filename string for serialization instead of a File object.

--- a/docs/style_reference.md
+++ b/docs/style_reference.md
@@ -4,8 +4,8 @@
 - `u` (Boolean) - Underline
 - `fg_color` (String) - Text Color - Ex: `000000`
 - `bg_color` (String) - Cell background color - Ex: `CCCCCC`
-- `alignment` (Hash) - Text alignment. 
-    - Available sub-options are `:horizontal`, `:vertical`, `:wrap_text`. 
+- `alignment` (Hash) - Text alignment.
+    - Available sub-options are `:horizontal`, `:vertical`, `:wrap_text`.
     - Example:  `alignment: {horizontal: true, vertical: true, wrap_text: false}`
 - `strike` (Boolean) - Indicates if the text should be rendered with a strikethrough
 - `outline` (Boolean) - Indicates if the text should be rendered with a shadow
@@ -19,7 +19,7 @@
   - `5` - Decorative
 - `charset` (Integer) - The character set to use. Axlsx documentation says this setting is ignored most of the time.
 - `type` (Symbol) - Type of the cell. Options are: `:xf` (Default) or `:dxf`
-- `border` (Hash) - Borders support style, color and edges options. Example: `border: {style: :thin, color: "000000", edges: [:top, :bottom, :left, :right]}`. Available styles for the border are: 
+- `border` (Hash) - Borders support style, color and edges options. Example: `border: {style: :thin, color: "000000", edges: [:top, :bottom, :left, :right]}`. Available styles for the border are:
   - `:none`
   - `:thin`
   - `:medium`
@@ -40,10 +40,10 @@
 - `num_fmt` (Integer) - See section below
 
 # `format_code` and `num_fmt`
-To output a dollar sign, comma's every three values, and minumum two decimal places use: 
+To output a dollar sign, comma's every three values, and minimum two decimal places use:
 `format_code: '\$#,##0.00'`
 
-This will output a nicely formatted date/time: 
+This will output a nicely formatted date/time:
 `m/d/yyyy h:mm:ss AM/PM`
 
 I think its much more preferable to write out the `format_code` manually instead of using `num_fmt` however the option is there.
@@ -51,7 +51,7 @@ I think its much more preferable to write out the `format_code` manually instead
 Heres a list of the `num_fmt` code (left side) and corresponding `format_code` string (right side)
 
 - `1` - `'0'`
-- `2` - `'0.00'` 
+- `2` - `'0.00'`
 - `3` - `'#,##0'`
 - `4` - `'#,##0.00'`
 - `5` - `'$#,##0_);($#,##0)'`

--- a/examples/hide_sheet_example.md
+++ b/examples/hide_sheet_example.md
@@ -15,11 +15,11 @@ wb.add_worksheet(name: 'normal') do |sheet|
 end
 
 wb.add_worksheet(name: 'hidden', state: :hidden) do |sheet|
-  sheet.add_row ['you cant see me!']
+  sheet.add_row ["you can't see me!"]
 end
 
 wb.add_worksheet(name: 'very hidden', state: :very_hidden) do |sheet|
-  sheet.add_row ['you really cant see me!']
+  sheet.add_row ["you really can't see me!"]
 end
 
 p.serialize 'hide_sheet_example.xlsx'

--- a/examples/row_heights_example.md
+++ b/examples/row_heights_example.md
@@ -11,7 +11,7 @@ p = Axlsx::Package.new
 wb = p.workbook
 
 wb.add_worksheet(name: 'Row heights') do |sheet|
-  sheet.add_row ['This row will have a fixed height', 'It will overwite the default row height'], height: 30
+  sheet.add_row ['This row will have a fixed height', 'It will overwrite the default row height'], height: 30
   sheet.add_row ['This row can have a different height too'], height: 10
   sheet.add_row ['This row is the original']
 end


### PR DESCRIPTION
```
codespell **/*.md -w
```

Also strip some trailing whitespaces
