### PR TITLE
Update RuboCop and add Packaging extension

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 require:
+  - rubocop-packaging
   - rubocop-performance
   - rubocop-minitest
 
@@ -41,6 +42,9 @@ Minitest/RefuteFalse:
   Enabled: false
 
 Naming:
+  Enabled: true
+
+Packaging:
   Enabled: true
 
 Performance:

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,9 @@ group :development, :test do
   gem 'yard'
 
   if RUBY_VERSION >= '2.7'
-    gem 'rubocop', '1.65.0'
+    gem 'rubocop', '1.65.1'
     gem 'rubocop-minitest', '0.35.1'
+    gem 'rubocop-packaging', '0.5.2'
     gem 'rubocop-performance', '1.21.1'
   end
 end


### PR DESCRIPTION
RuboCop::Packaging helps to enforce some of the guidelines that are expected of upstream maintainers so that the downstream can build their packages in a clean environment without any problems.
