### PR TITLE
Add `uri_parser` method for RFC2396 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 - **Unreleased**
   - [PR #359](https://github.com/caxlsx/caxlsx/pull/359) Add `PivotTable#grand_totals` option to remove grand totals row/col
   - [PR #362](https://github.com/caxlsx/caxlsx/pull/362) Use widest width even if provided as fixed value
+  - [PR #398](https://github.com/caxlsx/caxlsx/pull/398) Add `Axlsx#uri_parser` method for RFC2396 compatibility
 
 - **February.26.24**: 4.1.0
   - [PR #316](https://github.com/caxlsx/caxlsx/pull/316) Prevent camelization of hyperlink locations

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -33,6 +33,7 @@ require 'bigdecimal'
 require 'cgi'
 require 'set'
 require 'time'
+require 'uri'
 
 if Gem.loaded_specs.key?("axlsx_styler")
   raise StandardError, "Please remove `axlsx_styler` from your Gemfile, the associated functionality is now built-in to `caxlsx` directly."
@@ -228,5 +229,20 @@ module Axlsx
   def self.escape_formulas=(value)
     Axlsx.validate_boolean(value)
     @escape_formulas = value
+  end
+
+  # Returns a URI parser instance, preferring RFC2396_PARSER if available,
+  # otherwise falling back to DEFAULT_PARSER. This method ensures consistent
+  # URI parsing across different Ruby versions.
+  # This method can be removed when dropping compatibility for Ruby < 3.4
+  # See https://github.com/ruby/uri/pull/114 for details.
+  # @return [Object]
+  def self.uri_parser
+    @uri_parser ||=
+      if defined?(URI::RFC2396_PARSER)
+        URI::RFC2396_PARSER
+      else
+        URI::DEFAULT_PARSER
+      end
   end
 end

--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -80,7 +80,7 @@ module Axlsx
     def image_src=(v)
       Axlsx.validate_string(v)
       if remote?
-        RegexValidator.validate('Pic.image_src', /\A#{URI::DEFAULT_PARSER.make_regexp}\z/, v)
+        RegexValidator.validate('Pic.image_src', /\A#{Axlsx.uri_parser.make_regexp}\z/, v)
         RestrictionValidator.validate 'Pic.image_src', ALLOWED_MIME_TYPES, MimeTypeUtils.get_mime_type_from_uri(v)
       else
         RestrictionValidator.validate 'Pic.image_src', ALLOWED_MIME_TYPES, MimeTypeUtils.get_mime_type(v)


### PR DESCRIPTION
This commit introduces a new method `Axlsx#uri_parser` to handle URI parsing in a way that's compatible with both newer and older versions of Ruby's URI library. It checks for the presence of `URI::RFC2396_PARSER` and falls back to `URI::DEFAULT_PARSER` if not available, ensuring consistent behavior across different Ruby versions.

Close #397

Ref: ruby/uri#114

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).