### PR TITLE
Implement dateGroupItem filtering in Filters#apply

### DIFF
--- a/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
@@ -40,13 +40,16 @@ module Axlsx
     # does not meet any of the specified filter_items or
     # date_group_items restrictions.
     # @param [Cell] cell The cell to test against items
-    # TODO implement this for date filters as well!
     def apply(cell) # rubocop:disable Naming/PredicateMethod
       return false unless cell
 
-      filter_items.each do |filter|
-        return false if cell.value == filter.val
+      return false if filter_items.any? { |f| cell.value == f.val }
+
+      if date_group_items.any?
+        dt = normalize_cell_datetime(cell)
+        return false if date_group_items.any? { |dgi| dgi.matches?(dt) }
       end
+
       true
     end
 
@@ -97,8 +100,6 @@ module Axlsx
 
     # Date group items are date group filter items where you specify the
     # date_group and a value for that option as part of the auto_filter
-    # @note This can be specified, but will not be applied to the date
-    # values in your workbook at this time.
     def date_group_items=(options)
       options.each do |date_group|
         raise ArgumentError, "date_group_items should be an array of hashes specifying the options for each date_group_item" unless date_group.is_a?(Hash)

--- a/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
@@ -119,24 +119,14 @@ module Axlsx
 
       v = cell.value
       case v
-      when Time
-        { year: v.year, month: v.month, day: v.day,
-          hour: v.hour, minute: v.min, second: v.sec }
-      when DateTime
+      when Time, DateTime
         { year: v.year, month: v.month, day: v.day,
           hour: v.hour, minute: v.min, second: v.sec }
       when Date
         { year: v.year, month: v.month, day: v.day,
           hour: 0, minute: 0, second: 0 }
       when Numeric
-        int_part = v.floor
-        d = DateTimeConverter.date_from_serial(int_part)
-        total_seconds = ((v - int_part) * 86400).round
-        h = total_seconds / 3600
-        m = (total_seconds % 3600) / 60
-        s = total_seconds % 60
-        { year: d.year, month: d.month, day: d.day,
-          hour: h, minute: m, second: s }
+        DateTimeConverter.datetime_components_from_serial(v)
       end
     end
 

--- a/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
@@ -107,6 +107,32 @@ module Axlsx
       end
     end
 
+    private
+
+    # Normalize a cell's value to a Hash with date/time components.
+    # Returns nil if the cell value is not a date or time.
+    # @param [Cell] cell
+    # @return [Hash, nil] { year:, month:, day:, hour:, minute:, second: } or nil
+    def normalize_cell_datetime(cell)
+      return nil if cell.nil?
+
+      v = cell.value
+      case v
+      when Time
+        { year: v.year, month: v.month, day: v.day,
+          hour: v.hour, minute: v.min, second: v.sec }
+      when Date
+        { year: v.year, month: v.month, day: v.day,
+          hour: 0, minute: 0, second: 0 }
+      when Numeric
+        d = DateTimeConverter.date_from_serial(v)
+        { year: d.year, month: d.month, day: d.day,
+          hour: 0, minute: 0, second: 0 }
+      end
+    end
+
+    public
+
     # This class expresses a filter criteria value.
     class Filter
       # Creates a new filter value object

--- a/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
@@ -122,13 +122,21 @@ module Axlsx
       when Time
         { year: v.year, month: v.month, day: v.day,
           hour: v.hour, minute: v.min, second: v.sec }
+      when DateTime
+        { year: v.year, month: v.month, day: v.day,
+          hour: v.hour, minute: v.min, second: v.sec }
       when Date
         { year: v.year, month: v.month, day: v.day,
           hour: 0, minute: 0, second: 0 }
       when Numeric
-        d = DateTimeConverter.date_from_serial(v)
+        int_part = v.floor
+        d = DateTimeConverter.date_from_serial(int_part)
+        total_seconds = ((v - int_part) * 86400).round
+        h = total_seconds / 3600
+        m = (total_seconds % 3600) / 60
+        s = total_seconds % 60
         { year: d.year, month: d.month, day: d.day,
-          hour: 0, minute: 0, second: 0 }
+          hour: h, minute: m, second: s }
       end
     end
 

--- a/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
@@ -263,6 +263,24 @@ module Axlsx
         @date_time_grouping = grouping.to_s
       end
 
