### PR TITLE
Use timecop to fix transient time failure in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 ---------
 - **Unreleased**
-
+  - [PR #475](https://github.com/caxlsx/caxlsx/pull/475) Use timecop to fix transient time failure in tests
 
 - **August.16.25**: 4.3.0
   - [PR #421](https://github.com/caxlsx/caxlsx/pull/421) Add Rubyzip >= 2.4 support

--- a/test/doc_props/tc_core.rb
+++ b/test/doc_props/tc_core.rb
@@ -5,9 +5,10 @@ require 'tc_helper'
 class TestCore < Minitest::Test
   def setup
     @core = Axlsx::Core.new
-    # could still see some false positives if the second changes between the next two calls
-    @time = Time.now.strftime('%Y-%m-%dT%H:%M:%SZ')
-    @doc = Nokogiri::XML(@core.to_xml_string)
+    Timecop.freeze do
+      @time = Time.now.strftime('%Y-%m-%dT%H:%M:%SZ')
+      @doc = Nokogiri::XML(@core.to_xml_string)
+    end
   end
 
   def test_valid_document


### PR DESCRIPTION
Fixes an annoyance. Timecop is already in the project's Gemfile