### PR TITLE
Do not require bigdecimal

### DIFF
--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -9,7 +9,6 @@ require 'nokogiri'
 require 'zip'
 
 # Ruby core dependencies
-require 'bigdecimal'
 require 'cgi'
 require 'set'
 require 'time'


### PR DESCRIPTION
Requires #401

---

Remove unnecessary `bigdecimal` require

The `bigdecimal` require was introduced in commit 11303a4 but appears 
to be unnecessary.

After thoroughly inspecting the codebase, no instances  of `BigDecimal`
or methods like `to_d` and `to_digits` were found, indicating 
that the dependency can safely be removed.

Although `bigdecimal` is indirectly included via the `crack` gem, which
is  a dependency of `webmock`, the only occurrences of `webmock` in the
code  are related to test the method
`Axlsx::MimeTypeUtils.get_mime_type_from_uri` for detecting mime types
of remote files. In this context, `bigdecimal` is not used.

Close #404
