### PR TITLE
Bump Rubyzip requirement to >= 2.4 to allow 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 CHANGELOG
 ---------
 - **Unreleased**
+  - [PR #421](https://github.com/caxlsx/caxlsx/pull/421) Add Rubyzip >= 2.4 support
 
 - **December.15.24**: 4.2.0
   - [PR #359](https://github.com/caxlsx/caxlsx/pull/359) Add `PivotTable#grand_totals` option to remove grand totals row/col

--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "htmlentities", "~> 4.3", '>= 4.3.4'
   s.add_dependency "marcel", '~> 1.0'
   s.add_dependency 'nokogiri', '~> 1.10', '>= 1.10.4'
-  s.add_dependency 'rubyzip', '>= 1.3.0', '< 3'
+  s.add_dependency 'rubyzip', '>= 2.4', '< 4'
 
   s.required_ruby_version = '>= 2.6'
   s.require_path = 'lib'

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -211,7 +211,8 @@ module Axlsx
     # @return [Zip::Entry]
     def zip_entry_for_part(part)
       timestamp = Zip::DOSTime.at(@core.created.to_i)
-      Zip::Entry.new("", part[:entry], "", "", 0, 0, Zip::Entry::DEFLATED, 0, timestamp)
+
+      Zip::Entry.new("", part[:entry], time: timestamp)
     end
 
     # The parts of a package

--- a/lib/axlsx/util/buffered_zip_output_stream.rb
+++ b/lib/axlsx/util/buffered_zip_output_stream.rb
@@ -19,7 +19,7 @@ module Axlsx
     #
     # The directory and its contents are removed at the end of the block.
     def self.open(file_name, encrypter = nil)
-      Zip::OutputStream.open(file_name, encrypter) do |zos|
+      Zip::OutputStream.open(file_name, encrypter: encrypter) do |zos|
         bzos = new(zos)
         yield(bzos)
       ensure
@@ -28,7 +28,7 @@ module Axlsx
     end
 
     def self.write_buffer(io = ::StringIO.new, encrypter = nil)
-      Zip::OutputStream.write_buffer(io, encrypter) do |zos|
+      Zip::OutputStream.write_buffer(io, encrypter: encrypter) do |zos|
         bzos = new(zos)
         yield(bzos)
       ensure


### PR DESCRIPTION
Since:
- As per Rubyzip's readme, it is not recommended to use any versions of Rubyzip earlier than 2.3 due to security issues
- Rubyzip 2.4 requires Ruby >= 2.4
- Caxlsx requires Ruby >= 2.6

This commit bumps the minimum required Rubyzip version to 2.4 and changes syntax accordingly to allow 3.0 compatibility with the minimum amount of changes to production code

Closes #384

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] ~I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.~
- [x] ~If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.~
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] ~I have updated the documentation accordingly.~
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).