### PR TITLE
Fix Lint/AmbiguousOperatorPrecedence offense

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,11 +21,6 @@ Layout/HashAlignment:
   Exclude:
     - 'lib/axlsx/workbook/worksheet/border_creator.rb'
 
-# This cop supports safe autocorrection (--autocorrect).
-Lint/AmbiguousOperatorPrecedence:
-  Exclude:
-    - 'lib/axlsx/workbook/worksheet/worksheet.rb'
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AllowSafeAssignment.
 Lint/AssignmentInCondition:

--- a/lib/axlsx/util/simple_typed_list.rb
+++ b/lib/axlsx/util/simple_typed_list.rb
@@ -90,19 +90,22 @@ module Axlsx
       self
     end
 
-    # join operator
-    # @param [Array] other the array to join
+    # Appends the elements of +others+ to self.
+    # @param [Array<Array>] others one or more arrays to join
     # @raise [ArgumentError] if any of the values being joined are not
     # one of the allowed types
     # @return [SimpleTypedList]
-    def +(other)
-      other.each do |item|
-        self << item
+    def concat(*others)
+      others.each do |other|
+        other.each do |item|
+          self << item
+        end
       end
-      super
+      self
     end
 
-    # Concat operator
+    # Pushes the given object on to the end of this array and returns the index
+    # of the item added.
     # @param [Any] v the data to be added
     # @raise [ArgumentError] if the value being added is not one of the allowed types
     # @return [Integer] returns the index of the item added.
@@ -112,7 +115,17 @@ module Axlsx
       size - 1
     end
 
-    alias :push :<<
+    # Pushes the given object(s) on to the end of this array. This expression
+    # returns the array itself, so several appends may be chained together.
+    # @param [Any] values the data to be added
+    # @raise [ArgumentError] if any of the values being joined are not
+    # @return [SimpleTypedList]
+    def push(*values)
+      values.each do |value|
+        self << value
+      end
+      self
+    end
 
     # delete the item from the list
     # @param [Any] v The item to be deleted.

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -666,12 +666,11 @@ module Axlsx
     # @return [Relationships]
     def relationships
       r = Relationships.new
-      r + [tables.relationships,
-           worksheet_comments.relationships,
-           hyperlinks.relationships,
-           worksheet_drawing.relationship,
-           pivot_tables.relationships].flatten.compact || []
-      r
+      r.concat [tables.relationships,
+                worksheet_comments.relationships,
+                hyperlinks.relationships,
+                worksheet_drawing.relationship,
+                pivot_tables.relationships].flatten.compact
     end
 
     # Returns the cell or cells defined using Excel style A1:B3 references.

--- a/test/util/tc_simple_typed_list.rb
+++ b/test/util/tc_simple_typed_list.rb
@@ -24,13 +24,13 @@ class TestSimpleTypedList < Minitest::Test
     refute_raises { @list[0] = 1 }
   end
 
-  def test_concat_assignment
+  def test_push_operator_assignment
     assert_raises(ArgumentError) { @list << nil }
     assert_raises(ArgumentError) { @list << "1" }
     refute_raises { @list << 1 }
   end
 
-  def test_concat_should_return_index
+  def test_push_operator_returns_index
     assert_empty(@list)
     assert_equal(0, @list << 1)
     assert_equal(1, @list << 2)
@@ -40,19 +40,47 @@ class TestSimpleTypedList < Minitest::Test
     assert_equal(0, @list.index(2))
   end
 
-  def test_push_should_return_index
-    assert_equal(0, @list.push(1))
-    assert_equal(1, @list.push(2))
-    @list.delete_at 0
+  # rubocop:disable Style/ConcatArrayLiterals
+  def test_concat_assignment
+    assert_raises(ArgumentError) { @list.concat([1, nil]) }
+    refute_raises { @list.concat [1] }
+  end
 
-    assert_equal(1, @list.push(3))
-    assert_equal(0, @list.index(2))
+  def test_concat_multiple_arrays
+    @list.concat([1], [2])
+
+    assert_equal([1, 2], @list)
+  end
+
+  def test_concat_returns_self
+    assert_equal(@list, @list.concat([1]))
+  end
+
+  def test_concat_mutates_object
+    @list.concat([1])
+
+    assert_equal([1], @list)
+  end
+  # rubocop:enable Style/ConcatArrayLiterals
+
+  def test_push_assignment
+    assert_raises(ArgumentError) { @list.push("1") }
+    assert_raises(ArgumentError) { @list.push(1, nil) }
+    refute_raises { @list.push(1, 2) }
+  end
+
+  def test_push_returns_self
+    assert_equal(@list, @list.push(1))
+  end
+
+  def test_push_mutates_object
+    @list.push(1)
+
+    assert_equal([1], @list)
   end
 
   def test_locking
-    @list.push 1
-    @list.push 2
-    @list.push 3
+    @list.push 1, 2, 3
     @list.lock
 
     assert_raises(ArgumentError) { @list.delete 1  }
@@ -79,8 +107,7 @@ class TestSimpleTypedList < Minitest::Test
   end
 
   def test_equality
-    @list.push 1
-    @list.push 2
+    @list.push 1, 2
 
     assert_equal([1, 2], @list)
   end


### PR DESCRIPTION
- Rename `+` method to `concat` for consistency with Array's API
- Avoid confusion caused by `+` unexpectedly modifying the receiver
- Prevent `Lint/Void` offense in static code analysis

Close #294

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).