### PR TITLE
Replace rubyzip with zip_kit

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency "marcel", '~> 1.0'
   s.add_dependency 'nokogiri', '~> 1.10', '>= 1.10.4'
   s.add_dependency 'rubyzip', '>= 2.4', '< 4'
+  s.add_dependency "zip_kit", "~> 6.0"
 
   s.required_ruby_version = '>= 2.6'
   s.require_path = 'lib'

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -22,6 +22,7 @@ require_relative 'axlsx/util/serialized_attributes'
 require_relative 'axlsx/util/options_parser'
 require_relative 'axlsx/util/mime_type_utils'
 require_relative 'axlsx/util/buffered_zip_output_stream'
+require_relative 'axlsx/util/zip_kit_output_stream'
 require_relative 'axlsx/util/zip_command'
 
 require_relative 'axlsx/stylesheet/styles'

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -6,7 +6,7 @@ require_relative 'axlsx/version'
 require 'htmlentities'
 require 'marcel'
 require 'nokogiri'
-require 'zip'
+require 'zip_kit'
 
 # Ruby core dependencies
 require 'cgi'

--- a/lib/axlsx/content_type/content_type.rb
+++ b/lib/axlsx/content_type/content_type.rb
@@ -12,7 +12,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'

--- a/lib/axlsx/content_type/content_type.rb
+++ b/lib/axlsx/content_type/content_type.rb
@@ -13,7 +13,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
       str << '<Types xmlns="' << XML_NS_T << '">'

--- a/lib/axlsx/doc_props/app.rb
+++ b/lib/axlsx/doc_props/app.rb
@@ -285,7 +285,9 @@ module Axlsx
     alias :DocSecurity= :doc_security=
 
     # Serialize the app.xml document
-    # @return [String]
+    #
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
       str << '<Properties xmlns="' << APP_NS << '" xmlns:vt="' << APP_NS_VT << '">'

--- a/lib/axlsx/doc_props/core.rb
+++ b/lib/axlsx/doc_props/core.rb
@@ -20,8 +20,9 @@ module Axlsx
     # Creation time of the document. If nil, the current time will be used.
     attr_accessor :created
 
-    # serializes the core.xml document
-    # @return [String]
+    # Serializes the core.xml document
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
       str << '<cp:coreProperties xmlns:cp="' << CORE_NS << '" xmlns:dc="' << CORE_NS_DC << '" '

--- a/lib/axlsx/drawing/area_chart.rb
+++ b/lib/axlsx/drawing/area_chart.rb
@@ -72,7 +72,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       super do

--- a/lib/axlsx/drawing/area_chart.rb
+++ b/lib/axlsx/drawing/area_chart.rb
@@ -73,7 +73,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       super do
         str << "<c:" << node_name << ">"

--- a/lib/axlsx/drawing/area_series.rb
+++ b/lib/axlsx/drawing/area_series.rb
@@ -69,7 +69,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       super do

--- a/lib/axlsx/drawing/area_series.rb
+++ b/lib/axlsx/drawing/area_series.rb
@@ -70,7 +70,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       super do
         if color

--- a/lib/axlsx/drawing/axes.rb
+++ b/lib/axlsx/drawing/axes.rb
@@ -24,7 +24,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @param [Hash] options
     # @option options ids
     # If the ids option is specified only the axis identifier is

--- a/lib/axlsx/drawing/axis.rb
+++ b/lib/axlsx/drawing/axis.rb
@@ -165,7 +165,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<c:axId val="' << @id.to_s << '"/>'
       @scaling.to_xml_string str

--- a/lib/axlsx/drawing/axis.rb
+++ b/lib/axlsx/drawing/axis.rb
@@ -164,7 +164,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<c:axId val="' << @id.to_s << '"/>'

--- a/lib/axlsx/drawing/bar_3D_chart.rb
+++ b/lib/axlsx/drawing/bar_3D_chart.rb
@@ -118,7 +118,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       super do

--- a/lib/axlsx/drawing/bar_3D_chart.rb
+++ b/lib/axlsx/drawing/bar_3D_chart.rb
@@ -119,7 +119,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       super do
         str << '<c:bar3DChart>'

--- a/lib/axlsx/drawing/bar_chart.rb
+++ b/lib/axlsx/drawing/bar_chart.rb
@@ -108,7 +108,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       super do

--- a/lib/axlsx/drawing/bar_chart.rb
+++ b/lib/axlsx/drawing/bar_chart.rb
@@ -109,7 +109,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       super do
         str << '<c:barChart>'

--- a/lib/axlsx/drawing/bar_series.rb
+++ b/lib/axlsx/drawing/bar_series.rb
@@ -60,7 +60,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       super do
         colors.each_with_index do |c, index|

--- a/lib/axlsx/drawing/bar_series.rb
+++ b/lib/axlsx/drawing/bar_series.rb
@@ -59,7 +59,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       super do

--- a/lib/axlsx/drawing/bubble_chart.rb
+++ b/lib/axlsx/drawing/bubble_chart.rb
@@ -34,7 +34,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       super do
         str << '<c:bubbleChart>'

--- a/lib/axlsx/drawing/bubble_chart.rb
+++ b/lib/axlsx/drawing/bubble_chart.rb
@@ -33,7 +33,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       super do

--- a/lib/axlsx/drawing/bubble_series.rb
+++ b/lib/axlsx/drawing/bubble_series.rb
@@ -40,7 +40,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       super do
         # needs to override the super color here to push in ln/and something else!

--- a/lib/axlsx/drawing/bubble_series.rb
+++ b/lib/axlsx/drawing/bubble_series.rb
@@ -39,7 +39,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       super do

--- a/lib/axlsx/drawing/cat_axis.rb
+++ b/lib/axlsx/drawing/cat_axis.rb
@@ -81,7 +81,7 @@ module Axlsx
     alias :lblOffset= :lbl_offset=
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<c:catAx>'

--- a/lib/axlsx/drawing/cat_axis.rb
+++ b/lib/axlsx/drawing/cat_axis.rb
@@ -82,7 +82,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<c:catAx>'
       super

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -223,7 +223,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -224,7 +224,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
       str << '<c:chartSpace xmlns:c="' << XML_NS_C << '" xmlns:a="' << XML_NS_A << '" xmlns:r="' << XML_NS_R << '">'

--- a/lib/axlsx/drawing/d_lbls.rb
+++ b/lib/axlsx/drawing/d_lbls.rb
@@ -70,7 +70,7 @@ module Axlsx
     end
 
     # serializes the data labels
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       validate_attributes_for_chart_type
       str << '<c:dLbls>'

--- a/lib/axlsx/drawing/drawing.rb
+++ b/lib/axlsx/drawing/drawing.rb
@@ -155,7 +155,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
       str << '<xdr:wsDr xmlns:xdr="' << XML_NS_XDR << '" xmlns:a="' << XML_NS_A << '">'

--- a/lib/axlsx/drawing/drawing.rb
+++ b/lib/axlsx/drawing/drawing.rb
@@ -154,7 +154,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'

--- a/lib/axlsx/drawing/graphic_frame.rb
+++ b/lib/axlsx/drawing/graphic_frame.rb
@@ -30,7 +30,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       # macro attribute should be optional!
       str << '<xdr:graphicFrame>'

--- a/lib/axlsx/drawing/graphic_frame.rb
+++ b/lib/axlsx/drawing/graphic_frame.rb
@@ -29,7 +29,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       # macro attribute should be optional!

--- a/lib/axlsx/drawing/hyperlink.rb
+++ b/lib/axlsx/drawing/hyperlink.rb
@@ -99,7 +99,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       serialized_tag 'a:hlinkClick', str, { 'r:id': relationship.Id, 'xmlns:r': XML_NS_R }

--- a/lib/axlsx/drawing/hyperlink.rb
+++ b/lib/axlsx/drawing/hyperlink.rb
@@ -100,7 +100,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       serialized_tag 'a:hlinkClick', str, { 'r:id': relationship.Id, 'xmlns:r': XML_NS_R }
     end

--- a/lib/axlsx/drawing/line_3D_chart.rb
+++ b/lib/axlsx/drawing/line_3D_chart.rb
@@ -56,7 +56,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       super do
         str << '<c:gapDepth val="' << @gap_depth.to_s << '"/>' unless @gap_depth.nil?

--- a/lib/axlsx/drawing/line_3D_chart.rb
+++ b/lib/axlsx/drawing/line_3D_chart.rb
@@ -55,7 +55,7 @@ module Axlsx
     alias :gapDepth= :gap_depth=
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       super do

--- a/lib/axlsx/drawing/line_chart.rb
+++ b/lib/axlsx/drawing/line_chart.rb
@@ -72,7 +72,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       super do

--- a/lib/axlsx/drawing/line_chart.rb
+++ b/lib/axlsx/drawing/line_chart.rb
@@ -73,7 +73,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       super do
         str << "<c:" << node_name << ">"

--- a/lib/axlsx/drawing/line_series.rb
+++ b/lib/axlsx/drawing/line_series.rb
@@ -69,7 +69,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       super do

--- a/lib/axlsx/drawing/line_series.rb
+++ b/lib/axlsx/drawing/line_series.rb
@@ -70,7 +70,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       super do
         if color

--- a/lib/axlsx/drawing/marker.rb
+++ b/lib/axlsx/drawing/marker.rb
@@ -70,7 +70,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       [:col, :colOff, :row, :rowOff].each do |k|
         str << '<xdr:' << k.to_s << '>' << send(k).to_s << '</xdr:' << k.to_s << '>'

--- a/lib/axlsx/drawing/marker.rb
+++ b/lib/axlsx/drawing/marker.rb
@@ -69,7 +69,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       [:col, :colOff, :row, :rowOff].each do |k|

--- a/lib/axlsx/drawing/num_data_source.rb
+++ b/lib/axlsx/drawing/num_data_source.rb
@@ -43,7 +43,7 @@ module Axlsx
     end
 
     # serialize the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     def to_xml_string(str = +'')
       str << '<c:' << tag_name.to_s << '>'
       if @f

--- a/lib/axlsx/drawing/one_cell_anchor.rb
+++ b/lib/axlsx/drawing/one_cell_anchor.rb
@@ -79,7 +79,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<xdr:oneCellAnchor>'
       str << '<xdr:from>'

--- a/lib/axlsx/drawing/one_cell_anchor.rb
+++ b/lib/axlsx/drawing/one_cell_anchor.rb
@@ -78,7 +78,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<xdr:oneCellAnchor>'

--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -197,7 +197,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<xdr:pic>'
       str << '<xdr:nvPicPr>'

