### PR TITLE
Refactor border_creator for improved performance

### DIFF
--- a/lib/axlsx/workbook/worksheet/border_creator.rb
+++ b/lib/axlsx/workbook/worksheet/border_creator.rb
@@ -63,19 +63,19 @@ module Axlsx
     end
 
     def first_row
-      @first_row ||= first_cell.scan(/\d+/).first
+      @first_row ||= first_cell[/\d+/]
     end
 
     def first_col
-      @first_col ||= first_cell.scan(/\D+/).first
+      @first_col ||= first_cell[/\D+/]
     end
 
     def last_row
-      @last_row ||= last_cell.scan(/\d+/).first
+      @last_row ||= last_cell[/\d+/]
     end
 
     def last_col
-      @last_col ||= last_cell.scan(/\D+/).first
+      @last_col ||= last_cell[/\D+/]
     end
   end
 end


### PR DESCRIPTION
This commit updates the `border_creator.rb` file to use a regular expression match instead of `scan`

```rb
def scan
  'A1'.scan(/\d+/).first
end

def array_match
  'A1'[/\d+/]
end

raise if scan != array_match

%i[ips memory].each do |benchmark|
  Benchmark.send(benchmark) do |x|
    x.report('scan') { scan }
    x.report('array_match') { array_match }
    x.compare!
  end
end
```

```
IPS Comparison:
         array_match:  1770072.4 i/s
                scan:   824069.5 i/s - 2.15x  (± 0.00) slower

Memory Comparison:
         array_match:        208 allocated
                scan:        248 allocated - 1.19x more
```