+      GROUPING_FIELDS = {
+        'year'   => %i[year],
+        'month'  => %i[year month],
+        'day'    => %i[year month day],
+        'hour'   => %i[year month day hour],
+        'minute' => %i[year month day hour minute],
+        'second' => %i[year month day hour minute second]
+      }.freeze
+
+      # Returns true if this date group item matches the given normalized datetime hash.
+      # @param [Hash, nil] dt { year:, month:, day:, hour:, minute:, second: } from normalize_cell_datetime
+      # @return [Boolean]
+      def matches?(dt)
+        return false unless dt
+
+        GROUPING_FIELDS[date_time_grouping].all? { |f| send(f).to_i == dt[f].to_i }
+      end
+
       # Serialize the object to xml
       # @param [String] str The string object this serialization will be concatenated to.
       def to_xml_string(str = +'')

--- a/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
@@ -130,8 +130,6 @@ module Axlsx
       end
     end
 
-    public
-
     # This class expresses a filter criteria value.
     class Filter
       # Creates a new filter value object
@@ -263,12 +261,12 @@ module Axlsx
       end
 
       GROUPING_FIELDS = {
-        'year'   => %i[year],
-        'month'  => %i[year month],
-        'day'    => %i[year month day],
-        'hour'   => %i[year month day hour],
-        'minute' => %i[year month day hour minute],
-        'second' => %i[year month day hour minute second]
+        'year' => [:year],
+        'month' => [:year, :month],
+        'day' => [:year, :month, :day],
+        'hour' => [:year, :month, :day, :hour],
+        'minute' => [:year, :month, :day, :hour, :minute],
+        'second' => [:year, :month, :day, :hour, :minute, :second]
       }.freeze
 
       # Returns true if this date group item matches the given normalized datetime hash.

--- a/lib/axlsx/workbook/worksheet/date_time_converter.rb
+++ b/lib/axlsx/workbook/worksheet/date_time_converter.rb
@@ -14,6 +14,14 @@ module Axlsx
       (offset_date - epoch).to_f
     end
 
+    # Converts an Excel serial number back to a Date object.
+    # @param [Numeric] serial The Excel date serial number
+    # @return [Date]
+    def self.date_from_serial(serial)
+      epoch = Axlsx::Workbook.date1904 ? Date.new(1904) : Date.new(1899, 12, 30)
+      epoch + serial.to_i
+    end
+
     # The time_to_serial methond converts a Time object its Excel serialized form.
     # @param [Time] time the time to be serialized
     # @return [Numeric]

--- a/lib/axlsx/workbook/worksheet/date_time_converter.rb
+++ b/lib/axlsx/workbook/worksheet/date_time_converter.rb
@@ -22,6 +22,19 @@ module Axlsx
       epoch + serial.to_i
     end
 
+    # Converts an Excel serial number to a Hash of date/time components.
+    # @param [Numeric] serial The Excel date-time serial number
+    # @return [Hash] { year:, month:, day:, hour:, minute:, second: }
+    def self.datetime_components_from_serial(serial)
+      int_part = serial.floor
+      d = date_from_serial(int_part)
+      total_seconds = ((serial - int_part) * 86400).round
+      { year: d.year, month: d.month, day: d.day,
+        hour: total_seconds / 3600,
+        minute: (total_seconds % 3600) / 60,
+        second: total_seconds % 60 }
+    end
+
     # The time_to_serial methond converts a Time object its Excel serialized form.
     # @param [Time] time the time to be serialized
     # @return [Numeric]

--- a/test/workbook/worksheet/auto_filter/tc_auto_filter.rb
+++ b/test/workbook/worksheet/auto_filter/tc_auto_filter.rb
@@ -42,4 +42,22 @@ class TestAutoFilter < Minitest::Test
 
     assert @auto_filter.worksheet.rows.last.hidden
   end
