### PR TITLE
Make `useAutoFormatting` and `applyWidthHeightFormats` configurable on PivotTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 CHANGELOG
 ---------
 - **Unreleased**
+  - [PR #520](https://github.com/caxlsx/caxlsx/pull/520) Add `use_auto_formatting` and `apply_width_height_formats` accessors to `PivotTable`
 
 - **March.23.26**: 4.4.2
   - [PR #510](https://github.com/caxlsx/caxlsx/pull/510) Add configurable `major_tick_mark` and `minor_tick_mark` attributes to chart axes

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -29,6 +29,8 @@ module Axlsx
       @grand_totals = :both
       @sort_on_headers = {}
       @style_info = {}
+      @use_auto_formatting = true
+      @apply_width_height_formats = true
       parse_options options
       yield self if block_given?
     end
@@ -84,6 +86,14 @@ module Axlsx
     # The sheet used as data source for the pivot table
     # @return [Worksheet]
     attr_writer :data_sheet
+
+    # Whether to apply auto formatting to the pivot table.
+    # @return [Boolean]
+    attr_accessor :use_auto_formatting
+
+    # Whether to apply width/height formats to the pivot table.
+    # @return [Boolean]
+    attr_accessor :apply_width_height_formats
 
     # @see #data_sheet
     def data_sheet
@@ -207,7 +217,11 @@ module Axlsx
       str << ' dataOnRows="1"' if data.size <= 1
       str << ' rowGrandTotals="0"' if grand_totals == :col_only || grand_totals == :none
       str << ' colGrandTotals="0"' if grand_totals == :row_only || grand_totals == :none
-      str << ' applyNumberFormats="0" applyBorderFormats="0" applyFontFormats="0" applyPatternFormats="0" applyAlignmentFormats="0" applyWidthHeightFormats="1" dataCaption="Data" showMultipleLabel="0" showMemberPropertyTips="0" useAutoFormatting="1" indent="0" compact="0" compactData="0" gridDropZones="1" multipleFieldFilters="0">'
+      str << ' applyNumberFormats="0" applyBorderFormats="0" applyFontFormats="0" applyPatternFormats="0" applyAlignmentFormats="0"'
+      str << ' applyWidthHeightFormats="' << (@apply_width_height_formats ? '1' : '0') << '"'
+      str << ' dataCaption="Data" showMultipleLabel="0" showMemberPropertyTips="0"'
+      str << ' useAutoFormatting="' << (@use_auto_formatting ? '1' : '0') << '"'
+      str << ' indent="0" compact="0" compactData="0" gridDropZones="1" multipleFieldFilters="0">'
 
       str << '<location firstDataCol="1" firstDataRow="1" firstHeaderRow="1" ref="' << ref << '"/>'
       str << '<pivotFields count="' << header_cells_count.to_s << '">'

--- a/test/workbook/worksheet/tc_pivot_table.rb
+++ b/test/workbook/worksheet/tc_pivot_table.rb
@@ -213,6 +213,40 @@ class TestPivotTable < Minitest::Test
     assert_equal('2', doc.at_css('colItems i[i=2] x')['v'])
   end
 
+  def test_use_auto_formatting
+    pivot_table = @ws.add_pivot_table('G5:G6', 'A1:E5') do |pt|
+      pt.data = ['Sales']
+    end
+
+    assert(pivot_table.use_auto_formatting)
+    assert_includes(pivot_table.to_xml_string, 'useAutoFormatting="1"')
+
+    pivot_table = @ws.add_pivot_table('G5:G6', 'A1:E5', { use_auto_formatting: false }) do |pt|
+      pt.data = ['Sales']
+    end
+
+    refute(pivot_table.use_auto_formatting)
+    assert_includes(pivot_table.to_xml_string, 'useAutoFormatting="0"')
+    shared_test_pivot_table_xml_validity(pivot_table)
+  end
+
+  def test_apply_width_height_formats
+    pivot_table = @ws.add_pivot_table('G5:G6', 'A1:E5') do |pt|
+      pt.data = ['Sales']
+    end
+
+    assert(pivot_table.apply_width_height_formats)
+    assert_includes(pivot_table.to_xml_string, 'applyWidthHeightFormats="1"')
+
+    pivot_table = @ws.add_pivot_table('G5:G6', 'A1:E5', { apply_width_height_formats: false }) do |pt|
+      pt.data = ['Sales']
+    end
+
+    refute(pivot_table.apply_width_height_formats)
+    assert_includes(pivot_table.to_xml_string, 'applyWidthHeightFormats="0"')
+    shared_test_pivot_table_xml_validity(pivot_table)
+  end
+
   def test_pivot_table_with_only_one_data_row
     # https://github.com/caxlsx/caxlsx/issues/110
 


### PR DESCRIPTION
Closes #519

Both attributes default to true (preserving existing behavior) and can be set via options or block when creating a pivot table.

### Description

#### Problem

`PivotTable#to_xml_string` hardcodes `useAutoFormatting="1"` and `applyWidthHeightFormats="1"`, making it impossible to generate pivot tables where "AutoFit column widths on update" is disabled.

#### Investigation

To understand what Excel writes when "AutoFit column widths on update" is turned off:

<img width="621" height="632" alt="autofit-column-widths-on-update" src="https://github.com/user-attachments/assets/874c08b1-b871-4d7a-b954-5f212d037ca8" />

1. Generated an xlsx file with caxlsx containing a pivot table
2. Opened it in Excel for Mac and unchecked `PivotTable Options` → `Layout` → `AutoFit column widths on update`
3. Saved and inspected the resulting XML with unzip

I found `useAutoFormatting="1"` attribute was absent from the `<pivotTableDefinition>` element when the option was disabled.

#### Solution

Introduce `use_auto_formatting` and `apply_width_height_formats` as configurable accessors on `PivotTable`, both defaulting to true to preserve existing behavior.

```ruby
# Default behavior unchanged
pivot_table = ws.add_pivot_table('G5:G6', 'A1:E5') do |pt|
  pt.rows = ['Year']
  pt.data = ['Sales']
end

# Disable "AutoFit column widths on update"
pivot_table = ws.add_pivot_table('G5:G6', 'A1:E5', { use_auto_formatting: false }) do |pt|
  pt.rows = ['Year']
  pt.data = ['Sales']
end
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).