--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -196,7 +196,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<xdr:pic>'

--- a/lib/axlsx/drawing/picture_locking.rb
+++ b/lib/axlsx/drawing/picture_locking.rb
@@ -32,7 +32,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       serialized_tag('a:picLocks', str)

--- a/lib/axlsx/drawing/picture_locking.rb
+++ b/lib/axlsx/drawing/picture_locking.rb
@@ -33,7 +33,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       serialized_tag('a:picLocks', str)
     end

--- a/lib/axlsx/drawing/pie_3D_chart.rb
+++ b/lib/axlsx/drawing/pie_3D_chart.rb
@@ -30,7 +30,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       super do
         str << '<c:pie3DChart>'

--- a/lib/axlsx/drawing/pie_3D_chart.rb
+++ b/lib/axlsx/drawing/pie_3D_chart.rb
@@ -29,7 +29,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       super do

--- a/lib/axlsx/drawing/pie_chart.rb
+++ b/lib/axlsx/drawing/pie_chart.rb
@@ -22,7 +22,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       super do
         str << '<c:pieChart>'

--- a/lib/axlsx/drawing/pie_chart.rb
+++ b/lib/axlsx/drawing/pie_chart.rb
@@ -21,7 +21,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       super do

--- a/lib/axlsx/drawing/pie_series.rb
+++ b/lib/axlsx/drawing/pie_series.rb
@@ -49,7 +49,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       super do
         str << '<c:explosion val="' << @explosion.to_s << '"/>' unless @explosion.nil?

--- a/lib/axlsx/drawing/pie_series.rb
+++ b/lib/axlsx/drawing/pie_series.rb
@@ -48,7 +48,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       super do

--- a/lib/axlsx/drawing/scaling.rb
+++ b/lib/axlsx/drawing/scaling.rb
@@ -59,7 +59,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<c:scaling>'

--- a/lib/axlsx/drawing/scaling.rb
+++ b/lib/axlsx/drawing/scaling.rb
@@ -60,7 +60,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<c:scaling>'
       str << '<c:logBase val="' << @logBase.to_s << '"/>' unless @logBase.nil?

--- a/lib/axlsx/drawing/scatter_chart.rb
+++ b/lib/axlsx/drawing/scatter_chart.rb
@@ -48,7 +48,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       super do
         str << '<c:scatterChart>'

--- a/lib/axlsx/drawing/scatter_chart.rb
+++ b/lib/axlsx/drawing/scatter_chart.rb
@@ -47,7 +47,7 @@ module Axlsx
     alias :scatterStyle= :scatter_style=
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       super do

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -79,7 +79,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       super do
         # needs to override the super color here to push in ln/and something else!

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -78,7 +78,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       super do

--- a/lib/axlsx/drawing/ser_axis.rb
+++ b/lib/axlsx/drawing/ser_axis.rb
@@ -36,7 +36,7 @@ module Axlsx
     alias :tickMarkSkip= :tick_mark_skip=
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<c:serAx>'

--- a/lib/axlsx/drawing/ser_axis.rb
+++ b/lib/axlsx/drawing/ser_axis.rb
@@ -37,7 +37,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<c:serAx>'
       super

--- a/lib/axlsx/drawing/series.rb
+++ b/lib/axlsx/drawing/series.rb
@@ -62,7 +62,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<c:ser>'
       str << '<c:idx val="' << index.to_s << '"/>'

--- a/lib/axlsx/drawing/series.rb
+++ b/lib/axlsx/drawing/series.rb
@@ -61,7 +61,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<c:ser>'

--- a/lib/axlsx/drawing/series_title.rb
+++ b/lib/axlsx/drawing/series_title.rb
@@ -4,7 +4,7 @@ module Axlsx
   # A series title is a Title with a slightly different serialization than chart titles.
   class SeriesTitle < Title
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       clean_value = Axlsx.trust_input ? @text.to_s : ::CGI.escapeHTML(Axlsx.sanitize(@text.to_s))

--- a/lib/axlsx/drawing/series_title.rb
+++ b/lib/axlsx/drawing/series_title.rb
@@ -5,7 +5,7 @@ module Axlsx
   class SeriesTitle < Title
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       clean_value = Axlsx.trust_input ? @text.to_s : ::CGI.escapeHTML(Axlsx.sanitize(@text.to_s))
 

--- a/lib/axlsx/drawing/title.rb
+++ b/lib/axlsx/drawing/title.rb
@@ -65,7 +65,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<c:title>'
       unless empty?

--- a/lib/axlsx/drawing/title.rb
+++ b/lib/axlsx/drawing/title.rb
@@ -64,7 +64,7 @@ module Axlsx
     # def spPr=(v) DataTypeValidator.validate 'Title.spPr', SpPr, v; @spPr = v; end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<c:title>'

--- a/lib/axlsx/drawing/two_cell_anchor.rb
+++ b/lib/axlsx/drawing/two_cell_anchor.rb
@@ -79,7 +79,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<xdr:twoCellAnchor>'

--- a/lib/axlsx/drawing/two_cell_anchor.rb
+++ b/lib/axlsx/drawing/two_cell_anchor.rb
@@ -80,7 +80,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<xdr:twoCellAnchor>'
       str << '<xdr:from>'

--- a/lib/axlsx/drawing/val_axis.rb
+++ b/lib/axlsx/drawing/val_axis.rb
@@ -25,7 +25,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<c:valAx>'
       super

--- a/lib/axlsx/drawing/val_axis.rb
+++ b/lib/axlsx/drawing/val_axis.rb
@@ -24,7 +24,7 @@ module Axlsx
     alias :crossBetween= :cross_between=
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<c:valAx>'

--- a/lib/axlsx/drawing/view_3D.rb
+++ b/lib/axlsx/drawing/view_3D.rb
@@ -100,7 +100,7 @@ module Axlsx
     # DataTypeValidator.validate "#{self.class}.perspective", [Integer], v, lambda {|arg| arg >= 0 && arg <= 240 }; @perspective = v; end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<c:view3D>'

--- a/lib/axlsx/drawing/view_3D.rb
+++ b/lib/axlsx/drawing/view_3D.rb
@@ -101,7 +101,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<c:view3D>'
       %w(rot_x h_percent rot_y depth_percent r_ang_ax perspective).each do |key|

--- a/lib/axlsx/drawing/vml_drawing.rb
+++ b/lib/axlsx/drawing/vml_drawing.rb
@@ -19,7 +19,7 @@ module Axlsx
 
     # serialize the vml_drawing to xml.
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << <<~XML
         <xml xmlns:v="urn:schemas-microsoft-com:vml"

--- a/lib/axlsx/drawing/vml_drawing.rb
+++ b/lib/axlsx/drawing/vml_drawing.rb
@@ -18,7 +18,7 @@ module Axlsx
     end
 
     # serialize the vml_drawing to xml.
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << <<~XML

--- a/lib/axlsx/drawing/vml_shape.rb
+++ b/lib/axlsx/drawing/vml_shape.rb
@@ -35,7 +35,7 @@ module Axlsx
     boolean_attr_accessor :visible
 
     # serialize the shape to a string
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << <<~XML

--- a/lib/axlsx/drawing/vml_shape.rb
+++ b/lib/axlsx/drawing/vml_shape.rb
@@ -36,7 +36,7 @@ module Axlsx
 
     # serialize the shape to a string
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << <<~XML
 

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -184,6 +184,14 @@ module Axlsx
     # @param [ZipKit::Streamer] streamer (or a compatible object)
     # @return [void]
     def write_parts(zip)
+      # Generate a Entry for the given package part.
+      # The important part here is to explicitly set the timestamp for the zip entry: Serializing axlsx packages
+      # with identical contents should result in identical zip files – however, the timestamp of a zip entry
+      # defaults to the time of serialization and therefore the zip file contents would be different every time
+      # the package is serialized.
+      #
+      # Note: {Core#created} also defaults to the current time – so to generate identical axlsx packages you have
+      # to set this explicitly, too (eg. with `Package.new(created_at: Time.local(2013, 1, 1))`).
       time_of_writing = @core.created || Time.now
       parts.each do |part|
         if part[:doc]
@@ -197,23 +205,6 @@ module Axlsx
         end
       end
       zip
-    end
-
-    # Generate a Entry for the given package part.
-    # The important part here is to explicitly set the timestamp for the zip entry: Serializing axlsx packages
-    # with identical contents should result in identical zip files – however, the timestamp of a zip entry
-    # defaults to the time of serialization and therefore the zip file contents would be different every time
-    # the package is serialized.
-    #
-    # Note: {Core#created} also defaults to the current time – so to generate identical axlsx packages you have
-    # to set this explicitly, too (eg. with `Package.new(created_at: Time.local(2013, 1, 1))`).
-    #
-    # @param part A hash describing a part of this package (see {#parts})
-    # @return [Zip::Entry]
-    def zip_entry_for_part(part)
-      {filename: part.fetch(:entry), }
-      timestamp = Zip::DOSTime.at(@core.created.to_i)
-      Zip::Entry.new("", part[:entry], time: timestamp)
     end
 
     # The parts of a package

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -121,9 +121,8 @@ module Axlsx
     #   p.serialize("example.xlsx", zip_command: "/path/to/zip")
     #   p.serialize("example.xlsx", zip_command: "zip -1")
     #
-    #   # Serialize to a stream
-    #   s = p.to_stream()
-    #   File.open('example_streamed.xlsx', 'wb') { |f| f.write(s.read) }
+    #   # Serialize to a writable IO (will never seek or rewind)
+    #   File.open('example_streamed.xlsx', 'wb') { |f| p.serialize(f) }
     def serialize(output, options = {}, secondary_options = nil)
       unless workbook.styles_applied
         workbook.apply_styles

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -158,7 +158,8 @@ module Axlsx
       Relationship.initialize_ids_cache
       # TODO: At the moment this returns a StringIO. But this can be
       # changed to generate the ZIP lazily and to return an IO that
-      # can be read() from instead. This is for the future.
+      # can be read() from instead. Strictly speaking the method is
+      # misnamed - it's more of a `to_string_io` than `to_stream`.
       stream = ZipKitOutputStream.write_buffer do |zip|
         write_parts(zip)
       end

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -97,7 +97,7 @@ module Axlsx
 
     # Serialize your workbook to disk as an xlsx document.
     #