+
+  def test_add_column_with_date_group_items_xml
+    ws = Axlsx::Package.new.workbook.add_worksheet
+    ws.add_row ['Date']
+    ws.add_row [Date.new(2026, 5, 3)]
+    ws.add_row [Date.new(2026, 6, 3)]
+    ws.auto_filter.range = 'A1:A3'
+    ws.auto_filter.add_column(0, :filters, date_group_items: [
+      { date_time_grouping: :month, year: 2026, month: 5 },
+      { date_time_grouping: :day,   year: 2026, month: 6, day: 3 }
+    ])
+    doc = Nokogiri::XML(ws.auto_filter.to_xml_string)
+
+    assert_equal(1, doc.xpath("//filterColumn[@colId='0']").size)
+    assert_equal(2, doc.xpath('//dateGroupItem').size)
+    assert_equal(1, doc.xpath("//dateGroupItem[@dateTimeGrouping='month']").size)
+    assert_equal(1, doc.xpath("//dateGroupItem[@dateTimeGrouping='day']").size)
+  end
 end

--- a/test/workbook/worksheet/auto_filter/tc_auto_filter.rb
+++ b/test/workbook/worksheet/auto_filter/tc_auto_filter.rb
@@ -43,6 +43,25 @@ class TestAutoFilter < Minitest::Test
     assert @auto_filter.worksheet.rows.last.hidden
   end
 
+  def test_apply_with_date_group_items
+    ws = Axlsx::Package.new.workbook.add_worksheet
+    ws.add_row ['Date']
+    ws.add_row [Date.new(2026, 5, 3)]
+    ws.add_row [Date.new(2026, 6, 3)]
+    ws.add_row [Date.new(2026, 6, 4)]
+
+    ws.auto_filter.range = 'A1:A4'
+    ws.auto_filter.add_column(0, :filters, date_group_items: [
+      { date_time_grouping: :month, year: 2026, month: 5 },
+      { date_time_grouping: :day,   year: 2026, month: 6, day: 3 }
+    ])
+    ws.auto_filter.apply
+
+    refute ws.rows[1].hidden
+    refute ws.rows[2].hidden
+    assert ws.rows[3].hidden
+  end
+
   def test_add_column_with_date_group_items_xml
     ws = Axlsx::Package.new.workbook.add_worksheet
     ws.add_row ['Date']

--- a/test/workbook/worksheet/auto_filter/tc_auto_filter.rb
+++ b/test/workbook/worksheet/auto_filter/tc_auto_filter.rb
@@ -52,9 +52,9 @@ class TestAutoFilter < Minitest::Test
 
     ws.auto_filter.range = 'A1:A4'
     ws.auto_filter.add_column(0, :filters, date_group_items: [
-      { date_time_grouping: :month, year: 2026, month: 5 },
-      { date_time_grouping: :day,   year: 2026, month: 6, day: 3 }
-    ])
+                                { date_time_grouping: :month, year: 2026, month: 5 },
+                                { date_time_grouping: :day,   year: 2026, month: 6, day: 3 }
+                              ])
     ws.auto_filter.apply
 
     refute ws.rows[1].hidden
@@ -69,9 +69,9 @@ class TestAutoFilter < Minitest::Test
     ws.add_row [Date.new(2026, 6, 3)]
     ws.auto_filter.range = 'A1:A3'
     ws.auto_filter.add_column(0, :filters, date_group_items: [
-      { date_time_grouping: :month, year: 2026, month: 5 },
-      { date_time_grouping: :day,   year: 2026, month: 6, day: 3 }
-    ])
+                                { date_time_grouping: :month, year: 2026, month: 5 },
+                                { date_time_grouping: :day,   year: 2026, month: 6, day: 3 }
+                              ])
     doc = Nokogiri::XML(ws.auto_filter.to_xml_string)
 
     assert_equal(1, doc.xpath("//filterColumn[@colId='0']").size)

--- a/test/workbook/worksheet/auto_filter/tc_filters.rb
+++ b/test/workbook/worksheet/auto_filter/tc_filters.rb
@@ -103,6 +103,29 @@ class TestFilters < Minitest::Test
     Axlsx::Workbook.date1904 = false
   end
 
+  def test_normalize_cell_datetime_with_datetime
+    dt = DateTime.new(2026, 6, 3, 14, 30, 45)
+    cell = Object.new
+    cell.define_singleton_method(:value) { dt }
+    result = @filters.send(:normalize_cell_datetime, cell)
+
+    assert_equal({ year: 2026, month: 6, day: 3, hour: 14, minute: 30, second: 45 }, result)
+  end
+
+  def test_normalize_cell_datetime_with_numeric_serial_with_time
+    Axlsx::Workbook.date1904 = false
+    serial = 46176 + (12 * 3600 + 30 * 60).to_f / 86400  # 12:30:00
+    cell = Object.new
+    cell.define_singleton_method(:value) { serial }
+    result = @filters.send(:normalize_cell_datetime, cell)
+
+    assert_equal 12, result[:hour]
+    assert_equal 30, result[:minute]
+    assert_equal 0,  result[:second]
+  ensure
+    Axlsx::Workbook.date1904 = false
+  end
+
   def test_normalize_cell_datetime_with_nil_cell
     assert_nil @filters.send(:normalize_cell_datetime, nil)
   end

