### PR TITLE
Fix PivotTable countNums subtotal label never applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 CHANGELOG
 ---------
 - **Unreleased**
+  - [PR #527](https://github.com/caxlsx/caxlsx/pull/527) Fix PivotTable countNums subtotal label never applied. Solves [Issue #526](https://github.com/caxlsx/caxlsx/issues/526)
   - [PR #522](https://github.com/caxlsx/caxlsx/pull/522) Allow custom name for pivot table data fields via :name option
   - [PR #520](https://github.com/caxlsx/caxlsx/pull/520) Add `use_auto_formatting` and `apply_width_height_formats` accessors to `PivotTable`
   - [PR #517](https://github.com/caxlsx/caxlsx/pull/517) Fix invalid XML when pivot table has both `columns` and multiple `data` fields configured. Solves [Issue #414](https://github.com/caxlsx/caxlsx/issues/414)

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -290,7 +290,7 @@ module Axlsx
         str << "<dataFields count=\"#{data.size}\">"
         data.each do |datum_value|
           subtotal_name = datum_value[:subtotal] || 'sum'
-          subtotal_name = 'count' if name == 'countNums' # both count & countNums are labelled as count
+          subtotal_name = 'count' if datum_value[:subtotal] == 'countNums' # both count & countNums are labelled as count
           field_name = datum_value[:name] || "#{subtotal_name.capitalize} of #{datum_value[:ref]}"
           str << "<dataField name='#{field_name}' fld='#{header_index_of(datum_value[:ref])}' baseField='0' baseItem='0'"
           str << " numFmtId='#{datum_value[:num_fmt]}'" if datum_value[:num_fmt]

--- a/test/workbook/worksheet/tc_pivot_table.rb
+++ b/test/workbook/worksheet/tc_pivot_table.rb
@@ -213,6 +213,15 @@ class TestPivotTable < Minitest::Test
     assert_equal('2', doc.at_css('colItems i[i=2] x')['v'])
   end
 
+  def test_data_field_name_uses_count_label_for_count_nums_subtotal
+    pivot_table = @ws.add_pivot_table('G5:G6', 'A1:E5') do |pt|
+      pt.data = [{ ref: "Sales", subtotal: 'countNums' }]
+    end
+    doc = Nokogiri::XML(pivot_table.to_xml_string)
+
+    assert_equal('Count of Sales', doc.at_css('dataFields dataField')['name'])
+  end
+
   def test_add_pivot_table_with_custom_name_on_data_field
     pivot_table = @ws.add_pivot_table('G5:G6', 'A1:E5') do |pt|
       pt.data = [{ ref: "Sales", name: "Total Sales" }]


### PR DESCRIPTION
Closes #526

### Description

[In `pivot_table.rb` line 267](https://github.com/caxlsx/caxlsx/blob/v4.4.2/lib/axlsx/workbook/worksheet/pivot_table.rb#L267), the following line was comparing against `self.name` (the pivot table's name) instead of the subtotal type:

```ruby
subtotal_name = 'count' if name == 'countNums'
```

This meant that when a user specified subtotal: 'countNums', the auto-generated field name would be "CountNums of X" instead of the correct "Count of X" (matching Excel's display behavior).

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).