-    # @param [String] output The name of the file you want to serialize your package to
+    # @param [String,IO] output The name of the file you want to serialize your package to, or an IO you can `write()` the file to
     # @param [Hash] options
     # @option options [Boolean] :confirm_valid Validate the package prior to serialization.
     # @option options [String] :zip_command When `nil`, `#serialize` with RubyZip to

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -205,7 +205,7 @@ module Axlsx
     private
 
     # Writes the package parts to a zip archive.
-    # @param [ZipKit::Streamer] streamer (or a compatible object)
+    # @param [ZipKit::Streamer] zip_kit_streamer (or a compatible object)
     # @return [void]
     # @private
     def write_parts(zip_kit_streamer)

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -205,7 +205,7 @@ module Axlsx
     private
 
     # Writes the package parts to a zip archive.
-    # @param [ZipKit::Streamer] zip_kit_streamer (or a compatible object)
+    # @param [ZipKit::Streamer] zip_kit_streamer Streamer to add entries to (or a compatible object)
     # @return [void]
     # @private
     def write_parts(zip_kit_streamer)

--- a/lib/axlsx/rels/relationship.rb
+++ b/lib/axlsx/rels/relationship.rb
@@ -110,7 +110,7 @@ module Axlsx
     end
 
     # serialize relationship
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       h = Axlsx.instance_values_for(self).reject { |k, _| k == "source_obj" }

--- a/lib/axlsx/rels/relationship.rb
+++ b/lib/axlsx/rels/relationship.rb
@@ -111,7 +111,7 @@ module Axlsx
 
     # serialize relationship
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       h = Axlsx.instance_values_for(self).reject { |k, _| k == "source_obj" }
       str << '<Relationship '

--- a/lib/axlsx/rels/relationships.rb
+++ b/lib/axlsx/rels/relationships.rb
@@ -19,7 +19,7 @@ module Axlsx
     end
 
     # serialize relationships
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'

--- a/lib/axlsx/rels/relationships.rb
+++ b/lib/axlsx/rels/relationships.rb
@@ -20,7 +20,7 @@ module Axlsx
 
     # serialize relationships
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
       str << '<Relationships xmlns="' << RELS_R << '">'

--- a/lib/axlsx/stylesheet/border.rb
+++ b/lib/axlsx/stylesheet/border.rb
@@ -63,7 +63,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<border '

--- a/lib/axlsx/stylesheet/border.rb
+++ b/lib/axlsx/stylesheet/border.rb
@@ -64,7 +64,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<border '
       serialized_attributes str

--- a/lib/axlsx/stylesheet/border_pr.rb
+++ b/lib/axlsx/stylesheet/border_pr.rb
@@ -71,7 +71,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<' << @name.to_s << ' style="' << @style.to_s << '">'

--- a/lib/axlsx/stylesheet/border_pr.rb
+++ b/lib/axlsx/stylesheet/border_pr.rb
@@ -72,7 +72,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<' << @name.to_s << ' style="' << @style.to_s << '">'
       @color.to_xml_string(str) if @color.is_a?(Color)

--- a/lib/axlsx/stylesheet/cell_alignment.rb
+++ b/lib/axlsx/stylesheet/cell_alignment.rb
@@ -147,7 +147,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       serialized_tag('alignment', str)
     end

--- a/lib/axlsx/stylesheet/cell_alignment.rb
+++ b/lib/axlsx/stylesheet/cell_alignment.rb
@@ -146,7 +146,7 @@ module Axlsx
     alias :readingOrder= :reading_order=
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       serialized_tag('alignment', str)

--- a/lib/axlsx/stylesheet/cell_protection.rb
+++ b/lib/axlsx/stylesheet/cell_protection.rb
@@ -38,7 +38,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       serialized_tag('protection', str)

--- a/lib/axlsx/stylesheet/cell_protection.rb
+++ b/lib/axlsx/stylesheet/cell_protection.rb
@@ -39,7 +39,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       serialized_tag('protection', str)
     end

--- a/lib/axlsx/stylesheet/cell_style.rb
+++ b/lib/axlsx/stylesheet/cell_style.rb
@@ -85,7 +85,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       serialized_tag('cellStyle', str)
     end

--- a/lib/axlsx/stylesheet/cell_style.rb
+++ b/lib/axlsx/stylesheet/cell_style.rb
@@ -84,7 +84,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       serialized_tag('cellStyle', str)

--- a/lib/axlsx/stylesheet/color.rb
+++ b/lib/axlsx/stylesheet/color.rb
@@ -76,7 +76,7 @@ module Axlsx
     # def indexed=(v) Axlsx::validate_unsigned_integer v; @indexed = v end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'', tag_name = 'color')
       serialized_tag(tag_name.to_s, str)

--- a/lib/axlsx/stylesheet/color.rb
+++ b/lib/axlsx/stylesheet/color.rb
@@ -77,7 +77,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'', tag_name = 'color')
       serialized_tag(tag_name.to_s, str)
     end

--- a/lib/axlsx/stylesheet/dxf.rb
+++ b/lib/axlsx/stylesheet/dxf.rb
@@ -85,7 +85,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<dxf>'

--- a/lib/axlsx/stylesheet/dxf.rb
+++ b/lib/axlsx/stylesheet/dxf.rb
@@ -86,7 +86,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<dxf>'
       # Dxf elements have no attributes. All of the instance variables

--- a/lib/axlsx/stylesheet/fill.rb
+++ b/lib/axlsx/stylesheet/fill.rb
@@ -20,7 +20,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<fill>'
       @fill_type.to_xml_string(str)

--- a/lib/axlsx/stylesheet/fill.rb
+++ b/lib/axlsx/stylesheet/fill.rb
@@ -19,7 +19,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<fill>'

--- a/lib/axlsx/stylesheet/font.rb
+++ b/lib/axlsx/stylesheet/font.rb
@@ -193,7 +193,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<font>'
       Axlsx.instance_values_for(self).each do |k, v|

--- a/lib/axlsx/stylesheet/font.rb
+++ b/lib/axlsx/stylesheet/font.rb
@@ -192,7 +192,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<font>'

--- a/lib/axlsx/stylesheet/gradient_fill.rb
+++ b/lib/axlsx/stylesheet/gradient_fill.rb
@@ -97,7 +97,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<gradientFill '
       serialized_attributes str

--- a/lib/axlsx/stylesheet/gradient_fill.rb
+++ b/lib/axlsx/stylesheet/gradient_fill.rb
@@ -96,7 +96,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<gradientFill '

--- a/lib/axlsx/stylesheet/gradient_stop.rb
+++ b/lib/axlsx/stylesheet/gradient_stop.rb
@@ -34,7 +34,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<stop position="' << position.to_s << '">'

--- a/lib/axlsx/stylesheet/gradient_stop.rb
+++ b/lib/axlsx/stylesheet/gradient_stop.rb
@@ -35,7 +35,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<stop position="' << position.to_s << '">'
       color.to_xml_string(str)

--- a/lib/axlsx/stylesheet/num_fmt.rb
+++ b/lib/axlsx/stylesheet/num_fmt.rb
@@ -73,7 +73,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       serialized_tag('numFmt', str)

--- a/lib/axlsx/stylesheet/num_fmt.rb
+++ b/lib/axlsx/stylesheet/num_fmt.rb
@@ -74,7 +74,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       serialized_tag('numFmt', str)
     end

--- a/lib/axlsx/stylesheet/pattern_fill.rb
+++ b/lib/axlsx/stylesheet/pattern_fill.rb
@@ -68,7 +68,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<patternFill patternType="' << patternType.to_s << '">'
       if fgColor.is_a?(Color)

--- a/lib/axlsx/stylesheet/pattern_fill.rb
+++ b/lib/axlsx/stylesheet/pattern_fill.rb
@@ -67,7 +67,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<patternFill patternType="' << patternType.to_s << '">'

--- a/lib/axlsx/stylesheet/styles.rb
+++ b/lib/axlsx/stylesheet/styles.rb
@@ -518,7 +518,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<styleSheet xmlns="' << XML_NS << '">'
       instance_vals = Axlsx.instance_values_for(self)

--- a/lib/axlsx/stylesheet/styles.rb
+++ b/lib/axlsx/stylesheet/styles.rb
@@ -517,7 +517,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<styleSheet xmlns="' << XML_NS << '">'

--- a/lib/axlsx/stylesheet/table_style.rb
+++ b/lib/axlsx/stylesheet/table_style.rb
@@ -51,7 +51,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<tableStyle '

--- a/lib/axlsx/stylesheet/table_style.rb
+++ b/lib/axlsx/stylesheet/table_style.rb
@@ -52,7 +52,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<tableStyle '
       serialized_attributes str, { count: size }

--- a/lib/axlsx/stylesheet/table_style_element.rb
+++ b/lib/axlsx/stylesheet/table_style_element.rb
@@ -77,7 +77,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       serialized_tag('tableStyleElement', str)
     end

--- a/lib/axlsx/stylesheet/table_style_element.rb
+++ b/lib/axlsx/stylesheet/table_style_element.rb
@@ -76,7 +76,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       serialized_tag('tableStyleElement', str)

--- a/lib/axlsx/stylesheet/table_styles.rb
+++ b/lib/axlsx/stylesheet/table_styles.rb
@@ -39,7 +39,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<tableStyles '
       serialized_attributes str, { count: size }

--- a/lib/axlsx/stylesheet/table_styles.rb
+++ b/lib/axlsx/stylesheet/table_styles.rb
@@ -38,7 +38,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<tableStyles '

--- a/lib/axlsx/stylesheet/xf.rb
+++ b/lib/axlsx/stylesheet/xf.rb
@@ -186,7 +186,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<xf '
       serialized_attributes str

--- a/lib/axlsx/stylesheet/xf.rb
+++ b/lib/axlsx/stylesheet/xf.rb
@@ -185,7 +185,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<xf '

--- a/lib/axlsx/util/serialized_attributes.rb
+++ b/lib/axlsx/util/serialized_attributes.rb
@@ -95,7 +95,7 @@ module Axlsx
     # break the xml.
     # @param [#<<] str A String, buffer or IO to append the serialization to. The string instance to which serialized data is appended
     # @param [Array] additional_attributes An array of additional attribute names.
-    # @return [String] The serialized output.
+    # @return [void]
     def serialized_element_attributes(str = +'', additional_attributes = [])
       attrs = self.class.xml_element_attributes + additional_attributes
       values = Axlsx.instance_values_for(self)
@@ -107,7 +107,6 @@ module Axlsx
         element_name = Axlsx.camel(attribute_name, false)
         str << '<' << element_name << '>' << value << '</' << element_name << '>'
       end
-      str
     end
   end
 end