--- a/test/workbook/worksheet/auto_filter/tc_filters.rb
+++ b/test/workbook/worksheet/auto_filter/tc_filters.rb
@@ -114,7 +114,7 @@ class TestFilters < Minitest::Test
 
   def test_normalize_cell_datetime_with_numeric_serial_with_time
     Axlsx::Workbook.date1904 = false
-    serial = 46176 + (12 * 3600 + 30 * 60).to_f / 86400  # 12:30:00
+    serial = 46_176 + (((12 * 3600) + (30 * 60)).to_f / 86_400)  # 12:30:00
     cell = Object.new
     cell.define_singleton_method(:value) { serial }
     result = @filters.send(:normalize_cell_datetime, cell)
@@ -133,14 +133,15 @@ class TestFilters < Minitest::Test
   def test_normalize_cell_datetime_with_non_date_value
     cell = Object.new
     cell.define_singleton_method(:value) { 'hello' }
+
     assert_nil @filters.send(:normalize_cell_datetime, cell)
   end
 
   def test_date_group_items_to_xml_string_multiple
     filters = Axlsx::Filters.new(date_group_items: [
-      { date_time_grouping: :month, year: 2026, month: 5 },
-      { date_time_grouping: :day, year: 2026, month: 6, day: 3 }
-    ])
+                                   { date_time_grouping: :month, year: 2026, month: 5 },
+                                   { date_time_grouping: :day, year: 2026, month: 6, day: 3 }
+                                 ])
     doc = Nokogiri::XML(filters.to_xml_string)
 
     assert_equal(2, doc.xpath('//dateGroupItem').size)
@@ -170,8 +171,8 @@ class TestFilters < Minitest::Test
 
   def test_apply_with_date_group_items_matching
     filters = Axlsx::Filters.new(date_group_items: [
-      { date_time_grouping: :month, year: 2026, month: 5 }
-    ])
+                                   { date_time_grouping: :month, year: 2026, month: 5 }
+                                 ])
     cell = Object.new
     cell.define_singleton_method(:value) { Date.new(2026, 5, 3) }
 
@@ -180,8 +181,8 @@ class TestFilters < Minitest::Test
 
   def test_apply_with_date_group_items_not_matching
     filters = Axlsx::Filters.new(date_group_items: [
-      { date_time_grouping: :month, year: 2026, month: 5 }
-    ])
+                                   { date_time_grouping: :month, year: 2026, month: 5 }
+                                 ])
     cell = Object.new
     cell.define_singleton_method(:value) { Date.new(2026, 6, 3) }
 
@@ -190,13 +191,16 @@ class TestFilters < Minitest::Test
 
   def test_apply_with_date_group_items_or_logic
     filters = Axlsx::Filters.new(date_group_items: [
-      { date_time_grouping: :month, year: 2026, month: 5 },
-      { date_time_grouping: :day,   year: 2026, month: 6, day: 3 }
-    ])
+                                   { date_time_grouping: :month, year: 2026, month: 5 },
+                                   { date_time_grouping: :day, year: 2026, month: 6, day: 3 }
+                                 ])
 
-    may3 = Object.new; may3.define_singleton_method(:value) { Date.new(2026, 5, 3) }
-    jun3 = Object.new; jun3.define_singleton_method(:value) { Date.new(2026, 6, 3) }
-    jun4 = Object.new; jun4.define_singleton_method(:value) { Date.new(2026, 6, 4) }
+    may3 = Object.new
+    may3.define_singleton_method(:value) { Date.new(2026, 5, 3) }
+    jun3 = Object.new
+    jun3.define_singleton_method(:value) { Date.new(2026, 6, 3) }
+    jun4 = Object.new
+    jun4.define_singleton_method(:value) { Date.new(2026, 6, 4) }
 
     assert_false filters.apply(may3)
     assert_false filters.apply(jun3)

