### PR TITLE
Update RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,8 @@ inherit_from: .rubocop_todo.yml
 
 require:
   - rubocop-packaging
+
+plugins:
   - rubocop-performance
   - rubocop-minitest
 
@@ -55,6 +57,10 @@ Security:
 
 Style:
   Enabled: true
+
+# Disabled for performance.
+Style/ComparableBetween:
+  Enabled: false
 
 # Disabled for performance. Reconsider when dropping Ruby < 3.4 support
 Style/MultipleComparison:

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development, :test do
   gem 'yard'
 
   if RUBY_VERSION >= '2.7'
-    gem 'rubocop', '1.73.2'
+    gem 'rubocop', '1.74.0'
     gem 'rubocop-minitest', '0.37.1'
     gem 'rubocop-packaging', '0.5.2'
     gem 'rubocop-performance', '1.24.0'


### PR DESCRIPTION
Disable new `Style/ComparableBetween` cop for performance

```
# Below range
Comparison:
            >= && <=: 21672186.8 i/s
            between?: 18758814.0 i/s - 1.16x  (± 0.00) slower

# Inside range or above range
Comparison (IPS):
            >= && <=: 17782096.7 i/s
            between?: 14252927.2 i/s - 1.25x  (± 0.00) slower
```

Ref: #434
