### PR TITLE
Fix valAx axis position for Apple Numbers support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 ---------
 - **Unreleased**
   - [PR #421](https://github.com/caxlsx/caxlsx/pull/421) Add Rubyzip >= 2.4 support
+  - [PR #448](https://github.com/caxlsx/caxlsx/pull/448) Fix Bar Chart: set axis position for Apple Numbers compatibility
 
 - **December.15.24**: 4.2.0
   - [PR #359](https://github.com/caxlsx/caxlsx/pull/359) Add `PivotTable#grand_totals` option to remove grand totals row/col

--- a/lib/axlsx/drawing/bar_3D_chart.rb
+++ b/lib/axlsx/drawing/bar_3D_chart.rb
@@ -141,7 +141,17 @@ module Axlsx
     # category axes specified via axes[:val_axes] and axes[:cat_axis]
     # @return [Axes]
     def axes
-      @axes ||= Axes.new(cat_axis: CatAxis, val_axis: ValAxis)
+      @axes ||= begin
+        a = Axes.new(cat_axis: CatAxis, val_axis: ValAxis)
+
+        if bar_dir == :col
+          a[:val_axis].ax_pos = :l
+        else
+          a[:cat_axis].ax_pos = :l
+        end
+
+        a
+      end
     end
   end
 end

--- a/lib/axlsx/drawing/bar_chart.rb
+++ b/lib/axlsx/drawing/bar_chart.rb
@@ -131,7 +131,17 @@ module Axlsx
     # category axes specified via axes[:val_axes] and axes[:cat_axis]
     # @return [Axes]
     def axes
-      @axes ||= Axes.new(cat_axis: CatAxis, val_axis: ValAxis)
+      @axes ||= begin
+        a = Axes.new(cat_axis: CatAxis, val_axis: ValAxis)
+
+        if bar_dir == :col
+          a[:val_axis].ax_pos = :l
+        else
+          a[:cat_axis].ax_pos = :l
+        end
+
+        a
+      end
     end
   end
 end

--- a/test/drawing/tc_bar_3D_chart.rb
+++ b/test/drawing/tc_bar_3D_chart.rb
@@ -83,4 +83,17 @@ class TestBar3DChart < Minitest::Test
 
     assert_equal(doc.xpath("//c:bar3DChart/c:gapWidth").first.attribute('val').value, gap_width_value.to_s)
   end
+
+  def test_cat_axis_position_for_horizontal_3d_bar_chart
+    axes = @chart.axes
+
+    assert_equal(:l, axes[:cat_axis].ax_pos, "cat_axis.ax_pos must be :l for horizontal bar charts")
+  end
+
+  def test_val_axis_position_for_vertical_3d_bar_chart
+    @chart.bar_dir = :col
+    axes = @chart.axes
+
+    assert_equal(:l, axes[:val_axis].ax_pos, "val_axis.ax_pos must be :l for vertical bar charts")
+  end
 end

--- a/test/drawing/tc_bar_chart.rb
+++ b/test/drawing/tc_bar_chart.rb
@@ -83,4 +83,17 @@ class TestBarChart < Minitest::Test
 
     assert_equal(doc.xpath("//c:barChart/c:overlap").first.attribute('val').value, overlap_value.to_s)
   end
+
+  def test_cat_axis_position_for_horizontal_bar_chart
+    axes = @chart.axes
+
+    assert_equal(:l, axes[:cat_axis].ax_pos, "cat_axis.ax_pos must be :l for horizontal bar charts")
+  end
+
+  def test_val_axis_position_for_vertical_bar_chart
+    @chart.bar_dir = :col
+    axes = @chart.axes
+
+    assert_equal(:l, axes[:val_axis].ax_pos, "val_axis.ax_pos must be :l for vertical bar charts")
+  end
 end


### PR DESCRIPTION
Problem:
XLSX files for vertical bar charts used `<c:axPos val="b"/>` for the `<c:valAx>` element, which is invalid per the Open XML Spreadsheet specification. The value axis must use `axPos="l"` (left) or `axPos="r"` (right); only `<c:catAx>` should use `axPos="b"` (bottom).

Impact:
Excel opens these files, but Apple Numbers enforces the specification and refuses to open charts with this schema error, causing incompatibility for Numbers users.

Solution:
Update chart XML generation to set `<c:axPos val="l"/>` for `<c:valAx>` and `<c:axPos val="b"/>` for `<c:catAx>`, as specified by the standard.

This is confirmed by extracting the `chart1.xml` from an XLSX file generated by Excel with a standard column/bar chart, where `<c:catAx>` uses `axPos="b"` and `<c:valAx>` uses `axPos="l"`.

For reference, see ECMA-376, 5th Edition, Part 1, §21.2.3.2 (ST_AxPos) and verify with Excel-generated files.

Assisted by GitHub Copilot

Fix #348

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] ~If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.~
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] ~I have updated the documentation accordingly.~
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).