--- a/test/workbook/worksheet/auto_filter/tc_filters.rb
+++ b/test/workbook/worksheet/auto_filter/tc_filters.rb
@@ -57,4 +57,29 @@ class TestFilters < Minitest::Test
 
     assert_equal(1, doc.xpath('//filters[@blank=1]').size)
   end
+
+  def test_date_group_items_to_xml_string_month_granularity
+    filters = Axlsx::Filters.new(date_group_items: [{ date_time_grouping: :month, year: 2026, month: 5 }])
+    doc = Nokogiri::XML(filters.to_xml_string)
+
+    assert_equal(1, doc.xpath("//dateGroupItem[@dateTimeGrouping='month'][@year='2026'][@month='5']").size)
+    assert_equal(0, doc.xpath('//dateGroupItem[@day]').size)
+  end
+
+  def test_date_group_items_to_xml_string_day_granularity
+    filters = Axlsx::Filters.new(date_group_items: [{ date_time_grouping: :day, year: 2026, month: 6, day: 3 }])
+    doc = Nokogiri::XML(filters.to_xml_string)
+
+    assert_equal(1, doc.xpath("//dateGroupItem[@dateTimeGrouping='day'][@year='2026'][@month='6'][@day='3']").size)
+  end
+
+  def test_date_group_items_to_xml_string_multiple
+    filters = Axlsx::Filters.new(date_group_items: [
+      { date_time_grouping: :month, year: 2026, month: 5 },
+      { date_time_grouping: :day, year: 2026, month: 6, day: 3 }
+    ])
+    doc = Nokogiri::XML(filters.to_xml_string)
+
+    assert_equal(2, doc.xpath('//dateGroupItem').size)
+  end
 end

--- a/test/workbook/worksheet/auto_filter/tc_filters.rb
+++ b/test/workbook/worksheet/auto_filter/tc_filters.rb
@@ -144,4 +144,39 @@ class TestFilters < Minitest::Test
 
     assert_false dgi.matches?(nil)
   end
+
+  def test_apply_with_date_group_items_matching
+    filters = Axlsx::Filters.new(date_group_items: [
+      { date_time_grouping: :month, year: 2026, month: 5 }
+    ])
+    cell = Object.new
+    cell.define_singleton_method(:value) { Date.new(2026, 5, 3) }
+
+    assert_false filters.apply(cell)
+  end
+
+  def test_apply_with_date_group_items_not_matching
+    filters = Axlsx::Filters.new(date_group_items: [
+      { date_time_grouping: :month, year: 2026, month: 5 }
+    ])
+    cell = Object.new
+    cell.define_singleton_method(:value) { Date.new(2026, 6, 3) }
+
+    assert filters.apply(cell)
+  end
+
+  def test_apply_with_date_group_items_or_logic
+    filters = Axlsx::Filters.new(date_group_items: [
+      { date_time_grouping: :month, year: 2026, month: 5 },
+      { date_time_grouping: :day,   year: 2026, month: 6, day: 3 }
+    ])
+
+    may3 = Object.new; may3.define_singleton_method(:value) { Date.new(2026, 5, 3) }
+    jun3 = Object.new; jun3.define_singleton_method(:value) { Date.new(2026, 6, 3) }
+    jun4 = Object.new; jun4.define_singleton_method(:value) { Date.new(2026, 6, 4) }
+
+    assert_false filters.apply(may3)
+    assert_false filters.apply(jun3)
+    assert       filters.apply(jun4)
+  end
 end

--- a/test/workbook/worksheet/auto_filter/tc_filters.rb
+++ b/test/workbook/worksheet/auto_filter/tc_filters.rb
@@ -73,6 +73,46 @@ class TestFilters < Minitest::Test
     assert_equal(1, doc.xpath("//dateGroupItem[@dateTimeGrouping='day'][@year='2026'][@month='6'][@day='3']").size)
   end
 