--- a/lib/axlsx/util/serialized_attributes.rb
+++ b/lib/axlsx/util/serialized_attributes.rb
@@ -55,7 +55,7 @@ module Axlsx
 
     # serializes the instance values of the defining object based on the
     # list of serializable attributes.
-    # @param [String] str The string instance to append this
+    # @param [#<<] str A String, buffer or IO to append the serialization to. The string instance to append this
     # serialization to.
     # @param [Hash] additional_attributes An option key value hash for
     # defining values that are not serializable attributes list.
@@ -93,7 +93,7 @@ module Axlsx
     # attribute name. You may pass in a block for evaluation against non nil
     # values. We use an array for element attributes because misordering will
     # break the xml.
-    # @param [String] str The string instance to which serialized data is appended
+    # @param [#<<] str A String, buffer or IO to append the serialization to. The string instance to which serialized data is appended
     # @param [Array] additional_attributes An array of additional attribute names.
     # @return [String] The serialized output.
     def serialized_element_attributes(str = +'', additional_attributes = [])

--- a/lib/axlsx/util/zip_command.rb
+++ b/lib/axlsx/util/zip_command.rb
@@ -28,7 +28,6 @@ module Axlsx
       Dir.mktmpdir do |dir|
         @dir = dir
         yield(self)
-        warn @files.inspect
         run_zip_command(write_to_file_at_path)
       end
     end

--- a/lib/axlsx/util/zip_command.rb
+++ b/lib/axlsx/util/zip_command.rb
@@ -5,13 +5,9 @@ require 'shellwords'
 
 module Axlsx
   # The ZipCommand class supports zipping the Excel file contents using
-  # a binary zip program instead of RubyZip's `Zip::OutputStream`.
+  # a binary zip program instead of a Ruby library.
   #
-  # The methods provided here mimic `Zip::OutputStream` so that `ZipCommand` can
-  # be used as a drop-in replacement. Note that method signatures are not
-  # identical to `ZipKitOutputStream`, they are only sufficiently close so that
-  # `ZipCommand` and `ZipKitOutputStream` can be interchangeably used within
-  # `caxlsx`.
+  # The methods provided here mimic ZipKitOutputStream.
   class ZipCommand
     # Raised when the zip command exits with a non-zero status.
     class ZipError < StandardError; end
@@ -25,12 +21,12 @@ module Axlsx
     #
     # The directory and its contents are removed at the end of the block.
     #
-    # @param write_to_file_at_path[String] path for the XLSX to write 
-    def open(write_to_file_at_path)
+    # @param write_to_file_named[String] filename for the XLSX to write
+    def open(write_to_file_named)
       Dir.mktmpdir do |dir|
         @dir = dir
         yield(self)
-        run_zip_command(write_to_file_at_path)
+        run_zip_command(write_to_file_named)
       end
     end
 

--- a/lib/axlsx/util/zip_command.rb
+++ b/lib/axlsx/util/zip_command.rb
@@ -9,8 +9,8 @@ module Axlsx
   #
   # The methods provided here mimic `Zip::OutputStream` so that `ZipCommand` can
   # be used as a drop-in replacement. Note that method signatures are not
-  # identical to `Zip::OutputStream`, they are only sufficiently close so that
-  # `ZipCommand` and `Zip::OutputStream` can be interchangeably used within
+  # identical to `ZipKitOutputStream`, they are only sufficiently close so that
+  # `ZipCommand` and `ZipKitOutputStream` can be interchangeably used within
   # `caxlsx`.
   class ZipCommand
     # Raised when the zip command exits with a non-zero status.
@@ -24,6 +24,8 @@ module Axlsx
     # Create a temporary directory for writing files to.
     #
     # The directory and its contents are removed at the end of the block.
+    #
+    # @param write_to_file_at_path[String] path for the XLSX to write 
     def open(write_to_file_at_path)
       Dir.mktmpdir do |dir|
         @dir = dir
@@ -32,14 +34,20 @@ module Axlsx
       end
     end
 
-    # Closes the current entry and opens a new for writing.
-    def write_file(filename, modification_time:)
+    # Adds a file to the ZIP. Yields an IO the file data can be written to.
+    # Works the same as `ZipKit::Streamer#write_file`
+    # @param filename[String] the name of the file in the ZIP
+    # @param modification_time[Time] the mtime to set for the entry in the ZIP
+    # @yield [#write] the writable IO for the file' binary data
+    #
+    # @return [void]
+    def write_file(filename, modification_time:, &blk)
       raise ArgumentError, "@dir not set" unless @dir
 
       tempfile_path = File.join(@dir, filename)
 
       FileUtils.mkdir_p(File.dirname(tempfile_path))
-      File.open(tempfile_path, "wb") { |fo| yield(fo) }
+      File.open(tempfile_path, "wb", &blk)
       File.utime(modification_time, modification_time, tempfile_path)
 
       @filenames << filename

--- a/lib/axlsx/util/zip_kit_output_stream.rb
+++ b/lib/axlsx/util/zip_kit_output_stream.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "zip_kit"
+
+module Axlsx
+  # The ZipKitOutputStream allows generation of a streaming ZIP file.
+  #
+  # The methods provided here mimic `Zip::OutputStream` so that this class can be used a drop-in replacement.
+  class ZipKitOutputStream
+    # Create a temporary file for writing the ZIP out, residing at `file_name`
+    #
+    # The directory and its contents are removed at the end of the block.
+    def self.open(file_path_or_writable)
+      if file_path_or_writable.is_a?(String) # Assume it is a path
+        File.open(file_path_or_writable, "wb") do |f|
+          ZipKit::Streamer.open(f) do |streamer|
+            yield(streamer)
+          end
+        end
+      elsif file_path_or_writable.respond_to?(:write)
+        ZipKit::Streamer.open(file_path_or_writable) do |streamer|
+          yield(new(streamer))
+        end
+      else
+        raise ArgumentError, "file_path_or_writable muse be a path to file or respond to write()"
+      end
+    end
+
+    def self.write_buffer(&blk)
+      StringIO.new.binmode.tap do |out|
+        ZipKit::Streamer.open(out, &blk)
+        out.rewind
+      end
+    end
+  end
+end

--- a/lib/axlsx/util/zip_kit_output_stream.rb
+++ b/lib/axlsx/util/zip_kit_output_stream.rb
@@ -9,21 +9,16 @@ module Axlsx
     # At the end of the block the central directory and EOCD marker will be written into the output.
     #
     # @yield [ZipKit::Streamer]
-    # @param file_path_or_writable[String,#IO] Either a path to a file - the ZIP will be written there, or an object that responds to #write -
+    # @param file_path_or_writable[String,#write] Either a path to a file - the ZIP will be written there, or an object that responds to #write -
     #     that object will receive the ZIP binary data.
-    def self.open(file_path_or_writable)
-      if file_path_or_writable.respond_to?(:write) # Assume it is something writable, like a Rails `stream`
-        ZipKit::Streamer.open(file_path_or_writable) do |streamer|
-          yield(new(streamer))
-        end
-      elsif file_path_or_writable.is_a?(String) # Assume it is a path
-        File.open(file_path_or_writable, "wb") do |f|
-          ZipKit::Streamer.open(f) do |streamer|
-            yield(streamer)
-          end
-        end
+    def self.open(file_path_or_writable, &blk)
+      if file_path_or_writable.is_a?(String)
+        # Assume it is a path
+        File.open(file_path_or_writable, "wb") { |f| open (f, &blk) }
       else
-        raise ArgumentError, "file_path_or_writable muse be a path to file or respond to write()"
+        # Assume it is something writable, like a Rails `stream` or any other destination
+        # for ZipKit
+        ZipKit::Streamer.open(file_path_or_writable, &blk)
       end
     end
 

--- a/lib/axlsx/util/zip_kit_output_stream.rb
+++ b/lib/axlsx/util/zip_kit_output_stream.rb
@@ -14,7 +14,7 @@ module Axlsx
     def self.open(file_path_or_writable, &blk)
       if file_path_or_writable.is_a?(String)
         # Assume it is a path
-        File.open(file_path_or_writable, "wb") { |f| open(f, &blk) }
+        File.open(file_path_or_writable, "wb") { |f| self.open(f, &blk) }
       else
         # Assume it is something writable, like a Rails `stream` or any other destination
         # for ZipKit

--- a/lib/axlsx/util/zip_kit_output_stream.rb
+++ b/lib/axlsx/util/zip_kit_output_stream.rb
@@ -3,29 +3,35 @@
 require "zip_kit"
 
 module Axlsx
-  # The ZipKitOutputStream allows generation of a streaming ZIP file.
-  #
-  # The methods provided here mimic `Zip::OutputStream` so that this class can be used a drop-in replacement.
+  # Allows generation of a ZIP file.
   class ZipKitOutputStream
-    # Create a temporary file for writing the ZIP out, residing at `file_name`
+    # Sets up a ZipKit::Streamer for writing the XLSX file and yields it to the caller.
+    # At the end of the block the central directory and EOCD marker will be written into the output.
     #
-    # The directory and its contents are removed at the end of the block.
+    # @yield [ZipKit::Streamer]
+    # @param file_path_or_writable[String,#IO] Either a path to a file - the ZIP will be written there, or an object that responds to #write -
+    #     that object will receive the ZIP binary data.
     def self.open(file_path_or_writable)
-      if file_path_or_writable.is_a?(String) # Assume it is a path
+      if file_path_or_writable.respond_to?(:write) # Assume it is something writable, like a Rails `stream`
+        ZipKit::Streamer.open(file_path_or_writable) do |streamer|
+          yield(new(streamer))
+        end
+      elsif file_path_or_writable.is_a?(String) # Assume it is a path
         File.open(file_path_or_writable, "wb") do |f|
           ZipKit::Streamer.open(f) do |streamer|
             yield(streamer)
           end
-        end
-      elsif file_path_or_writable.respond_to?(:write)
-        ZipKit::Streamer.open(file_path_or_writable) do |streamer|
-          yield(new(streamer))
         end
       else
         raise ArgumentError, "file_path_or_writable muse be a path to file or respond to write()"
       end
     end
 
+    # Sets up a ZipKit::Streamer for writing the XLSX file and yields it to the caller.
+    # At the end of the block the central directory and EOCD marker will be written into the output.
+    #
+    # @yield [ZipKit::Streamer]
+    # @return [StringIO] containing the ZIP, backed by a binary string, having pointer at 0
     def self.write_buffer(&blk)
       StringIO.new.binmode.tap do |out|
         ZipKit::Streamer.open(out, &blk)

