### PR TITLE
Allow custom name for pivot table data fields via :name option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 CHANGELOG
 ---------
 - **Unreleased**
+  - [PR #522](https://github.com/caxlsx/caxlsx/pull/522) Allow custom name for pivot table data fields via :name option
 
 - **March.23.26**: 4.4.2
   - [PR #510](https://github.com/caxlsx/caxlsx/pull/510) Add configurable `major_tick_mark` and `minor_tick_mark` attributes to chart axes

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -265,7 +265,8 @@ module Axlsx
         data.each do |datum_value|
           subtotal_name = datum_value[:subtotal] || 'sum'
           subtotal_name = 'count' if name == 'countNums' # both count & countNums are labelled as count
-          str << "<dataField name='#{subtotal_name.capitalize} of #{datum_value[:ref]}' fld='#{header_index_of(datum_value[:ref])}' baseField='0' baseItem='0'"
+          field_name = datum_value[:name] || "#{subtotal_name.capitalize} of #{datum_value[:ref]}"
+          str << "<dataField name='#{field_name}' fld='#{header_index_of(datum_value[:ref])}' baseField='0' baseItem='0'"
           str << " numFmtId='#{datum_value[:num_fmt]}'" if datum_value[:num_fmt]
           str << " subtotal='#{datum_value[:subtotal]}' " if datum_value[:subtotal]
           str << "/>"

--- a/test/workbook/worksheet/tc_pivot_table.rb
+++ b/test/workbook/worksheet/tc_pivot_table.rb
@@ -213,6 +213,25 @@ class TestPivotTable < Minitest::Test
     assert_equal('2', doc.at_css('colItems i[i=2] x')['v'])
   end
 
+  def test_add_pivot_table_with_custom_name_on_data_field
+    pivot_table = @ws.add_pivot_table('G5:G6', 'A1:E5') do |pt|
+      pt.data = [{ ref: "Sales", name: "Total Sales" }]
+    end
+    doc = Nokogiri::XML(pivot_table.to_xml_string)
+
+    assert_equal('Total Sales', doc.at_css('dataFields dataField')['name'])
+    shared_test_pivot_table_xml_validity(pivot_table)
+  end
+
+  def test_data_field_name_defaults_to_subtotal_of_ref_when_name_not_given
+    pivot_table = @ws.add_pivot_table('G5:G6', 'A1:E5') do |pt|
+      pt.data = [{ ref: "Sales" }]
+    end
+    doc = Nokogiri::XML(pivot_table.to_xml_string)
+
+    assert_equal('Sum of Sales', doc.at_css('dataFields dataField')['name'])
+  end
+
   def test_pivot_table_with_only_one_data_row
     # https://github.com/caxlsx/caxlsx/issues/110
 


### PR DESCRIPTION
Closes #521

### Description

Adds an optional `:name` key to data field hashes in pivot tables. When provided, it is used as the `name` attribute of `<dataField>` directly; when omitted, the existing `"#{subtotal.capitalize} of #{ref}"` default is preserved.

#### Motivation

The auto-generated name `"Sum of ColumnName"` is awkward for non-English users. When column headers are in another language (e.g. Japanese), the result is a mixed-language label like `"Sum of 合計点"` that looks unnatural and is often long enough to be truncated in Excel. This option lets callers supply a fully localized or abbreviated label.

#### Usage

```ruby
pivot_table.data = [
  { ref: '合計点', name: '合計' },
]
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).