+  def test_normalize_cell_datetime_with_date
+    cell = Object.new
+    cell.define_singleton_method(:value) { Date.new(2026, 5, 3) }
+    result = @filters.send(:normalize_cell_datetime, cell)
+
+    assert_equal({ year: 2026, month: 5, day: 3, hour: 0, minute: 0, second: 0 }, result)
+  end
+
+  def test_normalize_cell_datetime_with_time
+    t = Time.new(2026, 6, 3, 14, 30, 0)
+    cell = Object.new
+    cell.define_singleton_method(:value) { t }
+    result = @filters.send(:normalize_cell_datetime, cell)
+
+    assert_equal({ year: 2026, month: 6, day: 3, hour: 14, minute: 30, second: 0 }, result)
+  end
+
+  def test_normalize_cell_datetime_with_numeric_serial
+    Axlsx::Workbook.date1904 = false
+    cell = Object.new
+    cell.define_singleton_method(:value) { 46_145 }
+    result = @filters.send(:normalize_cell_datetime, cell)
+
+    assert_equal 2026, result[:year]
+    assert_equal 5,    result[:month]
+    assert_equal 3,    result[:day]
+  ensure
+    Axlsx::Workbook.date1904 = false
+  end
+
+  def test_normalize_cell_datetime_with_nil_cell
+    assert_nil @filters.send(:normalize_cell_datetime, nil)
+  end
+
+  def test_normalize_cell_datetime_with_non_date_value
+    cell = Object.new
+    cell.define_singleton_method(:value) { 'hello' }
+    assert_nil @filters.send(:normalize_cell_datetime, cell)
+  end
+
   def test_date_group_items_to_xml_string_multiple
     filters = Axlsx::Filters.new(date_group_items: [
       { date_time_grouping: :month, year: 2026, month: 5 },

--- a/test/workbook/worksheet/auto_filter/tc_filters.rb
+++ b/test/workbook/worksheet/auto_filter/tc_filters.rb
@@ -112,6 +112,15 @@ class TestFilters < Minitest::Test
     assert_equal({ year: 2026, month: 6, day: 3, hour: 14, minute: 30, second: 45 }, result)
   end
 
+  def test_normalize_cell_datetime_with_datetime_non_utc_offset
+    dt = DateTime.new(2026, 6, 3, 14, 30, 45, '+09:00')
+    cell = Object.new
+    cell.define_singleton_method(:value) { dt }
+    result = @filters.send(:normalize_cell_datetime, cell)
+
+    assert_equal({ year: 2026, month: 6, day: 3, hour: 14, minute: 30, second: 45 }, result)
+  end
+
   def test_normalize_cell_datetime_with_numeric_serial_with_time
     Axlsx::Workbook.date1904 = false
     serial = 46_176 + (((12 * 3600) + (30 * 60)).to_f / 86_400)  # 12:30:00
@@ -175,6 +184,20 @@ class TestFilters < Minitest::Test
                                  ])
     cell = Object.new
     cell.define_singleton_method(:value) { Date.new(2026, 5, 3) }
+
+    assert_false filters.apply(cell)
+  end
+
+  def test_apply_with_date_group_items_matching_datetime_non_utc_offset
+    # DateTimeConverter.date_to_serial does not compensate for non-UTC offsets, so this
+    # value would serialize to 2026-06-02 17:00 if written to a cell. Filters#apply must
+    # still match it against the day the user actually supplied (2026-06-03), not the
+    # UTC-shifted serialized value.
+    filters = Axlsx::Filters.new(date_group_items: [
+                                   { date_time_grouping: :day, year: 2026, month: 6, day: 3 }
+                                 ])
+    cell = Object.new
+    cell.define_singleton_method(:value) { DateTime.new(2026, 6, 3, 2, 0, 0, '+09:00') }
 
     assert_false filters.apply(cell)
   end

--- a/test/workbook/worksheet/auto_filter/tc_filters.rb
+++ b/test/workbook/worksheet/auto_filter/tc_filters.rb
@@ -122,4 +122,26 @@ class TestFilters < Minitest::Test
 
     assert_equal(2, doc.xpath('//dateGroupItem').size)
   end