--- a/lib/axlsx/util/zip_kit_output_stream.rb
+++ b/lib/axlsx/util/zip_kit_output_stream.rb
@@ -14,7 +14,7 @@ module Axlsx
     def self.open(file_path_or_writable, &blk)
       if file_path_or_writable.is_a?(String)
         # Assume it is a path
-        File.open(file_path_or_writable, "wb") { |f| open (f, &blk) }
+        File.open(file_path_or_writable, "wb") { |f| open(f, &blk) }
       else
         # Assume it is something writable, like a Rails `stream` or any other destination
         # for ZipKit

--- a/lib/axlsx/workbook/defined_names.rb
+++ b/lib/axlsx/workbook/defined_names.rb
@@ -9,7 +9,7 @@ module Axlsx
     end
 
     # Serialize to xml
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       return if empty?

--- a/lib/axlsx/workbook/defined_names.rb
+++ b/lib/axlsx/workbook/defined_names.rb
@@ -10,7 +10,7 @@ module Axlsx
 
     # Serialize to xml
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       return if empty?
 

--- a/lib/axlsx/workbook/shared_strings_table.rb
+++ b/lib/axlsx/workbook/shared_strings_table.rb
@@ -43,7 +43,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       Axlsx.sanitize(@shared_xml_string)
@@ -66,7 +66,9 @@ module Axlsx
           cell.send :ssti=, index
         else
           cell.send :ssti=, @index
-          @shared_xml_string << '<si>' << CellSerializer.run_xml_string(cell) << '</si>'
+          @shared_xml_string << '<si>'
+          CellSerializer.run_xml_string(cell, @shared_xml_string)
+          @shared_xml_string << '</si>'
           @unique_cells[cell_hash] = @index
           @index += 1
         end

--- a/lib/axlsx/workbook/shared_strings_table.rb
+++ b/lib/axlsx/workbook/shared_strings_table.rb
@@ -44,7 +44,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       Axlsx.sanitize(@shared_xml_string)
       str << '<?xml version="1.0" encoding="UTF-8"?><sst xmlns="' << XML_NS << '"'

--- a/lib/axlsx/workbook/workbook.rb
+++ b/lib/axlsx/workbook/workbook.rb
@@ -416,7 +416,7 @@ module Axlsx
     end
 
     # Serialize the workbook
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       add_worksheet(name: 'Sheet1') if worksheets.empty?

--- a/lib/axlsx/workbook/workbook.rb
+++ b/lib/axlsx/workbook/workbook.rb
@@ -417,7 +417,7 @@ module Axlsx
 
     # Serialize the workbook
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       add_worksheet(name: 'Sheet1') if worksheets.empty?
       str << '<?xml version="1.0" encoding="UTF-8"?>'

--- a/lib/axlsx/workbook/workbook_view.rb
+++ b/lib/axlsx/workbook/workbook_view.rb
@@ -66,7 +66,7 @@ module Axlsx
                           :show_sheet_tabs, :auto_filter_date_grouping
 
     # Serialize the WorkbookView
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<workbookView '

--- a/lib/axlsx/workbook/workbook_view.rb
+++ b/lib/axlsx/workbook/workbook_view.rb
@@ -67,7 +67,7 @@ module Axlsx
 
     # Serialize the WorkbookView
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<workbookView '
       serialized_attributes str

--- a/lib/axlsx/workbook/workbook_views.rb
+++ b/lib/axlsx/workbook/workbook_views.rb
@@ -9,7 +9,7 @@ module Axlsx
     end
 
     # Serialize to xml
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       return if empty?

--- a/lib/axlsx/workbook/workbook_views.rb
+++ b/lib/axlsx/workbook/workbook_views.rb
@@ -10,7 +10,7 @@ module Axlsx
 
     # Serialize to xml
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       return if empty?
 

--- a/lib/axlsx/workbook/worksheet/auto_filter/auto_filter.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/auto_filter.rb
@@ -120,7 +120,7 @@ module Axlsx
     end
 
     # serialize the object
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       return unless range
 

--- a/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
@@ -121,7 +121,7 @@ module Axlsx
       attr_accessor :val
 
       # Serializes the filter value object
-      # @param [String] str The string to concact the serialization information to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       def to_xml_string(str = +'')
         str << "<filter val='#{@val}' />"
       end
@@ -238,7 +238,7 @@ module Axlsx
       end
 
       # Serialize the object to xml
-      # @param [String] str The string object this serialization will be concatenated to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       def to_xml_string(str = +'')
         serialized_tag('dateGroupItem', str)
       end

--- a/lib/axlsx/workbook/worksheet/auto_filter/sort_condition.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/sort_condition.rb
@@ -37,7 +37,7 @@ module Axlsx
     end
 
     # serialize the object
-    # @return [String]
+    # @return [void]
     def to_xml_string(str, ref)
       ref = ref_to_single_column(ref, column_index)
 

--- a/lib/axlsx/workbook/worksheet/auto_filter/sort_state.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/sort_state.rb
@@ -40,7 +40,7 @@ module Axlsx
     end
 
     # serialize the object
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       return if sort_conditions.empty?
 

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -404,7 +404,7 @@ module Axlsx
     # Serializes the cell
     # @param [Integer] r_index The row index for the cell
     # @param [Integer] c_index The cell index in the row.
-    # @param [String] str The string index the cell content will be appended to. Defaults to empty string.
+    # @param [#<<] str A String, buffer or IO to append the serialization to. The string index the cell content will be appended to. Defaults to empty string.
     # @return [String] xml text for the cell
     def to_xml_string(r_index, c_index, str = +'')
       CellSerializer.to_xml_string r_index, c_index, self, str

--- a/lib/axlsx/workbook/worksheet/cell_serializer.rb
+++ b/lib/axlsx/workbook/worksheet/cell_serializer.rb
@@ -7,7 +7,7 @@ module Axlsx
       # Calls the proper serialization method based on type.
       # @param [Integer] row_index The index of the cell's row
       # @param [Integer] column_index The index of the cell's column
-      # @param [String] str The string to append serialization to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       # @return [String]
       def to_xml_string(row_index, column_index, cell, str = +'')
         str << '<c r="'
@@ -21,7 +21,7 @@ module Axlsx
       end
 
       # builds an xml text run based on this cells attributes.
-      # @param [String] str The string instance this run will be concated to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       # @return [String]
       def run_xml_string(cell, str = +'')
         if cell.is_text_run?
@@ -39,7 +39,7 @@ module Axlsx
 
       # serializes cells that are type iso_8601
       # @param [Cell] cell The cell that is being serialized
-      # @param [String] str The string the serialized content will be appended to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       # @return [String]
       def iso_8601(cell, str = +'')
         value_serialization 'd', cell.value, str
@@ -47,7 +47,7 @@ module Axlsx
 
       # serializes cells that are type date
       # @param [Cell] cell The cell that is being serialized
-      # @param [String] str The string the serialized content will be appended to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       # @return [String]
       def date(cell, str = +'')
         value_serialization false, DateTimeConverter.date_to_serial(cell.value).to_s, str
@@ -55,7 +55,7 @@ module Axlsx
 
       # Serializes cells that are type time
       # @param [Cell] cell The cell that is being serialized
-      # @param [String] str The string the serialized content will be appended to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       # @return [String]
       def time(cell, str = +'')
         value_serialization false, DateTimeConverter.time_to_serial(cell.value).to_s, str
@@ -63,7 +63,7 @@ module Axlsx
 
       # Serializes cells that are type boolean
       # @param [Cell] cell The cell that is being serialized
-      # @param [String] str The string the serialized content will be appended to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       # @return [String]
       def boolean(cell, str = +'')
         value_serialization 'b', cell.value.to_s, str
@@ -71,7 +71,7 @@ module Axlsx
 
       # Serializes cells that are type float
       # @param [Cell] cell The cell that is being serialized
-      # @param [String] str The string the serialized content will be appended to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       # @return [String]
       def float(cell, str = +'')
         numeric cell, str
@@ -79,7 +79,7 @@ module Axlsx
 
       # Serializes cells that are type integer
       # @param [Cell] cell The cell that is being serialized
-      # @param [String] str The string the serialized content will be appended to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       # @return [String]
       def integer(cell, str = +'')
         numeric cell, str
@@ -87,7 +87,7 @@ module Axlsx
 
       # Serializes cells that are type formula
       # @param [Cell] cell The cell that is being serialized
-      # @param [String] str The string the serialized content will be appended to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       # @return [String]
       def formula_serialization(cell, str = +'')
         str << 't="str"><f>' << cell.clean_value.delete_prefix(FORMULA_PREFIX) << '</f>'
@@ -96,7 +96,7 @@ module Axlsx
 
       # Serializes cells that are type array formula
       # @param [Cell] cell The cell that is being serialized
-      # @param [String] str The string the serialized content will be appended to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       # @return [String]
       def array_formula_serialization(cell, str = +'')
         str << 't="str">' << '<f t="array" ref="' << cell.r << '">' << cell.clean_value.delete_prefix(ARRAY_FORMULA_PREFIX).delete_suffix(ARRAY_FORMULA_SUFFIX) << '</f>'
@@ -105,7 +105,7 @@ module Axlsx
 
       # Serializes cells that are type inline_string
       # @param [Cell] cell The cell that is being serialized
-      # @param [String] str The string the serialized content will be appended to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       # @return [String]
       def inline_string_serialization(cell, str = +'')
         str << 't="inlineStr"><is>'
@@ -115,7 +115,7 @@ module Axlsx
 
       # Serializes cells that are type string
       # @param [Cell] cell The cell that is being serialized
-      # @param [String] str The string the serialized content will be appended to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       # @return [String]
       def string(cell, str = +'')
         if cell.is_array_formula?
@@ -131,7 +131,7 @@ module Axlsx
 
       # Serializes cells that are of the type richtext
       # @param [Cell] cell The cell that is being serialized
-      # @param [String] str The string the serialized content will be appended to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       # @return [String]
       def richtext(cell, str)
         if cell.ssti.nil?
@@ -143,7 +143,7 @@ module Axlsx
 
       # Serializes cells that are of the type text
       # @param [Cell] cell The cell that is being serialized
-      # @param [String] str The string the serialized content will be appended to.
+      # @param [#<<] str A String, buffer or IO to append the serialization to.
       # @return [String]
       def text(cell, str)
         if cell.ssti.nil?

--- a/lib/axlsx/workbook/worksheet/cell_serializer.rb
+++ b/lib/axlsx/workbook/worksheet/cell_serializer.rb
@@ -8,7 +8,7 @@ module Axlsx
       # @param [Integer] row_index The index of the cell's row
       # @param [Integer] column_index The index of the cell's column
       # @param [#<<] str A String, buffer or IO to append the serialization to.
