### PR TITLE
 Add secure_formulas Functionality to Explicitly Prevent Cells Being Re-evaluated as Formulas After File Generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 CHANGELOG
 ---------
 - **Unreleased**
+  - Add `secure_formulas` option to apply OOXML `quotePrefix` to cells with formula-like prefixes (`=`, `+`, `-`, `@`), preventing re-evaluation on user interaction. Solves [Issue #529](https://github.com/caxlsx/caxlsx/issues/529)
 
 - **June.09.26**: 4.5.0
   - [PR #527](https://github.com/caxlsx/caxlsx/pull/527) Fix PivotTable countNums subtotal label never applied. Solves [Issue #526](https://github.com/caxlsx/caxlsx/issues/526)

--- a/README.md
+++ b/README.md
@@ -147,6 +147,19 @@ To allow formulas globally by default (which was the behavior in axlsx 3.x and p
 Axlsx.escape_formulas = false
 ```
 
+### quotePrefix protection
+
+Excel can also re-evaluate string cells as formulas when a user double-clicks to edit them, if the value starts with `+`, `-`, or `@`. The `secure_formulas` option applies Excel's `quotePrefix` style attribute to these cells, which prevents re-evaluation without altering the displayed value:
+
+```ruby
+p = Axlsx::Package.new
+p.workbook.add_worksheet(secure_formulas: true) do |sheet|
+  sheet.add_row ["+cmd|'/C calc'!A0", "-SUM(A1)", "@SUM(A1)"]
+end
+```
+
+Bullet points (`"- text"`), negative numbers (`"-1.5"`), and non-string types are automatically excluded. You may set `secure_formulas` at the worksheet, row, or cell level.
+
 ## Known Software Interoperability Issues
 
 As axslx implements the Office Open XML (ECMA-376 spec) much of the

--- a/examples/README.md
+++ b/examples/README.md
@@ -72,6 +72,7 @@ Customizations:
 * [Basic formula](basic_formula_example.md)
 * [Cached formula](cached_formula_example.md)
 * [Escape formula](escape_formula_example.md)
+* [Secure formula](secure_formula_example.md)
 * [Defined name](defined_name_example.md)
 
 ### Media

--- a/examples/secure_formula_example.md
+++ b/examples/secure_formula_example.md
@@ -1,0 +1,44 @@
+## Description
+
+You may use `secure_formulas` to apply Excel's `quotePrefix` style attribute to cells whose string values start with formula-like prefixes (`=`, `+`, `-`, `@`). This prevents Excel from re-evaluating the cell as a formula when a user double-clicks to edit it, without altering the displayed value.
+
+This is a stronger protection than `escape_formulas`, which only prepends an apostrophe at serialization time. With `secure_formulas`, the cell's style in `styles.xml` includes `quotePrefix="1"`, telling Excel to never interpret the content as a formula.
+
+The following are possible:
+
+| Scope     | Example                                                                     | Notes                                                                                      |
+|-----------|-----------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| Global    | `Axlsx.secure_formulas = true`                                              | Affects workbooks created *after* setting.                                                 |
+| Workbook  | `workbook.secure_formulas = true`                                           | Affects child worksheets added *after* setting. Does not affect existing child worksheets. |
+| Worksheet | `workbook.add_worksheet(name: 'Name', secure_formulas: true)`               |                                                                                            |
+| Worksheet | `worksheet.secure_formulas = true`                                          | Affects child rows/cells added *after* setting. Does not affect existing child rows/cells. |
+| Row       | `worksheet.add_row(['+cmd', '-SUM(A1)'], secure_formulas: true)`            | Applies to all cells in the row.                                                           |
+| Cell      | `cell.secure_formulas = true`                                               |                                                                                            |
+
+Non-string types (numbers, dates, booleans) are never affected.
+
+## Code
+
+```ruby
+require 'axlsx'
+
+p = Axlsx::Package.new
+wb = p.workbook
+
+wb.add_worksheet(name: 'Secure Formulas', secure_formulas: true) do |sheet|
+  # These cells get quotePrefix applied (formula-like prefixes)
+  sheet.add_row ["+cmd|'/C calc'!A0", "-SUM(A1)", "@SUM(A1)", "=1+1"]
+
+  # Non-string and non-prefixed cells are unaffected
+  sheet.add_row [42, "safe text", 3.14]
+
+  # Per-cell override
+  sheet.add_row ["=HYPERLINK(...)"], secure_formulas: false
+end
+
+p.serialize 'secure_formula_example.xlsx'
+```
+
+## Output
+
+Cells with formula-like prefixes will display their literal text and cannot be re-evaluated as formulas, even when edited by the user.

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -231,6 +231,24 @@ module Axlsx
     @escape_formulas = value
   end
 
+  # Whether to apply maximum formula injection protection. When true, this is a superset of
+  # escape_formulas — it prevents =‑prefixed values from being serialized as formula elements
+  # AND applies quotePrefix to all cells starting with dangerous prefixes (=, +, -, @).
+  # quotePrefix tells Excel to never re-evaluate the cell content as a formula, even on
+  # user interaction (click-in and press Enter).
+  # See https://owasp.org/www-community/attacks/CSV_Injection for details.
+  # @return [Boolean]
+  def self.secure_formulas
+    !defined?(@secure_formulas) || @secure_formulas.nil? ? false : @secure_formulas
+  end
+
+  # Sets whether to apply quotePrefix protection to dangerous formula prefixes.
+  # @param [Boolean] value The value to set.
+  def self.secure_formulas=(value)
+    Axlsx.validate_boolean(value)
+    @secure_formulas = value
+  end
+
   # Whether to validate the sheet name length.
   # @return [Boolean]
   def self.validate_sheet_name_length

--- a/lib/axlsx/stylesheet/styles.rb
+++ b/lib/axlsx/stylesheet/styles.rb
@@ -287,6 +287,19 @@ module Axlsx
       end
     end
 
+    # Returns the index of a cellXfs entry that is identical to the one at base_style_index
+    # but with quotePrefix set to true. Caches derived styles to avoid duplication.
+    # @param [Integer] base_style_index The index of the base style in cellXfs
+    # @return [Integer] The index of the quotePrefix-enabled style
+    def quote_prefix_style_for(base_style_index)
+      @quote_prefix_cache ||= {}
+      @quote_prefix_cache[base_style_index] ||= begin
+        new_xf = cellXfs[base_style_index].dup
+        new_xf.quotePrefix = true
+        cellXfs << new_xf
+      end
+    end
+
     # parses add_style options for protection styles
     # noop if options hash does not include :hide or :locked key
 

--- a/lib/axlsx/util/constants.rb
+++ b/lib/axlsx/util/constants.rb
@@ -435,5 +435,10 @@ module Axlsx
   # Trailing character that indicates an array formula.
   ARRAY_FORMULA_SUFFIX = '}'
 
+  # Characters that can trigger formula evaluation in Excel upon user interaction,
+  # even when stored as plain strings. Used by secure_formulas to apply quotePrefix protection.
+  # See: https://owasp.org/www-community/attacks/CSV_Injection
+  SECONDARY_FORMULA_PREFIXES = ['+', '-', '@'].freeze
+
   BOOLEAN_VALUES = [true, false].freeze
 end

--- a/lib/axlsx/workbook/workbook.rb
+++ b/lib/axlsx/workbook/workbook.rb
@@ -254,6 +254,7 @@ module Axlsx
       @font_scale_divisor = FONT_SCALE_DIVISOR
 
       self.escape_formulas = options[:escape_formulas].nil? ? Axlsx.escape_formulas : options[:escape_formulas]
+      self.secure_formulas = options[:secure_formulas].nil? ? Axlsx.secure_formulas : options[:secure_formulas]
       self.date1904 = !options[:date1904].nil? && options[:date1904]
       yield self if block_given?
     end
@@ -294,6 +295,17 @@ module Axlsx
     def escape_formulas=(value)
       Axlsx.validate_boolean(value)
       @escape_formulas = value
+    end
+
+    # Whether to apply quotePrefix protection to cells starting with dangerous formula prefixes.
+    # @return [Boolean]
+    attr_reader :secure_formulas
+
+    # Sets whether to apply quotePrefix protection to dangerous formula prefixes.
+    # @param [Boolean] value The value to set.
+    def secure_formulas=(value)
+      Axlsx.validate_boolean(value)
+      @secure_formulas = value
     end
 
     # Indicates if the workbook should use autowidths or not.

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -46,6 +46,8 @@ module Axlsx
       self.formula_value = val unless val.nil?
       val = options.delete(:escape_formulas)
       self.escape_formulas = val unless val.nil?
+      val = options.delete(:secure_formulas)
+      self.secure_formulas = val unless val.nil?
 
       parse_options(options) unless options.empty?
 
@@ -82,9 +84,20 @@ module Axlsx
       defined?(@style) ? @style : 0
     end
 
+    # Returns the effective style index for serialization, accounting for quotePrefix
+    # when secure_formulas is enabled for cells with dangerous prefixes.
+    # @return [Integer]
+    def effective_style_index
+      if needs_quote_prefix?
+        styles.quote_prefix_style_for(style)
+      else
+        style
+      end
+    end
+
     # Internal
     def style_str
-      defined?(@style) ? @style.to_s : '0'
+      effective_style_index.to_s
     end
 
     attr_accessor :raw_style
@@ -153,6 +166,55 @@ module Axlsx
       Axlsx.validate_boolean(value)
       @escape_formulas = value
     end
+
+    # Whether to apply quotePrefix protection to cells starting with dangerous formula prefixes.
+    # Falls back to the worksheet setting if not explicitly set on the cell.
+    # @return [Boolean]
+    def secure_formulas
+      defined?(@secure_formulas) ? @secure_formulas : row.worksheet.secure_formulas
+    end
+
+    # Sets whether to apply quotePrefix protection to dangerous formula prefixes.
+    # @param [Boolean] value The value to set.
+    def secure_formulas=(value)
+      Axlsx.validate_boolean(value)
+      @secure_formulas = value
+    end
+
+    # Whether this cell needs quotePrefix protection applied to its style.
+    # Returns true when secure_formulas is enabled and the cell value starts with
+    # a dangerous prefix (=, +, -, @) that Excel could re-evaluate as a formula.
+    # Also checks for leading whitespace before a dangerous prefix.
+    # Excludes bullet points ("- text") and plain negative numbers from protection.
+    # @return [Boolean]
+    def needs_quote_prefix?
+      return false unless secure_formulas
+      return false unless type == :string || type == :text
+      return false if @value.nil? || @value.empty?
+
+      stripped = @value.lstrip
+      return false if safe_negative?(stripped)
+
+      stripped.start_with?(FORMULA_PREFIX, *SECONDARY_FORMULA_PREFIXES)
+    end
+
+    private
+
+    # A string starting with "-" is safe if it's a bullet point ("- " prefix)
+    # or a plain negative number. Numeric values are already excluded by the
+    # type check above (axlsx casts them to :integer/:float), but string
+    # representations like "-1.5" entered as text are also safe.
+    def safe_negative?(string)
+      return false unless string.start_with?('-')
+
+      # Bullet point: "- " (dash followed by space)
+      return true if string.start_with?('- ')
+
+      # Plain negative number stored as string
+      Float(string, exception: false) != nil
+    end
+
+    public
 
     # The value of this cell.
     # @return [String, Integer, Float, Time, Boolean] casted value based on cell's type attribute.
@@ -411,13 +473,13 @@ module Axlsx
     end
 
     def is_formula? # rubocop:disable Naming/PredicatePrefix
-      return false if escape_formulas
+      return false if escape_formulas || secure_formulas
 
       type == :string && @value.to_s.start_with?(FORMULA_PREFIX)
     end
 
     def is_array_formula? # rubocop:disable Naming/PredicatePrefix
-      return false if escape_formulas
+      return false if escape_formulas || secure_formulas
 
       type == :string &&
         @value.to_s.start_with?(ARRAY_FORMULA_PREFIX) &&

--- a/lib/axlsx/workbook/worksheet/row.rb
+++ b/lib/axlsx/workbook/worksheet/row.rb
@@ -126,6 +126,15 @@ module Axlsx
       end
     end
 
+    # Sets secure_formulas for every cell in this row. This determines whether to apply
+    # quotePrefix protection to cells starting with dangerous formula prefixes.
+    # @param [Array, Boolean] value The value to set.
+    def secure_formulas=(value)
+      each_with_index do |cell, index|
+        cell.secure_formulas = value.is_a?(Array) ? value[index] : value
+      end
+    end
+
     # @see height
     def height=(v)
       unless v.nil?
@@ -158,14 +167,16 @@ module Axlsx
     # @option options [Array, Symbol] types
     # @option options [Array, Integer] style
     # @option options [Array, Boolean] escape_formulas
+    # @option options [Array, Boolean] secure_formulas
     def array_to_cells(values, options = {})
       DataTypeValidator.validate :array_to_cells, Array, values
-      types, style, formula_values, escape_formulas, offset = options.delete(:types), options.delete(:style), options.delete(:formula_values), options.delete(:escape_formulas), options.delete(:offset)
+      types, style, formula_values, escape_formulas, secure_formulas, offset = options.delete(:types), options.delete(:style), options.delete(:formula_values), options.delete(:escape_formulas), options.delete(:secure_formulas), options.delete(:offset)
       offset.to_i.times { |index| self[index] = Cell.new(self) } if offset
       values.each_with_index do |value, index|
         options[:style] = (style.is_a?(Array) ? style[index] : style) || worksheet.column_info[index]&.style
         options[:type] = types.is_a?(Array) ? types[index] : types if types
         options[:escape_formulas] = escape_formulas.is_a?(Array) ? escape_formulas[index] : escape_formulas unless escape_formulas.nil?
+        options[:secure_formulas] = secure_formulas.is_a?(Array) ? secure_formulas[index] : secure_formulas unless secure_formulas.nil?
         options[:formula_value] = formula_values[index] if formula_values.is_a?(Array)
 
         self[index + offset.to_i] = Cell.new(self, value, options)

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -22,6 +22,7 @@ module Axlsx
       initialize_page_options(options)
       parse_options options
       self.escape_formulas = wb.escape_formulas unless defined? @escape_formulas
+      self.secure_formulas = wb.secure_formulas unless defined? @secure_formulas
       @workbook.worksheets << self
       @sheet_id = index + 1
       yield self if block_given?
@@ -58,6 +59,18 @@ module Axlsx
     def escape_formulas=(value)
       Axlsx.validate_boolean(value)
       @escape_formulas = value
+    end
+
+    # Whether to apply quotePrefix protection to cells starting with dangerous formula prefixes.
+    # @return [Boolean]
+    attr_reader :secure_formulas
+
+    # Sets whether to apply quotePrefix protection to dangerous formula prefixes.
+    # @param [Boolean] value The value to set.
+    # @return [Boolean]
+    def secure_formulas=(value)
+      Axlsx.validate_boolean(value)
+      @secure_formulas = value
     end
 
     # Specifies the visible state of this sheet. Allowed states are

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -576,4 +576,166 @@ class TestCell < Minitest::Test
 
     assert_empty(errors)
   end
+
+  private
+
+  def add_secure_row(values, secure_formulas: true, **row_opts)
+    p = Axlsx::Package.new
+    ws = p.workbook.add_worksheet(secure_formulas: secure_formulas) do |sheet|
+      sheet.add_row values, **row_opts
+    end
+    [p, ws, ws.rows.first.cells]
+  end
+
+  public
+
+  def test_secure_formulas_applies_quote_prefix
+    pkg, _ws, cells = add_secure_row(["+cmd|'/C powershell'!A0", "-SUM(A1)", "@SUM(A1)", "normal text"])
+
+    assert_predicate cells[0], :needs_quote_prefix?
+    assert_predicate cells[1], :needs_quote_prefix?
+    assert_predicate cells[2], :needs_quote_prefix?
+    refute_predicate cells[3], :needs_quote_prefix?
+
+    assert_operator cells[0].effective_style_index, :>, 0
+    assert_equal 0, cells[3].effective_style_index
+
+    xf = pkg.workbook.styles.cellXfs[cells[0].effective_style_index]
+
+    assert xf.quotePrefix
+  end
+
+  def test_secure_formulas_does_not_affect_non_string_types
+    _p, _ws, cells = add_secure_row([-1, -2.5, "+44 7700 900000"])
+
+    refute_predicate cells[0], :needs_quote_prefix?
+    refute_predicate cells[1], :needs_quote_prefix?
+    assert_predicate cells[2], :needs_quote_prefix?
+  end
+
+  def test_secure_formulas_default_is_false
+    _p, _ws, cells = add_secure_row(["+cmd|'/C powershell'!A0"], secure_formulas: false)
+
+    refute_predicate cells.first, :needs_quote_prefix?
+  end
+
+  def test_secure_formulas_per_cell_override
+    p = Axlsx::Package.new
+    ws = p.workbook.add_worksheet(secure_formulas: true) do |sheet|
+      sheet.add_row ["+DDE attack", "+allowed"], secure_formulas: [true, false]
+    end
+    cells = ws.rows.first.cells
+
+    assert_predicate cells[0], :needs_quote_prefix?
+    refute_predicate cells[1], :needs_quote_prefix?
+  end
+
+  def test_secure_formulas_serializes_quote_prefix_in_styles
+    p, ws, _cells = add_secure_row(["+cmd|'/C powershell'!A0"])
+
+    doc = Nokogiri::XML(ws.to_xml_string)
+    doc.remove_namespaces!
+
+    cell_node = doc.xpath("//c").first
+    style_index = cell_node["s"].to_i
+
+    assert_operator style_index, :>, 0
+
+    styles_doc = Nokogiri::XML(p.workbook.styles.to_xml_string)
+    styles_doc.remove_namespaces!
+    xf_nodes = styles_doc.xpath("//cellXfs/xf")
+
+    assert_equal "1", xf_nodes[style_index]["quotePrefix"]
+  end
+
+  def test_secure_formulas_with_leading_whitespace
+    _p, _ws, cells = add_secure_row([" =IF(1=1,RUN(),0)", "  +cmd|'/C calc'!A0", "\t-SUM(A1)", " @SUM(A1)", " safe text"])
+
+    assert_predicate cells[0], :needs_quote_prefix?
+    assert_predicate cells[1], :needs_quote_prefix?
+    assert_predicate cells[2], :needs_quote_prefix?
+    assert_predicate cells[3], :needs_quote_prefix?
+    refute_predicate cells[4], :needs_quote_prefix?
+  end
+
+  # Data-driven tests for secure_formulas quote prefix behavior
+  SAFE_VALUES = {
+    "negative_numbers" => { values: ["-1", "-2.5", "-1.23e10", "-0.5", "-100", "-99.99", "-0", "-1000000"],
+                            types: Array.new(8, :string) },
+    "bullet_points" => { values: ["- VAT adjustment", "- Discount applied", "- Item one",
+                                  "- Not applicable", "- See attached document", "- "] },
+    "special_chars_in_middle" => { values: ["Name@email.com", "A+B", "2+2=4", "Item - description",
+                                            "C++", "Item = Value", "Hello world", "100"] },
+    "empty_and_nil" => { values: ["", nil] }
+  }.freeze
+
+  DANGEROUS_VALUES = {
+    "dash_prefixed" => ["-SUM(A1)", "-cmd|'/C calc'!A0", "-2+3+cmd|'/C calc'!A0",
+                        "-text", "--double", "-"],
+    "all_prefixes" => ["=cmd|/C calc!A0", "=SUM(A1:A10)", "=1+1", "=",
+                       "+cmd|'/C powershell'!A0", "+SUM(A1)", "++i", "+",
+                       "@SUM(A1)", "@@mention"]
+  }.freeze
+
+  SAFE_VALUES.each do |label, config|
+    define_method(:"test_secure_formulas_safe_#{label}") do
+      p = Axlsx::Package.new
+      ws = p.workbook.add_worksheet(secure_formulas: true) do |sheet|
+        sheet.add_row config[:values], **(config[:types] ? { types: config[:types] } : {})
+      end
+
+      ws.rows.first.cells.each do |cell|
+        refute_predicate cell, :needs_quote_prefix?,
+                         "#{cell.value.inspect} should be safe (#{label})"
+      end
+    end
+  end
+
+  DANGEROUS_VALUES.each do |label, values|
+    define_method(:"test_secure_formulas_dangerous_#{label}") do
+      p = Axlsx::Package.new
+      ws = p.workbook.add_worksheet(secure_formulas: true) do |sheet|
+        sheet.add_row values
+      end
+
+      ws.rows.first.cells.each do |cell|
+        assert_predicate cell, :needs_quote_prefix?,
+                         "#{cell.value.inspect} should be dangerous (#{label})"
+      end
+    end
+  end
+
+  def test_secure_formulas_serializes_no_quote_prefix_on_safe_values
+    _p, ws, _cells = add_secure_row(["-1", "- VAT adjustment", "Hello world", "Name@email.com"],
+                                    types: Array.new(4, :string))
+
+    doc = Nokogiri::XML(ws.to_xml_string)
+    doc.remove_namespaces!
+
+    doc.xpath("//c").each do |cell_node|
+      style_index = (cell_node["s"] || "0").to_i
+
+      assert_equal 0, style_index,
+                   "Cell #{cell_node.at_xpath('.//t')&.text.inspect} should use base style (index 0), got #{style_index}"
+    end
+  end
+
+  def test_secure_formulas_serializes_quote_prefix_on_dangerous_values
+    p, ws, _cells = add_secure_row(["=SUM(A1)", "+cmd|'/C calc'!A0", "-SUM(A1)", "@SUM(A1)"])
+
+    doc = Nokogiri::XML(ws.to_xml_string)
+    doc.remove_namespaces!
+
+    styles_doc = Nokogiri::XML(p.workbook.styles.to_xml_string)
+    styles_doc.remove_namespaces!
+    xf_nodes = styles_doc.xpath("//cellXfs/xf")
+
+    doc.xpath("//c").each do |cell_node|
+      style_index = (cell_node["s"] || "0").to_i
+      xf = xf_nodes[style_index]
+
+      assert_equal "1", xf["quotePrefix"],
+                   "Cell #{cell_node.at_xpath('.//t')&.text.inspect} should have quotePrefix=\"1\", style_index=#{style_index}"
+    end
+  end
 end


### PR DESCRIPTION
### Description
Motivation:

The existing escape_formulas option only prevents =-prefixed values from being serialized as <f> formula elements. However, values starting with +, -, or @ are stored as plain strings that Excel will re-evaluate as formulas upon user interaction (click-in and press Enter), enabling DDE command execution and other injection attacks documented by OWASP under CSV Injection.

A previous attempt (#190) to expand is_formula? to cover these prefixes caused a regression — values like @SUM(A1) were emitted as invalid <f> elements, corrupting workbooks. That approach was reverted in #209.

This ticket would close issue [#529](https://github.com/caxlsx/caxlsx/issues/529)

Actions:

- Add SECONDARY_FORMULA_PREFIXES constant (['+', '-', '@']) to constants.rb
- Add secure_formulas option with full cascade support: global (Axlsx.secure_formulas) → workbook → worksheet → row → cell
- secure_formulas is a superset of escape_formulas: when true, it prevents = values from being serialized as formulas AND applies quotePrefix="1" to cells starting with =, +, -, or @ prefixes
- quotePrefix is an existing OOXML attribute on the Xf style that tells Excel to never re-evaluate cell content as a formula, even on user interaction — without any visible prefix character
- Add Styles#quote_prefix_style_for which derives and caches a quotePrefix-enabled Xf from the cell's base style
- Cell#effective_style_index transparently resolves the correct style index at serialization time via style_str
- Defaults to false for backward compatibility; numeric types (integer, float) are never affected regardless of their sign

Usage:

  Axlsx.secure_formulas = true # or per-worksheet/row/cell: sheet.add_row [user_input], secure_formulas: true

Added .lstrip call in the needs_quote_prefix? method, so that leading whitespace is not considered when determining if a string needs to be quoted.

Added further logic that allows cells with safe_negative? prefixes to not be escaped.  This inlcudes negative numbers stored as strings, and bullet points that use a '- ' prefix.

Added further tests for different cell values that might appear to ensure that needs_quote_prefix? evaluates to true or false correctly.

Please note that I have put forward a discussion on the original ticket as to whether this approach of a secondary, stronger setting is preferable to altering the existing functionality.

Essentially, the two options are:

1. Have a `secure_functions` option that requires explicit enabling, and retain the existing `escape_formulas` default
2. Change `escape_formulas`, so that it adds the `quotePrefix`, rather than just not setting cells as formulas.

The pros of option 1 (this PR) is that it would be completely backward compatible.  The pros of option 2 is that it would far more accurately serve the namespace of what the `escape_formulas` method implies that it does.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [X] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [NA] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I added an entry to the [changelog](../blob/master/CHANGELOG.md).