### PR TITLE
Remove redundant `||` fallback in SimpleTypedList

### DIFF
--- a/lib/axlsx/util/simple_typed_list.rb
+++ b/lib/axlsx/util/simple_typed_list.rb
@@ -183,8 +183,7 @@ module Axlsx
     end
 
     def to_xml_string(str = +'')
-      classname = @allowed_types[0].name.split('::').last
-      el_name = serialize_as.to_s || (classname[0, 1].downcase + classname[1..])
+      el_name = serialize_as.to_s
       str << '<' << el_name << ' count="' << size.to_s << '">'
       each { |item| item.to_xml_string(str) }
       str << '</' << el_name << '>'


### PR DESCRIPTION
The new cop flagged a fallback path in `SimpleTypedList#to_xml_string` for cases where `serialize_as` is nil.  

After reviewing the serialization logic and attempting to reproduce a real-world scenario, no case was found where this fallback is invoked in normal usage.  

No consumers, including PivotTables, call `to_xml_string` without a valid `serialize_as` value.  

This code path is therefore not an issue and is currently redundant.

Remove the dead condition for clarity and maintainability.

Close #447

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).