### PR TITLE
Fix warning in `AutoFilter#add_column` test

### DIFF
--- a/test/workbook/worksheet/auto_filter/tc_auto_filter.rb
+++ b/test/workbook/worksheet/auto_filter/tc_auto_filter.rb
@@ -27,9 +27,7 @@ class TestAutoFilter < Minitest::Test
   end
 
   def test_add_column
-    @auto_filter.add_column(0, :filters) do |column|
-      assert_kind_of FilterColumn, column
-    end
+    assert_kind_of Axlsx::FilterColumn, @auto_filter.add_column(0, :filters)
   end
 
   def test_applya


### PR DESCRIPTION
The previous test for `AutoFilter#add_column` was passing a block to the method, which was not being used and triggered a warning. This commit modifies the test to directly assert on the return value of `add_column` instead.

This change ensures that the test actually verifies the correct behavior of the `add_column` method, eliminating the potential for false positives and addressing the related warning about ignored blocks.

Close #399
