### PR TITLE
Add --enable-frozen-string-literal to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,4 +43,4 @@ jobs:
 
     - name: Run tests
       run: |
-        bundle exec rake
+        RUBYOPT="--enable-frozen-string-literal" bundle exec rake


### PR DESCRIPTION
### Description
While trying to add `--enable-frozen-string-literal` in the CI of my dependent gem (spreadsheet_architect) I am seeing issues with `to_stream` 

```
FrozenError: can't modify frozen String: "<Types xmlns=\""
    caxlsx (3.4.1) lib/axlsx/content_type/content_type.rb:17:in `to_xml_string'
    caxlsx (3.4.1) lib/axlsx/package.rb:185:in `block in write_parts'
    caxlsx (3.4.1) lib/axlsx/package.rb:182:in `each'
    caxlsx (3.4.1) lib/axlsx/package.rb:182:in `write_parts'
    caxlsx (3.4.1) lib/axlsx/package.rb:134:in `to_stream'
```

Not sure what the difference is between the command line option and the magic comments. Creating this PR to try and find out.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).