+
+  def test_date_group_item_matches_month_granularity
+    dgi = Axlsx::Filters::DateGroupItem.new(date_time_grouping: :month, year: 2026, month: 5)
+
+    assert dgi.matches?({ year: 2026, month: 5, day:  3, hour: 0, minute: 0, second: 0 })
+    assert_false dgi.matches?({ year: 2026, month: 6, day:  3, hour: 0, minute: 0, second: 0 })
+    assert_false dgi.matches?({ year: 2025, month: 5, day:  3, hour: 0, minute: 0, second: 0 })
+  end
+
+  def test_date_group_item_matches_day_granularity
+    dgi = Axlsx::Filters::DateGroupItem.new(date_time_grouping: :day, year: 2026, month: 6, day: 3)
+
+    assert dgi.matches?({ year: 2026, month: 6, day: 3, hour: 0, minute: 0, second: 0 })
+    assert_false dgi.matches?({ year: 2026, month: 6, day: 4, hour: 0, minute: 0, second: 0 })
+    assert_false dgi.matches?({ year: 2026, month: 5, day: 3, hour: 0, minute: 0, second: 0 })
+  end
+
+  def test_date_group_item_matches_returns_false_for_nil
+    dgi = Axlsx::Filters::DateGroupItem.new(date_time_grouping: :month, year: 2026, month: 5)
+
+    assert_false dgi.matches?(nil)
+  end
 end

--- a/test/workbook/worksheet/tc_date_time_converter.rb
+++ b/test/workbook/worksheet/tc_date_time_converter.rb
@@ -85,6 +85,30 @@ class TestDateTimeConverter < Minitest::Test
     Axlsx::Workbook.date1904 = false
   end
 
+  def test_datetime_components_from_serial_date_only
+    Axlsx::Workbook.date1904 = false
+    result = Axlsx::DateTimeConverter.datetime_components_from_serial(46_145)
+
+    assert_equal({ year: 2026, month: 5, day: 3, hour: 0, minute: 0, second: 0 }, result)
+  ensure
+    Axlsx::Workbook.date1904 = false
+  end
+
+  def test_datetime_components_from_serial_with_time
+    Axlsx::Workbook.date1904 = false
+    serial = 46_176 + (12 * 3600 + 30 * 60).to_f / 86400  # 2026-06-03 12:30:00
+    result = Axlsx::DateTimeConverter.datetime_components_from_serial(serial)
+
+    assert_equal 2026, result[:year]
+    assert_equal 6,    result[:month]
+    assert_equal 3,    result[:day]
+    assert_equal 12,   result[:hour]
+    assert_equal 30,   result[:minute]
+    assert_equal 0,    result[:second]
+  ensure
+    Axlsx::Workbook.date1904 = false
+  end
+
   def test_timezone
     utc = Time.utc 2012 # January 1st, 2012 at 0:00 UTC
     local = Time.parse "2012-01-01 09:00:00 +0900"

--- a/test/workbook/worksheet/tc_date_time_converter.rb
+++ b/test/workbook/worksheet/tc_date_time_converter.rb
@@ -69,8 +69,9 @@ class TestDateTimeConverter < Minitest::Test
 
   def test_date_from_serial_1900
     Axlsx::Workbook.date1904 = false
+
     {
-      2.0      => Date.new(1900, 1, 1),
+      2.0 => Date.new(1900, 1, 1),
       38_749.0 => Date.new(2006, 2, 1),
       46_145.0 => Date.new(2026, 5, 3)
     }.each do |serial, expected|
@@ -80,6 +81,7 @@ class TestDateTimeConverter < Minitest::Test
 
   def test_date_from_serial_1904
     Axlsx::Workbook.date1904 = true
+
     assert_equal Date.new(1904, 1, 1), Axlsx::DateTimeConverter.date_from_serial(0)
   ensure
     Axlsx::Workbook.date1904 = false
@@ -96,7 +98,7 @@ class TestDateTimeConverter < Minitest::Test
 
   def test_datetime_components_from_serial_with_time
     Axlsx::Workbook.date1904 = false
-    serial = 46_176 + (12 * 3600 + 30 * 60).to_f / 86400  # 2026-06-03 12:30:00
+    serial = 46_176 + (((12 * 3600) + (30 * 60)).to_f / 86_400)  # 2026-06-03 12:30:00
     result = Axlsx::DateTimeConverter.datetime_components_from_serial(serial)
 
     assert_equal 2026, result[:year]

--- a/test/workbook/worksheet/tc_date_time_converter.rb
+++ b/test/workbook/worksheet/tc_date_time_converter.rb
@@ -67,6 +67,24 @@ class TestDateTimeConverter < Minitest::Test
     end
   end
 