-      # @return [String]
+      # @return [void]
       def to_xml_string(row_index, column_index, cell, str = +'')
         str << '<c r="'
         str << Axlsx.col_ref(column_index) << Axlsx.row_ref(row_index)
@@ -22,7 +22,7 @@ module Axlsx
 
       # builds an xml text run based on this cells attributes.
       # @param [#<<] str A String, buffer or IO to append the serialization to.
-      # @return [String]
+      # @return [void]
       def run_xml_string(cell, str = +'')
         if cell.is_text_run?
           valid = RichTextRun::INLINE_STYLES - [:value, :type]
@@ -34,13 +34,13 @@ module Axlsx
         else
           str << '<t>' << cell.clean_value << '</t>'
         end
-        str
+        nil
       end
 
       # serializes cells that are type iso_8601
       # @param [Cell] cell The cell that is being serialized
       # @param [#<<] str A String, buffer or IO to append the serialization to.
-      # @return [String]
+      # @return [void]
       def iso_8601(cell, str = +'')
         value_serialization 'd', cell.value, str
       end
@@ -48,7 +48,7 @@ module Axlsx
       # serializes cells that are type date
       # @param [Cell] cell The cell that is being serialized
       # @param [#<<] str A String, buffer or IO to append the serialization to.
-      # @return [String]
+      # @return [void]
       def date(cell, str = +'')
         value_serialization false, DateTimeConverter.date_to_serial(cell.value).to_s, str
       end
@@ -56,7 +56,7 @@ module Axlsx
       # Serializes cells that are type time
       # @param [Cell] cell The cell that is being serialized
       # @param [#<<] str A String, buffer or IO to append the serialization to.
-      # @return [String]
+      # @return [void]
       def time(cell, str = +'')
         value_serialization false, DateTimeConverter.time_to_serial(cell.value).to_s, str
       end
@@ -64,7 +64,7 @@ module Axlsx
       # Serializes cells that are type boolean
       # @param [Cell] cell The cell that is being serialized
       # @param [#<<] str A String, buffer or IO to append the serialization to.
-      # @return [String]
+      # @return [void]
       def boolean(cell, str = +'')
         value_serialization 'b', cell.value.to_s, str
       end
@@ -72,7 +72,7 @@ module Axlsx
       # Serializes cells that are type float
       # @param [Cell] cell The cell that is being serialized
       # @param [#<<] str A String, buffer or IO to append the serialization to.
-      # @return [String]
+      # @return [void]
       def float(cell, str = +'')
         numeric cell, str
       end
@@ -80,7 +80,7 @@ module Axlsx
       # Serializes cells that are type integer
       # @param [Cell] cell The cell that is being serialized
       # @param [#<<] str A String, buffer or IO to append the serialization to.
-      # @return [String]
+      # @return [void]
       def integer(cell, str = +'')
         numeric cell, str
       end
@@ -88,7 +88,7 @@ module Axlsx
       # Serializes cells that are type formula
       # @param [Cell] cell The cell that is being serialized
       # @param [#<<] str A String, buffer or IO to append the serialization to.
-      # @return [String]
+      # @return [void]
       def formula_serialization(cell, str = +'')
         str << 't="str"><f>' << cell.clean_value.delete_prefix(FORMULA_PREFIX) << '</f>'
         str << '<v>' << cell.formula_value.to_s << '</v>' unless cell.formula_value.nil?
@@ -97,7 +97,7 @@ module Axlsx
       # Serializes cells that are type array formula
       # @param [Cell] cell The cell that is being serialized
       # @param [#<<] str A String, buffer or IO to append the serialization to.
-      # @return [String]
+      # @return [void]
       def array_formula_serialization(cell, str = +'')
         str << 't="str">' << '<f t="array" ref="' << cell.r << '">' << cell.clean_value.delete_prefix(ARRAY_FORMULA_PREFIX).delete_suffix(ARRAY_FORMULA_SUFFIX) << '</f>'
         str << '<v>' << cell.formula_value.to_s << '</v>' unless cell.formula_value.nil?
@@ -106,7 +106,7 @@ module Axlsx
       # Serializes cells that are type inline_string
       # @param [Cell] cell The cell that is being serialized
       # @param [#<<] str A String, buffer or IO to append the serialization to.
-      # @return [String]
+      # @return [void]
       def inline_string_serialization(cell, str = +'')
         str << 't="inlineStr"><is>'
         run_xml_string cell, str
@@ -116,7 +116,7 @@ module Axlsx
       # Serializes cells that are type string
       # @param [Cell] cell The cell that is being serialized
       # @param [#<<] str A String, buffer or IO to append the serialization to.
-      # @return [String]
+      # @return [void]
       def string(cell, str = +'')
         if cell.is_array_formula?
           array_formula_serialization cell, str
@@ -132,7 +132,7 @@ module Axlsx
       # Serializes cells that are of the type richtext
       # @param [Cell] cell The cell that is being serialized
       # @param [#<<] str A String, buffer or IO to append the serialization to.
-      # @return [String]
+      # @return [void]
       def richtext(cell, str)
         if cell.ssti.nil?
           inline_string_serialization cell, str
@@ -144,7 +144,7 @@ module Axlsx
       # Serializes cells that are of the type text
       # @param [Cell] cell The cell that is being serialized
       # @param [#<<] str A String, buffer or IO to append the serialization to.
-      # @return [String]
+      # @return [void]
       def text(cell, str)
         if cell.ssti.nil?
           inline_string_serialization cell, str

--- a/lib/axlsx/workbook/worksheet/cfvo.rb
+++ b/lib/axlsx/workbook/worksheet/cfvo.rb
@@ -60,7 +60,7 @@ module Axlsx
 
     # serialize the Csvo object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       serialized_tag('cfvo', str)
     end

--- a/lib/axlsx/workbook/worksheet/cfvo.rb
+++ b/lib/axlsx/workbook/worksheet/cfvo.rb
@@ -59,7 +59,7 @@ module Axlsx
     end
 
     # serialize the Csvo object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       serialized_tag('cfvo', str)

--- a/lib/axlsx/workbook/worksheet/cfvos.rb
+++ b/lib/axlsx/workbook/worksheet/cfvos.rb
@@ -9,7 +9,7 @@ module Axlsx
     end
 
     # Serialize the Cfvo object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       each { |cfvo| cfvo.to_xml_string(str) }

--- a/lib/axlsx/workbook/worksheet/cfvos.rb
+++ b/lib/axlsx/workbook/worksheet/cfvos.rb
@@ -10,7 +10,7 @@ module Axlsx
 
     # Serialize the Cfvo object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       each { |cfvo| cfvo.to_xml_string(str) }
     end

--- a/lib/axlsx/workbook/worksheet/col.rb
+++ b/lib/axlsx/workbook/worksheet/col.rb
@@ -149,7 +149,7 @@ module Axlsx
 
     # Serialize this columns data to an xml string
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       serialized_tag('col', str)
     end

--- a/lib/axlsx/workbook/worksheet/col.rb
+++ b/lib/axlsx/workbook/worksheet/col.rb
@@ -148,7 +148,7 @@ module Axlsx
     end
 
     # Serialize this columns data to an xml string
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       serialized_tag('col', str)

--- a/lib/axlsx/workbook/worksheet/col_breaks.rb
+++ b/lib/axlsx/workbook/worksheet/col_breaks.rb
@@ -21,7 +21,7 @@ module Axlsx
     end
 
     # Serialize the collection to xml
-    # @param [String] str The string to append this lists xml to.
+    # @param [#<<] str A String, buffer or IO to append the serialization to. The string to append this lists xml to.
     # <colBreaks count="1" manualBreakCount="1">
     # <brk id="3" max="1048575" man="1"/>
     # </colBreaks>

--- a/lib/axlsx/workbook/worksheet/color_scale.rb
+++ b/lib/axlsx/workbook/worksheet/color_scale.rb
@@ -83,7 +83,7 @@ module Axlsx
 
     # Serialize this color_scale object data to an xml string
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<colorScale>'
       value_objects.to_xml_string(str)

--- a/lib/axlsx/workbook/worksheet/color_scale.rb
+++ b/lib/axlsx/workbook/worksheet/color_scale.rb
@@ -82,7 +82,7 @@ module Axlsx
     end
 
     # Serialize this color_scale object data to an xml string
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<colorScale>'

--- a/lib/axlsx/workbook/worksheet/cols.rb
+++ b/lib/axlsx/workbook/worksheet/cols.rb
@@ -13,7 +13,7 @@ module Axlsx
 
     # Serialize the Cols object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       return if empty?
 

--- a/lib/axlsx/workbook/worksheet/cols.rb
+++ b/lib/axlsx/workbook/worksheet/cols.rb
@@ -12,7 +12,7 @@ module Axlsx
     end
 
     # Serialize the Cols object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       return if empty?

--- a/lib/axlsx/workbook/worksheet/comment.rb
+++ b/lib/axlsx/workbook/worksheet/comment.rb
@@ -59,7 +59,7 @@ module Axlsx
     end
 
     # serialize the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       author = @comments.authors[author_index]

--- a/lib/axlsx/workbook/worksheet/comment.rb
+++ b/lib/axlsx/workbook/worksheet/comment.rb
@@ -60,7 +60,7 @@ module Axlsx
 
     # serialize the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       author = @comments.authors[author_index]
       str << '<comment ref="' << ref << '" authorId="' << author_index.to_s << '">'

--- a/lib/axlsx/workbook/worksheet/comments.rb
+++ b/lib/axlsx/workbook/worksheet/comments.rb
@@ -62,7 +62,7 @@ module Axlsx
     end
 
     # serialize the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'

--- a/lib/axlsx/workbook/worksheet/comments.rb
+++ b/lib/axlsx/workbook/worksheet/comments.rb
@@ -63,7 +63,7 @@ module Axlsx
 
     # serialize the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
       str << '<comments xmlns="' << XML_NS << '"><authors>'

--- a/lib/axlsx/workbook/worksheet/conditional_formatting.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting.rb
@@ -79,7 +79,7 @@ module Axlsx
     #        </cfRule>
     #    </conditionalFormatting>
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<conditionalFormatting sqref="' << sqref << '">'
       rules.each_with_index do |rule, index|

