### PR TITLE
Reorganize dependencies in axlsx.rb

### DIFF
--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -1,8 +1,19 @@
 # frozen_string_literal: true
 
-require 'htmlentities'
 require 'axlsx/version'
+
+# gemspec dependencies
+require 'htmlentities'
 require 'marcel'
+require 'nokogiri'
+require 'zip'
+
+# Ruby core dependencies
+require 'bigdecimal'
+require 'cgi'
+require 'set'
+require 'time'
+require 'uri'
 
 require 'axlsx/util/simple_typed_list'
 require 'axlsx/util/constants'
@@ -24,16 +35,6 @@ require 'axlsx/rels/relationships'
 require 'axlsx/drawing/drawing'
 require 'axlsx/workbook/workbook'
 require 'axlsx/package'
-# required gems
-require 'nokogiri'
-require 'zip'
-
-# core dependencies
-require 'bigdecimal'
-require 'cgi'
-require 'set'
-require 'time'
-require 'uri'
 
 if Gem.loaded_specs.key?("axlsx_styler")
   raise StandardError, "Please remove `axlsx_styler` from your Gemfile, the associated functionality is now built-in to `caxlsx` directly."


### PR DESCRIPTION
Requires #398

---

Reorganize dependencies in axlsx.rb 

- Group external and core gem dependencies at the top of the file
- Ensure all dependencies are loaded before internal library files

This change improves the organization and readability of the axlsx.rb
file, making it easier for developers to understand and maintain the
library's dependency structure. The new arrangement provides a clearer
overview of both external and core dependencies required by the axlsx
library.