+  def test_date_from_serial_1900
+    Axlsx::Workbook.date1904 = false
+    {
+      2.0      => Date.new(1900, 1, 1),
+      38_749.0 => Date.new(2006, 2, 1),
+      46_145.0 => Date.new(2026, 5, 3)
+    }.each do |serial, expected|
+      assert_equal expected, Axlsx::DateTimeConverter.date_from_serial(serial)
+    end
+  end
+
+  def test_date_from_serial_1904
+    Axlsx::Workbook.date1904 = true
+    assert_equal Date.new(1904, 1, 1), Axlsx::DateTimeConverter.date_from_serial(0)
+  ensure
+    Axlsx::Workbook.date1904 = false
+  end
+
   def test_timezone
     utc = Time.utc 2012 # January 1st, 2012 at 0:00 UTC
     local = Time.parse "2012-01-01 09:00:00 +0900"


### PR DESCRIPTION
### Description
`Filters#apply` did not apply `date_group_items` when filtering cell values. This limitation was also documented in `date_group_items=`, which documented that the option could be specified but would not affect workbook values.

This PR adds filtering based on dateGroupItem so that `Filters#apply` correctly determines row visibility for date filters.

### Changes
`lib/axlsx/workbook/worksheet/auto_filter/filters.rb`

- Add date_group_items matching logic to `Filters#apply`
- Add a private `normalize_cell_datetime` helper for comparing `Date`, `Time`, `DateTime`, and Excel serial numeric values uniformly
- Add `DateGroupItem#matches?` to compare normalized datetime components according to `dateTimeGrouping`
- Remove the outdated TODO and `@note`

`lib/axlsx/workbook/worksheet/date_time_converter.rb`

- Add `DateTimeConverter.date_from_serial`
- Add `DateTimeConverter.datetime_components_from_serial`

### Behavior Notes
- `dateGroupItem` entries within one `filters` element are treated as OR conditions (a row is visible if it matches any entry).
- `matches?` compares fields cumulatively from the coarsest level down to the selected `dateTimeGrouping` (year → month → day → hour → minute → second). For `dateTimeGrouping="month"`, year and month must match; finer fields are ignored.
- `normalize_cell_datetime` treats a `Numeric` cell value as an Excel serial date. This is compatible with axlsx's serialized representation of date/time values, but it also means a plain numeric column with a `dateGroupItem` filter would be interpreted as dates. In practice, `dateGroupItem` filters are expected to be used on date columns, so this matches the intended usage. This is noted in case the maintainers prefer a stricter guard.

### Specification Reference
The `filters` element is defined in ECMA-376 Part 1 §18.3.2.8, with `dateGroupItem` defined in §18.3.2.4 and `ST_DateTimeGrouping` in §18.18.22.

```
<filters>
  <dateGroupItem year="2006" month="1" day="2" dateTimeGrouping="day"/>
  <dateGroupItem year="2005" month="1" day="2" dateTimeGrouping="day"/>
</filters>
```

The spec includes an example where multiple `dateGroupItem` elements are used within one `filters` element, which is consistent with treating them as OR conditions. The example for `dateTimeGrouping="day"` includes year, month, and day fields, which is consistent with comparing fields cumulatively up to the selected grouping level.


### How to Verify

Run:

```rb
require 'axlsx'
require 'date'

package = Axlsx::Package.new
wb = package.workbook

wb.add_worksheet(name: "DateFilterTest") do |ws|
  ws.add_row ["Date", "Value"]
  ws.add_row [Date.new(2024, 1, 15), 100]
  ws.add_row [Date.new(2024, 6, 20), 200]
  ws.add_row [Date.new(2025, 3, 10), 300]

  ws.auto_filter = "A1:B4"
  ws.auto_filter.add_column(0, :filters,
    date_group_items: [{ date_time_grouping: 'year', year: '2024' }]
  )
  ws.auto_filter.apply

  p ws.rows.map(&:hidden)
  # Expected: [nil, false, false, true]
end
```

### Testing
Added tests for:

- `Filters#apply` with date_group_items
- year, month, and day grouping
- OR logic across multiple dateGroupItem entries
- `DateGroupItem#matches?`
- datetime normalization for Date, Time, DateTime, Numeric serial values, nil, and non-date values
- Excel serial conversion helpers
- dateGroupItem XML serialization regression coverage

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I added an entry to the [changelog](../blob/master/CHANGELOG.md).