### PR TITLE
Configure Style/NumericPredicate for performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,3 +59,6 @@ Style:
 Style/NumericLiterals:
   Exclude:
     - 'lib/**/*'
+
+Style/NumericPredicate:
+  EnforcedStyle: comparison

--- a/lib/axlsx/content_type/abstract_content_type.rb
+++ b/lib/axlsx/content_type/abstract_content_type.rb
@@ -28,7 +28,7 @@ module Axlsx
     def to_xml_string(node_name = '', str = +'')
       str << '<' << node_name << ' '
       Axlsx.instance_values_for(self).each_with_index do |key_value, index|
-        str << ' ' unless index.zero?
+        str << ' ' unless index == 0
         str << Axlsx.camel(key_value.first) << '="' << key_value.last.to_s << '"'
       end
       str << '/>'

--- a/lib/axlsx/rels/relationship.rb
+++ b/lib/axlsx/rels/relationship.rb
@@ -116,7 +116,7 @@ module Axlsx
       h = Axlsx.instance_values_for(self).reject { |k, _| k == "source_obj" }
       str << '<Relationship '
       h.each_with_index do |key_value, index|
-        str << ' ' unless index.zero?
+        str << ' ' unless index == 0
         str << key_value.first.to_s << '="' << Axlsx.coder.encode(key_value.last.to_s) << '"'
       end
       str << '/>'

--- a/lib/axlsx/util/simple_typed_list.rb
+++ b/lib/axlsx/util/simple_typed_list.rb
@@ -57,7 +57,7 @@ module Axlsx
     # Transposes the list (without blowing up like ruby does)
     # any non populated cell in the matrix will be a nil value
     def transpose
-      return clone if size.zero?
+      return clone if size == 0
 
       row_count = size
       max_column_count = map { |row| row.cells.size }.max

--- a/lib/axlsx/workbook/worksheet/auto_filter/auto_filter.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/auto_filter.rb
@@ -80,7 +80,7 @@ module Axlsx
                            condition.order == :asc ? index1 <=> index2 : index2 <=> index1
                          end
 
-            break unless comparison.zero?
+            break unless comparison == 0
           end
 
           comparison

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -41,7 +41,7 @@ module Axlsx
       self.type = type unless type == :string
 
       val = options.delete(:style)
-      self.style = val unless val.nil? || val.zero?
+      self.style = val unless val.nil? || val == 0
       val = options.delete(:formula_value)
       self.formula_value = val unless val.nil?
       val = options.delete(:escape_formulas)
@@ -549,14 +549,14 @@ module Axlsx
 
       case type
       when :date
-        self.style = STYLE_DATE if style.zero?
+        self.style = STYLE_DATE if style == 0
         if !v.is_a?(Date) && v.respond_to?(:to_date)
           v.to_date
         else
           v
         end
       when :time
-        self.style = STYLE_DATE if style.zero?
+        self.style = STYLE_DATE if style == 0
         if !v.is_a?(Time) && v.respond_to?(:to_time)
           v.to_time
         else

--- a/lib/axlsx/workbook/worksheet/conditional_formatting.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting.rb
@@ -83,7 +83,7 @@ module Axlsx
     def to_xml_string(str = +'')
       str << '<conditionalFormatting sqref="' << sqref << '">'
       rules.each_with_index do |rule, index|
-        str << ' ' unless index.zero?
+        str << ' ' unless index == 0
         rule.to_xml_string(str)
       end
       str << '</conditionalFormatting>'

--- a/lib/axlsx/workbook/worksheet/data_validation.rb
+++ b/lib/axlsx/workbook/worksheet/data_validation.rb
@@ -278,7 +278,7 @@ module Axlsx
 
       str << '<dataValidation '
       h.each_with_index do |key_value, index|
-        str << ' ' unless index.zero?
+        str << ' ' unless index == 0
         str << key_value.first << '="' << Axlsx.booleanize(key_value.last).to_s << '"'
       end
       str << '>'


### PR DESCRIPTION
Switch from using predicate methods like `v.zero?` to direct comparisons
like `v == 0` for performance optimization.

Although this may not yield a visible improvement with the current
implementation, using `== 0` instead of `.zero?` in a method for cell
rendering could lead to significant performance gains in the future.

Benchmarks show that comparisons are faster than predicates across
multiple Ruby versions:

```
Comparison (Ruby 2.6 to 3.2, v = 0):
              v == 0: 21479329.3 i/s
             v.zero?: 17979885.4 i/s - 1.19x  (± 0.00) slower

Comparison (Ruby 3.3, v = 0):
              v == 0: 23652215.7 i/s
             v.zero?: 21843174.0 i/s - 1.08x  (± 0.00) slower

Comparison (Ruby 2.6 to 3.3, v = 1):
              v == 0: 23227474.2 i/s
             v.zero?: 21675200.9 i/s - 1.07x  (± 0.00) slower
```

---

Hello, 

~I'm having slightly and consistently better results on this branch. It is more noticeable on x64 Ruby. It depends on Ruby version and it's about 6% on 2.6.10 and 2% on 3.3.5~

~Can you try `test/benchmark.rb` (several times) to see if you have the same results?~

I can't confirm overall performance improvements, because this method is only invoked 29 times in benchmarks. However, if `,zero?` will be added to a method used to render cells, it would be a problem