### PR TITLE
Fix pivot table XML when columns and multiple data fields are combined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 CHANGELOG
 ---------
 - **Unreleased**
+  - [PR #517](https://github.com/caxlsx/caxlsx/pull/517) Fix invalid XML when pivot table has both `columns` and multiple `data` fields configured. Solves [Issue #414](https://github.com/caxlsx/caxlsx/issues/414)
 
 - **March.23.26**: 4.4.2
   - [PR #510](https://github.com/caxlsx/caxlsx/pull/510) Add configurable `major_tick_mark` and `minor_tick_mark` attributes to chart axes

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -247,11 +247,25 @@ module Axlsx
           str << '<colItems count="1"><i/></colItems>'
         end
       else
-        str << '<colFields count="' << columns.size.to_s << '">'
-        columns.each do |column_value|
-          str << '<field x="' << header_index_of(column_value).to_s << '"/>'
+        if data.size > 1
+          str << '<colFields count="' << (columns.size + 1).to_s << '">'
+          columns.each do |column_value|
+            str << '<field x="' << header_index_of(column_value).to_s << '"/>'
+          end
+          str << '<field x="-2"/></colFields>'
+          str << "<colItems count=\"#{data.size}\">"
+          str << '<i><x/></i>'
+          (data.size - 1).times do |i|
+            str << "<i i=\"#{i + 1}\"><x v=\"#{i + 1}\"/></i>"
+          end
+          str << '</colItems>'
+        else
+          str << '<colFields count="' << columns.size.to_s << '">'
+          columns.each do |column_value|
+            str << '<field x="' << header_index_of(column_value).to_s << '"/>'
+          end
+          str << '</colFields>'
         end
-        str << '</colFields>'
       end
       unless pages.empty?
         str << '<pageFields count="' << pages.size.to_s << '">'

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -246,26 +246,24 @@ module Axlsx
         else
           str << '<colItems count="1"><i/></colItems>'
         end
-      else
-        if data.size > 1
-          str << '<colFields count="' << (columns.size + 1).to_s << '">'
-          columns.each do |column_value|
-            str << '<field x="' << header_index_of(column_value).to_s << '"/>'
-          end
-          str << '<field x="-2"/></colFields>'
-          str << "<colItems count=\"#{data.size}\">"
-          str << '<i><x/></i>'
-          (data.size - 1).times do |i|
-            str << "<i i=\"#{i + 1}\"><x v=\"#{i + 1}\"/></i>"
-          end
-          str << '</colItems>'
-        else
-          str << '<colFields count="' << columns.size.to_s << '">'
-          columns.each do |column_value|
-            str << '<field x="' << header_index_of(column_value).to_s << '"/>'
-          end
-          str << '</colFields>'
+      elsif data.size > 1
+        str << '<colFields count="' << (columns.size + 1).to_s << '">'
+        columns.each do |column_value|
+          str << '<field x="' << header_index_of(column_value).to_s << '"/>'
         end
+        str << '<field x="-2"/></colFields>'
+        str << "<colItems count=\"#{data.size}\">"
+        str << '<i><x/></i>'
+        (data.size - 1).times do |i|
+          str << "<i i=\"#{i + 1}\"><x v=\"#{i + 1}\"/></i>"
+        end
+        str << '</colItems>'
+      else
+        str << '<colFields count="' << columns.size.to_s << '">'
+        columns.each do |column_value|
+          str << '<field x="' << header_index_of(column_value).to_s << '"/>'
+        end
+        str << '</colFields>'
       end
       unless pages.empty?
         str << '<pageFields count="' << pages.size.to_s << '">'

--- a/test/workbook/worksheet/tc_pivot_table.rb
+++ b/test/workbook/worksheet/tc_pivot_table.rb
@@ -230,4 +230,31 @@ class TestPivotTable < Minitest::Test
 
     refute_includes(xml, 'colFields')
   end
+
+  def test_pivot_table_with_columns_and_more_than_one_data_field
+    # https://github.com/caxlsx/caxlsx/issues/414
+
+    pivot_table = @ws.add_pivot_table('G5:G6', 'A1:E5') do |pt|
+      pt.rows = ['Year']
+      pt.columns = ['Type']
+      pt.data = [
+        { ref: 'Sales' },
+        { ref: 'Month' }
+      ]
+    end
+
+    xml = pivot_table.to_xml_string
+    doc = Nokogiri::XML(xml)
+
+    assert_includes(xml, 'colItems')
+
+    assert_equal('2', doc.at_css('colFields')['count'])
+    assert_equal('-2', doc.css('colFields field').last['x'])
+
+    assert_equal('2', doc.at_css('colItems')['count'])
+    assert_nil(doc.at_css('colItems i')['x'])
+    assert_equal('1', doc.at_css('colItems i[i=1] x')['v'])
+
+    shared_test_pivot_table_xml_validity(pivot_table)
+  end
 end


### PR DESCRIPTION
Closes #414

### Description

When a pivot table has both `columns` and multiple `data` fields configured, the generated XML was missing the `x="-2"` marker `<field>` inside `<colFields>` and the entire `<colItems>` block.

#### How to reproduce

Reported with caxlsx v4.4.2. The following code produces a file that Excel
reports workbooks get damaged:

```rb
require 'axlsx'

p = Axlsx::Package.new
wb = p.workbook

data_sheet = wb.add_worksheet(name: 'Data') do |sheet|
  sheet.add_row ['Grade', 'Class', 'Name', 'Exam', 'Math', 'English', 'Science']

  [
    [1, 'A', 'Alice',   'Mid',  85, 90, 78],
    [1, 'A', 'Alice',   'End',  88, 92, 81],
    [1, 'A', 'Bob',     'Mid',  72, 68, 75],
    [1, 'A', 'Bob',     'End',  76, 71, 79],
    [1, 'B', 'Charlie', 'Mid',  91, 88, 93],
    [1, 'B', 'Charlie', 'End',  94, 90, 95],
    [2, 'A', 'Diana',   'Mid',  80, 85, 82],
    [2, 'A', 'Diana',   'End',  83, 87, 84],
    [2, 'B', 'Eve',     'Mid',  77, 74, 80],
    [2, 'B', 'Eve',     'End',  79, 76, 83],
  ].each { |row| sheet.add_row(row) }
end

wb.add_worksheet(name: 'Pivot') do |sheet|
  sheet.add_pivot_table('A1', 'A1:G11') do |pt|
    pt.data_sheet = data_sheet
    pt.rows    = ['Grade', 'Name']
    pt.columns = ['Exam']
    pt.data    = [
      { ref: 'Math',    subtotal: 'sum' },
      { ref: 'English', subtotal: 'sum' },
      { ref: 'Science', subtotal: 'sum' },
    ]
  end
end

p.serialize('pivot_demo.xlsx')
puts 'Generated: pivot_demo.xlsx'
```

- Generated at tag v4.4.2 [pivot_demo_before.xlsx](https://github.com/user-attachments/files/27793018/pivot_demo_before.xlsx)
- Generated at this PR [pivot_demo_after.xlsx](https://github.com/user-attachments/files/27793020/pivot_demo_after.xlsx)



#### Root cause

https://github.com/caxlsx/caxlsx/blob/v4.4.2/lib/axlsx/workbook/worksheet/pivot_table.rb#L249-L255

The `else` branch only generated `<colFields>` but did not handle the `data.size > 1` case, unlike the `columns.empty?` branch which already handled it correctly.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).