--- a/lib/axlsx/workbook/worksheet/conditional_formatting.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting.rb
@@ -78,7 +78,7 @@ module Axlsx
     #             <formula>0.5</formula>
     #        </cfRule>
     #    </conditionalFormatting>
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<conditionalFormatting sqref="' << sqref << '">'

--- a/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
@@ -258,7 +258,7 @@ module Axlsx
 
     # Serializes the conditional formatting rule
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<cfRule '
       serialized_attributes str

--- a/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
@@ -257,7 +257,7 @@ module Axlsx
     end
 
     # Serializes the conditional formatting rule
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<cfRule '

--- a/lib/axlsx/workbook/worksheet/data_bar.rb
+++ b/lib/axlsx/workbook/worksheet/data_bar.rb
@@ -104,7 +104,7 @@ module Axlsx
     end
 
     # Serialize this object to an xml string
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       serialized_tag('dataBar', str) do

--- a/lib/axlsx/workbook/worksheet/data_bar.rb
+++ b/lib/axlsx/workbook/worksheet/data_bar.rb
@@ -105,7 +105,7 @@ module Axlsx
 
     # Serialize this object to an xml string
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       serialized_tag('dataBar', str) do
         value_objects.to_xml_string(str)

--- a/lib/axlsx/workbook/worksheet/data_validation.rb
+++ b/lib/axlsx/workbook/worksheet/data_validation.rb
@@ -271,7 +271,7 @@ module Axlsx
 
     # Serializes the data validation
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       valid_attributes = get_valid_attributes
       h = Axlsx.instance_values_for(self).select { |key, _| valid_attributes.include?(key.to_sym) && !CHILD_ELEMENTS.include?(key.to_sym) }

--- a/lib/axlsx/workbook/worksheet/data_validation.rb
+++ b/lib/axlsx/workbook/worksheet/data_validation.rb
@@ -270,7 +270,7 @@ module Axlsx
     end
 
     # Serializes the data validation
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       valid_attributes = get_valid_attributes

--- a/lib/axlsx/workbook/worksheet/dimension.rb
+++ b/lib/axlsx/workbook/worksheet/dimension.rb
@@ -35,7 +35,7 @@ module Axlsx
     end
 
     # serialize the object
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       return if worksheet.rows.empty?
 

--- a/lib/axlsx/workbook/worksheet/header_footer.rb
+++ b/lib/axlsx/workbook/worksheet/header_footer.rb
@@ -41,7 +41,7 @@ module Axlsx
 
     # Serializes the header/footer object.
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       serialized_tag('headerFooter', str) do
         serialized_element_attributes(str) do |value|

--- a/lib/axlsx/workbook/worksheet/header_footer.rb
+++ b/lib/axlsx/workbook/worksheet/header_footer.rb
@@ -40,7 +40,7 @@ module Axlsx
     end
 
     # Serializes the header/footer object.
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       serialized_tag('headerFooter', str) do

--- a/lib/axlsx/workbook/worksheet/icon_set.rb
+++ b/lib/axlsx/workbook/worksheet/icon_set.rb
@@ -88,7 +88,7 @@ module Axlsx
 
     # Serialize this object to an xml string
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       initialize_value_objects if @value_objects.nil?
 

--- a/lib/axlsx/workbook/worksheet/icon_set.rb
+++ b/lib/axlsx/workbook/worksheet/icon_set.rb
@@ -87,7 +87,7 @@ module Axlsx
     end
 
     # Serialize this object to an xml string
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       initialize_value_objects if @value_objects.nil?

--- a/lib/axlsx/workbook/worksheet/merged_cells.rb
+++ b/lib/axlsx/workbook/worksheet/merged_cells.rb
@@ -24,7 +24,7 @@ module Axlsx
     end
 
     # serialize the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       return if empty?

--- a/lib/axlsx/workbook/worksheet/merged_cells.rb
+++ b/lib/axlsx/workbook/worksheet/merged_cells.rb
@@ -25,7 +25,7 @@ module Axlsx
 
     # serialize the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       return if empty?
 

--- a/lib/axlsx/workbook/worksheet/outline_pr.rb
+++ b/lib/axlsx/workbook/worksheet/outline_pr.rb
@@ -26,7 +26,7 @@ module Axlsx
 
     # Serialize the object
     # @param [#<<] str A String, buffer or IO to append the serialization to. serialized output will be appended to this object if provided.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<outlinePr '
       serialized_attributes(str)

--- a/lib/axlsx/workbook/worksheet/outline_pr.rb
+++ b/lib/axlsx/workbook/worksheet/outline_pr.rb
@@ -25,7 +25,7 @@ module Axlsx
     end
 
     # Serialize the object
-    # @param [String] str serialized output will be appended to this object if provided.
+    # @param [#<<] str A String, buffer or IO to append the serialization to. serialized output will be appended to this object if provided.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<outlinePr '

--- a/lib/axlsx/workbook/worksheet/page_margins.rb
+++ b/lib/axlsx/workbook/worksheet/page_margins.rb
@@ -114,7 +114,7 @@ module Axlsx
     end
 
     # Serializes the page margins element
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     # @note For compatibility, this is a noop unless custom margins have been specified.
     # @see #custom_margins_specified?

--- a/lib/axlsx/workbook/worksheet/page_setup.rb
+++ b/lib/axlsx/workbook/worksheet/page_setup.rb
@@ -254,7 +254,7 @@ module Axlsx
 
     # Serializes the page settings element.
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       serialized_tag('pageSetup', str)
     end

--- a/lib/axlsx/workbook/worksheet/page_setup.rb
+++ b/lib/axlsx/workbook/worksheet/page_setup.rb
@@ -253,7 +253,7 @@ module Axlsx
     end
 
     # Serializes the page settings element.
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       serialized_tag('pageSetup', str)

--- a/lib/axlsx/workbook/worksheet/pane.rb
+++ b/lib/axlsx/workbook/worksheet/pane.rb
@@ -127,7 +127,7 @@ module Axlsx
 
     # Serializes the data validation
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       finalize
       serialized_tag 'pane', str

--- a/lib/axlsx/workbook/worksheet/pane.rb
+++ b/lib/axlsx/workbook/worksheet/pane.rb
@@ -126,7 +126,7 @@ module Axlsx
     end
 
     # Serializes the data validation
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       finalize

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -198,7 +198,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -199,7 +199,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
 

--- a/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
@@ -44,7 +44,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
       str << '<pivotCacheDefinition xmlns="' << XML_NS << '" xmlns:r="' << XML_NS_R << '" invalid="1" refreshOnLoad="1" recordCount="0">'

--- a/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
@@ -43,7 +43,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'

--- a/lib/axlsx/workbook/worksheet/print_options.rb
+++ b/lib/axlsx/workbook/worksheet/print_options.rb
@@ -32,7 +32,7 @@ module Axlsx
     # Serializes the page options element.
     # @note As all attributes default to "false" according to the xml schema definition, the generated xml includes only those attributes that are set to true.
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       serialized_tag 'printOptions', str
     end

--- a/lib/axlsx/workbook/worksheet/print_options.rb
+++ b/lib/axlsx/workbook/worksheet/print_options.rb
@@ -31,7 +31,7 @@ module Axlsx
 
     # Serializes the page options element.
     # @note As all attributes default to "false" according to the xml schema definition, the generated xml includes only those attributes that are set to true.
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       serialized_tag 'printOptions', str

--- a/lib/axlsx/workbook/worksheet/protected_range.rb
+++ b/lib/axlsx/workbook/worksheet/protected_range.rb
@@ -38,9 +38,7 @@ module Axlsx
     end
 
     # serializes the proteted range
-    # @param [String] str if this string object is provided we append
-    # our output to that object. Use this - it helps limit the number of
-    # objects created during serialization
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     def to_xml_string(str = +'')
       serialized_tag 'protectedRange', str
     end

--- a/lib/axlsx/workbook/worksheet/protected_ranges.rb
+++ b/lib/axlsx/workbook/worksheet/protected_ranges.rb
@@ -27,7 +27,7 @@ module Axlsx
 
     # Serializes the protected ranges
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       return if empty?
 

--- a/lib/axlsx/workbook/worksheet/protected_ranges.rb
+++ b/lib/axlsx/workbook/worksheet/protected_ranges.rb
@@ -26,7 +26,7 @@ module Axlsx
     end
 
     # Serializes the protected ranges
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       return if empty?

--- a/lib/axlsx/workbook/worksheet/rich_text.rb
+++ b/lib/axlsx/workbook/worksheet/rich_text.rb
@@ -46,7 +46,7 @@ module Axlsx
 
     # renders the RichTextRuns in this collection
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       each { |run| run.to_xml_string(str) }
       str

--- a/lib/axlsx/workbook/worksheet/rich_text.rb
+++ b/lib/axlsx/workbook/worksheet/rich_text.rb
@@ -45,7 +45,7 @@ module Axlsx
     end
 
     # renders the RichTextRuns in this collection
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       each { |run| run.to_xml_string(str) }

--- a/lib/axlsx/workbook/worksheet/rich_text_run.rb
+++ b/lib/axlsx/workbook/worksheet/rich_text_run.rb
@@ -224,7 +224,7 @@ module Axlsx
 
     # Serializes the RichTextRun
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       valid = RichTextRun::INLINE_STYLES
       data = Axlsx.instance_values_for(self).transform_keys(&:to_sym)

--- a/lib/axlsx/workbook/worksheet/rich_text_run.rb
+++ b/lib/axlsx/workbook/worksheet/rich_text_run.rb
@@ -223,7 +223,7 @@ module Axlsx
     end
 
     # Serializes the RichTextRun
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       valid = RichTextRun::INLINE_STYLES

--- a/lib/axlsx/workbook/worksheet/row.rb
+++ b/lib/axlsx/workbook/worksheet/row.rb
@@ -86,7 +86,7 @@ module Axlsx
 
     # Serializes the row
     # @param [Integer] r_index The row index, 0 based.
-    # @param [String] str The string this rows xml will be appended to.
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(r_index, str = +'')
       serialized_tag('row', str, r: Axlsx.row_ref(r_index)) do

--- a/lib/axlsx/workbook/worksheet/row.rb
+++ b/lib/axlsx/workbook/worksheet/row.rb
@@ -87,7 +87,7 @@ module Axlsx
     # Serializes the row
     # @param [Integer] r_index The row index, 0 based.
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(r_index, str = +'')
       serialized_tag('row', str, r: Axlsx.row_ref(r_index)) do
         each_with_index { |cell, c_index| cell.to_xml_string(r_index, c_index, str) }

