### PR TITLE
Update RuboCop and autofix new safe offenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development, :test do
   gem 'yard'
 
   if RUBY_VERSION >= '2.7'
-    gem 'rubocop', '1.79.1'
+    gem 'rubocop', '1.79.2'
     gem 'rubocop-minitest', '0.38.1'
     gem 'rubocop-packaging', '0.6.0'
     gem 'rubocop-performance', '1.25.0'

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -886,7 +886,7 @@ class TestWorksheet < Minitest::Test
       family: 1
     }
 
-    assert_equal b2_cell_style, (wb.styles.style_index.values.find { |x| x == b2_cell_style })
+    assert_equal(b2_cell_style, wb.styles.style_index.values.find { |x| x == b2_cell_style })
 
     d3_cell_style = {
       border: {
@@ -900,7 +900,7 @@ class TestWorksheet < Minitest::Test
       family: 1
     }
 
-    assert_equal d3_cell_style, (wb.styles.style_index.values.find { |x| x == d3_cell_style })
+    assert_equal(d3_cell_style, wb.styles.style_index.values.find { |x| x == d3_cell_style })
   end
 
   def test_mixed_borders_1


### PR DESCRIPTION
RuboCop discovered a couple of new safe offenses in non-production code:

- Lint/AmbiguousBlockAssociation
- Style/RedundantParentheses

They have been automatically fixed

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] ~I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.~
- [x] ~If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.~
- [x] ~If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.~
- [x] ~I have updated the documentation accordingly.~
- [x] All new and existing tests passed.
- [x] ~I added an entry to the [changelog](../blob/master/CHANGELOG.md).~