### PR TITLE
Fix potential false positive assertion

### DIFF
--- a/test/stylesheet/tc_styles.rb
+++ b/test/stylesheet/tc_styles.rb
@@ -62,7 +62,7 @@ class TestStyles < Minitest::Test
     parts = @styles.borders.last.prs
 
     parts.each { |pr| assert_equal("0000FFFF", pr.color.rgb, "Style is applied to #{pr.name} properly") }
-    assert_equal(2, (parts.map { |pr| pr.name.to_s }.sort && ['bottom', 'top']).size, "specify two edges, and you get two border prs")
+    assert_equal(2, (parts.map { |pr| pr.name.to_s }.sort & ['bottom', 'top']).size, "specify two edges, and you get two border prs")
   end
 
   def test_do_not_alter_options_in_add_style


### PR DESCRIPTION
Changed `&&` to `&` in assertion to correctly perform array intersection. `&&` was incorrectly used as a logical AND, so the result of `truthy_value && ['bottom', 'top']` returned `['bottom', 'top']`

```
[] && ['bottom', 'top']
 => ["bottom", "top"] 
```

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).