--- a/lib/axlsx/workbook/worksheet/selection.rb
+++ b/lib/axlsx/workbook/worksheet/selection.rb
@@ -98,7 +98,7 @@ module Axlsx
     end
 
     # Serializes the data validation
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       serialized_tag 'selection', str

--- a/lib/axlsx/workbook/worksheet/selection.rb
+++ b/lib/axlsx/workbook/worksheet/selection.rb
@@ -99,7 +99,7 @@ module Axlsx
 
     # Serializes the data validation
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       serialized_tag 'selection', str
     end

--- a/lib/axlsx/workbook/worksheet/sheet_calc_pr.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_calc_pr.rb
@@ -22,7 +22,7 @@ module Axlsx
     # Serialize the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
     # content to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<sheetCalcPr '
       serialized_attributes(str)

--- a/lib/axlsx/workbook/worksheet/sheet_calc_pr.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_calc_pr.rb
@@ -20,7 +20,7 @@ module Axlsx
     serializable_attributes :full_calc_on_load
 
     # Serialize the object
-    # @param [String] str the string to append this objects serialized
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # content to.
     # @return [String]
     def to_xml_string(str = +'')

--- a/lib/axlsx/workbook/worksheet/sheet_data.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_data.rb
@@ -15,7 +15,7 @@ module Axlsx
 
     # Serialize the sheet data
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<sheetData>'
       worksheet.rows.each_with_index do |row, index|

--- a/lib/axlsx/workbook/worksheet/sheet_data.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_data.rb
@@ -14,7 +14,7 @@ module Axlsx
     attr_reader :worksheet
 
     # Serialize the sheet data
-    # @param [String] str the string this objects serializaton will be concacted to.
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<sheetData>'

--- a/lib/axlsx/workbook/worksheet/sheet_format_pr.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_format_pr.rb
@@ -47,7 +47,7 @@ module Axlsx
 
     # serializes this object to an xml string
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<sheetFormatPr '
       serialized_attributes(str)

--- a/lib/axlsx/workbook/worksheet/sheet_format_pr.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_format_pr.rb
@@ -46,7 +46,7 @@ module Axlsx
     unsigned_int_attr_accessor :base_col_width, :outline_level_row, :outline_level_col
 
     # serializes this object to an xml string
-    # @param [String] str The string this objects serialization will be appended to
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<sheetFormatPr '

--- a/lib/axlsx/workbook/worksheet/sheet_pr.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_pr.rb
@@ -49,7 +49,7 @@ module Axlsx
 
     # Serialize the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       update_properties
       str << '<sheetPr '

--- a/lib/axlsx/workbook/worksheet/sheet_pr.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_pr.rb
@@ -48,7 +48,7 @@ module Axlsx
     attr_reader :tab_color
 
     # Serialize the object
-    # @param [String] str serialized output will be appended to this object if provided.
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       update_properties

--- a/lib/axlsx/workbook/worksheet/sheet_protection.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_protection.rb
@@ -73,7 +73,7 @@ module Axlsx
     end
 
     # Serialize the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       serialized_tag('sheetProtection', str)

--- a/lib/axlsx/workbook/worksheet/sheet_protection.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_protection.rb
@@ -74,7 +74,7 @@ module Axlsx
 
     # Serialize the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       serialized_tag('sheetProtection', str)
     end

--- a/lib/axlsx/workbook/worksheet/sheet_view.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_view.rb
@@ -212,7 +212,7 @@ module Axlsx
 
     # Serializes the data validation
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<sheetViews>'
       str << '<sheetView '

--- a/lib/axlsx/workbook/worksheet/sheet_view.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_view.rb
@@ -211,7 +211,7 @@ module Axlsx
     end
 
     # Serializes the data validation
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<sheetViews>'

--- a/lib/axlsx/workbook/worksheet/table.rb
+++ b/lib/axlsx/workbook/worksheet/table.rb
@@ -72,7 +72,7 @@ module Axlsx
 
     # Serializes the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
       str << '<table xmlns="' << XML_NS << '" id="' << (index + 1).to_s << '" name="' << @name << '" displayName="' << @name.gsub(/\s/, '_') << '" '

--- a/lib/axlsx/workbook/worksheet/table.rb
+++ b/lib/axlsx/workbook/worksheet/table.rb
@@ -71,7 +71,7 @@ module Axlsx
     end
 
     # Serializes the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<?xml version="1.0" encoding="UTF-8"?>'

--- a/lib/axlsx/workbook/worksheet/table_style_info.rb
+++ b/lib/axlsx/workbook/worksheet/table_style_info.rb
@@ -42,7 +42,7 @@ module Axlsx
     attr_accessor :name
 
     # serializes this object to an xml string
-    # @param [String] str the string to contact this objects serialization to.
+    # @param [#<<] str A String, buffer or IO to append the serialization to. the string to contact this objects serialization to.
     def to_xml_string(str = +'')
       serialized_tag('tableStyleInfo', str)
     end

--- a/lib/axlsx/workbook/worksheet/tables.rb
+++ b/lib/axlsx/workbook/worksheet/tables.rb
@@ -24,7 +24,7 @@ module Axlsx
 
     # renders the tables xml
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       return if empty?
 

--- a/lib/axlsx/workbook/worksheet/tables.rb
+++ b/lib/axlsx/workbook/worksheet/tables.rb
@@ -23,7 +23,7 @@ module Axlsx
     end
 
     # renders the tables xml
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       return if empty?

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -650,7 +650,7 @@ module Axlsx
 
     # Serializes the worksheet object to an xml string
     # This intentionally does not use nokogiri for performance reasons
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       add_autofilter_defined_name_to_workbook
       auto_filter.apply if auto_filter.range

--- a/lib/axlsx/workbook/worksheet/worksheet_comments.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_comments.rb
@@ -50,7 +50,7 @@ module Axlsx
 
     # Seraalize the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       return unless has_comments?
 

--- a/lib/axlsx/workbook/worksheet/worksheet_comments.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_comments.rb
@@ -49,7 +49,7 @@ module Axlsx
     end
 
     # Seraalize the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       return unless has_comments?

--- a/lib/axlsx/workbook/worksheet/worksheet_drawing.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_drawing.rb
@@ -55,7 +55,7 @@ module Axlsx
     end
 
     # Serialize the drawing for the worksheet
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     def to_xml_string(str = +'')
       return unless has_drawing?
 

--- a/lib/axlsx/workbook/worksheet/worksheet_hyperlink.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_hyperlink.rb
@@ -57,7 +57,7 @@ module Axlsx
 
     # Serialize the object
     # @param [#<<] str A String, buffer or IO to append the serialization to.
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       str << '<hyperlink '
       serialized_attributes str, location_or_id, false

--- a/lib/axlsx/workbook/worksheet/worksheet_hyperlink.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_hyperlink.rb
@@ -56,7 +56,7 @@ module Axlsx
     end
 
     # Serialize the object
-    # @param [String] str
+    # @param [#<<] str A String, buffer or IO to append the serialization to.
     # @return [String]
     def to_xml_string(str = +'')
       str << '<hyperlink '

--- a/lib/axlsx/workbook/worksheet/worksheet_hyperlinks.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_hyperlinks.rb
@@ -28,7 +28,7 @@ module Axlsx
     end
 
     # serialize the collection of hyperlinks
-    # @return [String]
+    # @return [void]
     def to_xml_string(str = +'')
       return if empty?
 

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -224,7 +224,8 @@ class TestPackage < Minitest::Test
     File.delete(@fname)
   end
 
-  # See comment for Package#zip_entry_for_part
+  # The timestamp gets set on the files in the ZIP, we want to ensure it stays correct
+  # and takes precedence over the current system time
   def test_serialization_creates_identical_files_at_any_time_if_created_at_is_set
     @package.core.created = Time.now.utc # This must be UTC otherwise Timecop returns a TZ-local value and the test fails
     zip_content_now = @package.to_stream.string

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -164,7 +164,7 @@ class TestPackage < Minitest::Test
     out_io = writable_class.new
     @package.serialize(out_io)
 
-    File.open(@fname, "wb") {|f| f.write(out_io.buf_string) }
+    File.open(@fname, "wb") { |f| f.write(out_io.buf_string) }
 
     assert_zip_file_contains_files_per_package_part(@fname, @package)
     assert_current_year_mtime_for_entry(@fname, @package)

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -164,7 +164,7 @@ class TestPackage < Minitest::Test
     out_io = writable_class.new
     @package.serialize(out_io)
 
-    File.open(@fname, "wb") { |f| f.write(out_io.buf_string) }
+    File.binwrite(@fname, out_io.buf_string)
 
     assert_zip_file_contains_files_per_package_part(@fname, @package)
     assert_current_year_mtime_for_entry(@fname, @package)
@@ -253,6 +253,7 @@ class TestPackage < Minitest::Test
     zip_content_now = @package.to_stream.string
     Timecop.travel(3600) do
       zip_content_then = @package.to_stream.string
+
       assert_same_bytes zip_content_then, zip_content_now, "zip files are not identical"
     end
   end

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -188,11 +188,11 @@ class TestPackage < Minitest::Test
   end
 
   def assert_created_with_rubyzip(fname, package)
-    assert_equal 2098, get_mtime(fname, package).year, "XLSX files created with RubyZip have 2098 as the file mtime"
+    assert_equal 2098, get_mtime(fname, package).year, "entry inside XLSX created with ZipKit must have 2098 as the mtime year"
   end
 
   def assert_created_with_zip_command(fname, package)
-    assert_equal Time.now.utc.year, get_mtime(fname, package).year, "XLSX files created with a zip command have the current year as the file mtime"
+    assert_equal Time.now.utc.year, get_mtime(fname, package).year, "entry inside XLSX created with ZipKit must have current year as the mtime year"
   end
 
   def get_mtime(fname, package)

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -2,6 +2,7 @@
 
 require 'tc_helper'
 require 'support/capture_warnings'
+require 'zip' # We still use Rubyzip in tests
 
 class TestPackage < Minitest::Test
   include CaptureWarnings


### PR DESCRIPTION
### Description

I propose replacing Rubyzip with ZipKit (https://github.com/julik/zip_kit). This will allow removing the `ZipCommand`, and also will later permit a key feature - **streaming output of the XLSX file itself.** You can, in fact, already give it a non-rewindable and non-seekable output that responds to `write()` and you won't need _any_ output buffering.

This approach has been used in https://github.com/felixbuenemann/xlsxtream to great effect.

I've left the uses of rubyzip in tests in place for now but they can be replaced with zip_kit calls too.

This does touch some private APIs but tests seem to be passing, so I presume this would not necessarily be a major version bump.

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).