### PR TITLE
Revert "Patch ooxml_crypt gem while waiting for the fix to be merged and shipped"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,9 +25,7 @@ group :test do
   gem 'win32ole', platforms: [:mingw, :x64_mingw, :mswin, :mswin64]
 
   if RUBY_ENGINE == 'ruby'
-    # Temporary override until the fix gets merged and released
-    # See: https://github.com/teamsimplepay/ooxml_crypt/pull/47
-    gem 'ooxml_crypt', git: 'https://github.com/kiskoza/ooxml_crypt', branch: 'update-vendors'
+    gem 'ooxml_crypt'
   end
 end
 


### PR DESCRIPTION
This reverts commit 1d56dc8a9dcafd17ad88e3fdc20162fc7cf61684.

Thanks to the author of ooxml_crypt, we don't need this patch anymore :tada: 