### PR TITLE
allow to specify vertical and horizontal as strings, too

### DIFF
--- a/lib/axlsx/stylesheet/cell_alignment.rb
+++ b/lib/axlsx/stylesheet/cell_alignment.rb
@@ -87,12 +87,16 @@ module Axlsx
 
     # @see horizontal
     def horizontal=(v)
+      v = v.to_sym if v
+
       Axlsx.validate_horizontal_alignment v
       @horizontal = v
     end
 
     # @see vertical
     def vertical=(v)
+      v = v.to_sym if v
+
       Axlsx.validate_vertical_alignment v
       @vertical = v
     end

--- a/test/stylesheet/tc_cell_alignment.rb
+++ b/test/stylesheet/tc_cell_alignment.rb
@@ -30,12 +30,14 @@ class TestCellAlignment < Minitest::Test
   def test_horizontal
     assert_raises(ArgumentError) { @item.horizontal = :red }
     refute_raises { @item.horizontal = :left }
+    refute_raises { @item.horizontal = 'left' }
     assert_equal(:left, @item.horizontal)
   end
 
   def test_vertical
     assert_raises(ArgumentError) { @item.vertical = :red }
     refute_raises { @item.vertical = :top }
+    refute_raises { @item.vertical = 'top' }
     assert_equal(:top, @item.vertical)
   end
 


### PR DESCRIPTION
### Description

Allow to set some options as strings, too.

I'm storing some styles in a database json column. It cannot hold symbols, so I get a hash like this back:

```rb
{
  "alignment" => {
    "vertical" => "top"
  }
}
```

This breaks the validator since it only accepts `:top`, not `"top"`:

```
Invalid Data: top. vertical_alignment must be one of [:top, :center, :bottom, :justify, :distributed].
```

Here's a first implementation which symbolizes the passed value so you can pass either `:top` or `"top"`.

First question: Do you think this is valid for this library? Or should it be strict like before about the parameters it accepts?

If you think it should accept either strings or symbols in such cases: Do you think this is the right approach to handle it? Or should it be changed somewhere else in the code?

Last but not least: There are probably more situations where it is like this. They should be changed accordingly then, too. I can take a look at this if you think it should be changed, too.

Thanks for your time!

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).