### PR TITLE
Use each with object instead of reduce to improve readability and performance

### DIFF
--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -89,12 +89,10 @@ module Axlsx
     letters_str = name[/[A-Z]+/]
 
     # capitalization?!?
-    v = letters_str.reverse.chars.reduce({ base: 1, i: 0 }) do |val, c|
+    v = letters_str.reverse.chars.each_with_object({ base: 1, i: 0 }) do |c, val|
       val[:i] += ((c.bytes.first - 64) * val[:base])
 
       val[:base] *= 26
-
-      next val
     end
 
     col_index = (v[:i] - 1)


### PR DESCRIPTION
Slightly simplifies the code and gives a minor performance improvement
on newer Ruby versions

M1 Pro, Ruby 3.3.5 x64, single char:

```
 name_to_indices_new:  1370019.0 i/s
     name_to_indices:  1322752.7 i/s - 1.04x  (± 0.00) slower
```

M1 Pro, Ruby 3.3.3 ARM, single char:

```
 name_to_indices_new:  2324745.0 i/s
     name_to_indices:  2157339.6 i/s - 1.08x  (± 0.00) slower
```
